### PR TITLE
Implement oxide version command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,6 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
- "once_cell",
  "strsim",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
+ "once_cell",
  "strsim",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,15 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
-name = "camino"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cargo-lock"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,29 +169,6 @@ dependencies = [
  "serde",
  "toml 0.5.11",
  "url",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.16",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1231,7 +1199,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "cargo_metadata",
+ "built",
  "chrono",
  "clap",
  "dialoguer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b2340f55d9661d76793b2bfc2eb0e62689bd79d067a95707ea762afd5e9dd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +126,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "once_cell",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "built"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-lock"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +178,29 @@ dependencies = [
  "serde",
  "toml 0.5.11",
  "url",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.16",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -376,6 +435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,10 +471,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -454,6 +531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -851,6 +937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1230,8 @@ name = "oxide"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
+ "cargo_metadata",
  "chrono",
  "clap",
  "dialoguer",
@@ -1138,6 +1241,7 @@ dependencies = [
  "oauth2",
  "open",
  "oxide-api",
+ "predicates",
  "pretty_assertions",
  "reqwest",
  "schemars",
@@ -1238,6 +1342,37 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c575290b64d24745b6c57a12a31465f0a66f3a4799686a6921526a33b0797965"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -1406,6 +1541,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1907,6 +2048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2389,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,11 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0.70"
+assert_cmd = "2.0.10"
 base64 = "0.21.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 clap = { version = "4.2", features = ["derive", "string", "env"] }
+cargo_metadata = "0.15.3"
 dialoguer = "0.10.3"
 dirs = "4.0.0"
 futures = "0.3.27"
@@ -19,6 +21,7 @@ oauth2 = "4.3.0"
 open = "4.0.1"
 oxide-api = { path = "sdk" }
 pretty_assertions = "1.3.0"
+predicates = "3.0.1"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ assert_cmd = "2.0.10"
 base64 = "0.21.0"
 built = "0.6.0"
 chrono = { version = "0.4.24", features = ["serde"] }
-clap = { version = "4.2", features = ["cargo", "derive", "string", "env"] }
+clap = { version = "4.2", features = ["derive", "string", "env"] }
 dialoguer = "0.10.3"
 dirs = "4.0.0"
 futures = "0.3.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ members = [
 anyhow = "1.0.70"
 assert_cmd = "2.0.10"
 base64 = "0.21.0"
+built = "0.6.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 clap = { version = "4.2", features = ["derive", "string", "env"] }
-cargo_metadata = "0.15.3"
 dialoguer = "0.10.3"
 dirs = "4.0.0"
 futures = "0.3.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ assert_cmd = "2.0.10"
 base64 = "0.21.0"
 built = "0.6.0"
 chrono = { version = "0.4.24", features = ["serde"] }
-clap = { version = "4.2", features = ["derive", "string", "env"] }
+clap = { version = "4.2", features = ["cargo", "derive", "string", "env"] }
 dialoguer = "0.10.3"
 dirs = "4.0.0"
 futures = "0.3.27"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,6 @@ default-run = "oxide"
 
 [dependencies]
 anyhow = { workspace = true }
-assert_cmd = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 dialoguer = { workspace = true }
@@ -36,6 +35,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
+assert_cmd = { workspace = true }
 
 [build-dependencies]
 built = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,8 +11,10 @@ default-run = "oxide"
 
 [dependencies]
 anyhow = { workspace = true }
+assert_cmd = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
+cargo_metadata = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
@@ -20,6 +22,7 @@ http = { workspace = true }
 oauth2 = { workspace = true }
 open = { workspace = true }
 oxide-api = { workspace = true }
+predicates = { workspace = true }
 reqwest = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = { workspace = true }
 assert_cmd = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-cargo_metadata = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
@@ -37,3 +36,6 @@ uuid = { workspace = true }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
+
+[build-dependencies]
+built = { workspace = true }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information")
+}

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,3 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
 fn main() {
-    built::write_built_file().expect("Failed to acquire build-time information")
+    let src = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    match built::util::get_repo_head(src.as_ref()) {
+        Ok(Some((_branch, _commit, _commit_short))) => (),
+        Ok(None) => panic!("Error: Build script could not find git commit information"),
+        Err(e) => panic!("Build script error: {}", e),
+    };
+
+    built::write_built_file().expect("Failed to acquire build-time information");
 }

--- a/cli/src/cmd_version.rs
+++ b/cli/src/cmd_version.rs
@@ -20,7 +20,7 @@ pub struct CmdVersion;
 
 impl CmdVersion {
     pub async fn run(&self) -> Result<()> {
-        println!("Oxide CLI {}", clap::crate_version!());
+        println!("Oxide CLI {}", built_info::PKG_VERSION);
 
         println!(
             "Built from commit: {} {}",

--- a/cli/src/cmd_version.rs
+++ b/cli/src/cmd_version.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+use anyhow::Result;
+use cargo_metadata::MetadataCommand;
+use clap::Parser;
+
+/// Prints version information about the CLI, associated API and source code location.
+#[derive(Parser, Debug, Clone)]
+#[clap(verbatim_doc_comment)]
+#[clap(name = "version")]
+pub struct CmdVersion;
+
+impl CmdVersion {
+    pub async fn run(&self) -> Result<()> {
+        println!("oxide CLI {}", env!("CARGO_PKG_VERSION"));
+
+        let path = env!("CARGO_MANIFEST_DIR");
+        let meta = MetadataCommand::new()
+            .manifest_path("./Cargo.toml")
+            .current_dir(&path)
+            .no_deps()
+            .exec()
+            .unwrap();
+
+        let root = meta.workspace_packages();
+        let api = root.into_iter().find(|&x| x.name == "oxide-api").unwrap();
+        println!("{} {}", api.name, api.version);
+
+        println!("source {}", env!("CARGO_PKG_REPOSITORY"));
+
+        Ok(())
+    }
+}
+
+#[test]
+fn version_success() {
+    use assert_cmd::Command;
+
+    let mut cmd = Command::cargo_bin("oxide").unwrap();
+
+    cmd.arg("version");
+    cmd.assert().success().stdout(
+        "oxide CLI 0.1.0\noxide-api 0.1.0\nsource https://github.com/oxidecomputer/oxide-sdk-and-cli\n",
+    );
+}

--- a/cli/src/cmd_version.rs
+++ b/cli/src/cmd_version.rs
@@ -6,6 +6,7 @@
 
 use anyhow::Result;
 use clap::Parser;
+use oxide_api::Client;
 
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -31,6 +32,9 @@ impl CmdVersion {
             }
         );
 
+        let client = Client::new("");
+        println!("Oxide API: {}", client.api_version());
+
         Ok(())
     }
 }
@@ -43,7 +47,7 @@ fn version_success() {
 
     cmd.arg("version");
     cmd.assert().success().stdout(format!(
-        "Oxide CLI 0.1.0\nBuilt from commit: {} {}\n",
+        "Oxide CLI 0.1.0\nBuilt from commit: {} {}\nOxide API: 0.0.1\n",
         built_info::GIT_COMMIT_HASH.unwrap(),
         if matches!(built_info::GIT_DIRTY, Some(true)) {
             "(dirty)"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,6 +16,7 @@ mod cmd_api;
 #[allow(unused_mut)] // TODO
 #[allow(unused)] // TODO
 mod cmd_auth;
+mod cmd_version;
 mod config;
 mod context;
 #[allow(unused_mut)]
@@ -85,6 +86,7 @@ async fn main() {
     // could be placed under another subcommand if needed.
     cmd = cmd.subcommand(cmd_auth::CmdAuth::command());
     cmd = cmd.subcommand(cmd_api::CmdApi::command());
+    cmd = cmd.subcommand(cmd_version::CmdVersion::command());
 
     let matches = cmd.get_matches();
 
@@ -103,6 +105,11 @@ async fn main() {
         Some(("api", sub_matches)) => {
             let x = cmd_api::CmdApi::from_arg_matches(sub_matches).unwrap();
             x.run(&mut ctx).await.unwrap();
+        }
+
+        Some(("version", sub_matches)) => {
+            let x = cmd_version::CmdVersion::from_arg_matches(sub_matches).unwrap();
+            x.run().await.unwrap();
         }
 
         _ => {


### PR DESCRIPTION
Closes: https://github.com/oxidecomputer/oxide-sdk-and-cli/issues/58

```console
$ oxide version
Oxide CLI 0.1.0
Built from commit: b2166b69f2c9f4209ee36783f41ab30fb458a437 (dirty)
Oxide API: 0.0.1

$ oxide version --help
Prints version information about the CLI.

Usage: oxide version

Options:
  -h, --help  Print help
```
