### PR TITLE
Create hosts file if it doesn't already exist, and add some docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,1 +1,9 @@
 # The Oxide CLI
+
+## Authentication
+
+There are two ways to authenticate against the Oxide rack using the CLI:
+
+- Environment variables: You can set the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables. This method is useful for service accounts.
+
+- Configuration file: When running the `oxide auth login` command, a `$HOME/.config/oxide/hosts.toml` file is generated. This file contains sensitive information like your token and user ID.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -5,8 +5,8 @@
 // Copyright 2023 Oxide Computer Company
 
 use std::collections::HashMap;
-use std::fs::{self, OpenOptions};
-use std::io::prelude::*;
+use std::fs::{create_dir_all, OpenOptions};
+use std::io::Read;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -47,7 +47,7 @@ impl Default for Config {
         let mut dir = dirs::home_dir().unwrap();
         dir.push(".config");
         dir.push("oxide");
-        fs::create_dir_all(&dir).unwrap();
+        create_dir_all(&dir).unwrap();
 
         let mut hosts_path = OpenOptions::new()
             .write(true)
@@ -73,7 +73,7 @@ impl Config {
         let mut dir = dirs::home_dir().unwrap();
         dir.push(".config");
         dir.push("oxide");
-        fs::create_dir_all(&dir).unwrap();
+        create_dir_all(&dir).unwrap();
 
         let mut hosts_path = OpenOptions::new()
             .write(true)


### PR DESCRIPTION
Fixes a bug where the `auth login` command would panic if the `$HOME/.config/oxide/` directory didn't already exist. Additionally added a bit of authentication end user docs (slowly chipping away at them?)