### PR TITLE
fix issues with `oxide auth login`

### DIFF
--- a/cli/src/cmd_api.rs
+++ b/cli/src/cmd_api.rs
@@ -155,8 +155,8 @@ impl CmdApi {
             }
         }
 
-        let client = ctx.client.client();
-        let uri = format!("{}{}", ctx.client.baseurl(), endpoint_with_query);
+        let client = ctx.client().client();
+        let uri = format!("{}{}", ctx.client().baseurl(), endpoint_with_query);
 
         // Make the request.
         let mut req = client.request(method.clone(), uri);
@@ -219,7 +219,7 @@ impl CmdApi {
                                 // TODO deal with limit
                                 let uri = format!(
                                     "{}{}?page_token={}",
-                                    ctx.client.baseurl(),
+                                    ctx.client().baseurl(),
                                     endpoint,
                                     next_page,
                                 );

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -159,7 +159,7 @@ impl CmdAuthLogin {
             token
         } else {
             let existing_token = ctx
-                .config
+                .config()
                 .hosts
                 .get(&self.host)
                 .map(|host_entry| &host_entry.token);
@@ -185,7 +185,7 @@ impl CmdAuthLogin {
             // Do an OAuth 2.0 Device Authorization Grant dance to get a token.
             let device_auth_url =
                 DeviceAuthorizationUrl::new(format!("{}device/auth", &self.host))?;
-            let client_id = &ctx.config.client_id;
+            let client_id = &ctx.config().client_id;
             let auth_client = BasicClient::new(
                 ClientId::new(client_id.to_string()),
                 None,
@@ -287,7 +287,8 @@ impl CmdAuthLogin {
             default: false,
         };
 
-        ctx.config.update_host(self.host.to_string(), host_entry)?;
+        ctx.config()
+            .update_host(self.host.to_string(), host_entry)?;
 
         Ok(())
     }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -10,51 +10,63 @@ use oxide_api::Client;
 use crate::config::Config;
 
 pub struct Context {
-    pub client: Client,
-    pub config: Config,
+    client: Option<Client>,
+    config: Config,
 }
 
 impl Context {
     pub fn new(config: Config) -> Result<Self> {
-        let (host, token) = match (std::env::var("OXIDE_HOST"), std::env::var("OXIDE_TOKEN")) {
-            (Ok(host), Ok(token)) => (host, token),
-            (Ok(host), Err(_)) => {
-                let Some(host_entry) = config.hosts.get(&host) else {
-                    return Err(anyhow!("host {} not found", host));
-                };
-                (host, host_entry.token.clone())
-            }
-            (Err(_), Ok(token)) => {
-                let Some((host, _)) = config.hosts.hosts.iter().next() else {
-                    return Err(anyhow!("no authenticated hosts"));
-                };
-                (host.clone(), token)
-            }
-            (Err(_), Err(_)) => {
-                let Some((host, host_entry)) = config.hosts.hosts.iter().next() else {
-                    return Err(anyhow!("no authenticated hosts"));
-                };
-                (host.clone(), host_entry.token.clone())
-            }
-        };
-
-        let auth = format!("Bearer {}", token);
-        let mut auth_value = reqwest::header::HeaderValue::from_str(&auth)?;
-        auth_value.set_sensitive(true);
-
-        let dur = std::time::Duration::from_secs(15);
-        let rclient = reqwest::Client::builder()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .default_headers(
-                [(http::header::AUTHORIZATION, auth_value)]
-                    .into_iter()
-                    .collect(),
-            )
-            .build()
-            .unwrap();
-        let client = oxide_api::Client::new_with_client(&host, rclient);
-
+        let client = get_client(&config)?;
         Ok(Self { client, config })
     }
+
+    pub fn client(&self) -> &Client {
+        self.client.as_ref().expect("no authenticated hosts")
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+}
+
+fn get_client(config: &Config) -> Result<Option<Client>> {
+    let (host, token) = match (std::env::var("OXIDE_HOST"), std::env::var("OXIDE_TOKEN")) {
+        (Ok(host), Ok(token)) => (host, token),
+        (Ok(host), Err(_)) => {
+            let Some(host_entry) = config.hosts.get(&host) else {
+                    return Err(anyhow!("host {} not found", host));
+                };
+            (host, host_entry.token.clone())
+        }
+        (Err(_), Ok(token)) => {
+            let Some((host, _)) = config.hosts.hosts.iter().next() else {
+                return Ok(None);
+            };
+            (host.clone(), token)
+        }
+        (Err(_), Err(_)) => {
+            let Some((host, host_entry)) = config.hosts.hosts.iter().next() else {
+                return Ok(None);
+            };
+            (host.clone(), host_entry.token.clone())
+        }
+    };
+
+    let auth = format!("Bearer {}", token);
+    let mut auth_value = reqwest::header::HeaderValue::from_str(&auth)?;
+    auth_value.set_sensitive(true);
+
+    let dur = std::time::Duration::from_secs(15);
+    let rclient = reqwest::Client::builder()
+        .connect_timeout(dur)
+        .timeout(dur)
+        .default_headers(
+            [(http::header::AUTHORIZATION, auth_value)]
+                .into_iter()
+                .collect(),
+        )
+        .build()
+        .unwrap();
+    let client = oxide_api::Client::new_with_client(&host, rclient);
+    Ok(Some(client))
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,7 +114,7 @@ async fn main() {
                 sm = sub_matches;
             }
 
-            let cli = Cli::new(ctx.client.clone());
+            let cli = Cli::new(ctx.client().clone());
 
             cli.execute(node.cmd.unwrap(), sm).await;
         }


### PR DESCRIPTION
We were assuming that we could open a browser--that's not necessarily the case.

We required `~/.config/oxide/hosts.toml` which made it impossible to populate the first time we ran `oxide auth login`.