### PR TITLE
remove query params on subsequent paginate requests

### DIFF
--- a/cli/src/cmd_api.rs
+++ b/cli/src/cmd_api.rs
@@ -207,6 +207,12 @@ impl CmdApi {
             // print out the contents of each page to make a unified json array
             // as the output.
 
+            // Remove any query parameters for subsequent requests.
+            let endpoint = match endpoint.split_once('?') {
+                Some((prefix, _)) => prefix,
+                None => endpoint.as_str(),
+            };
+
             let result = futures::stream::try_unfold(Some(resp), |maybe_resp| async {
                 match maybe_resp {
                     None => Ok(None),


### PR DESCRIPTION
This is an attempt at fixing #67.

After discussion with @ahl, I [fixed my API endpoint](https://github.com/oxidecomputer/omicron/pull/2645/commits/14c4a47527e0f7b6510941e34abbdf873d96e554). However, I'm still hitting the behavior described in the ticket.

Looking at the pagination requests a bit closer, it appears that pagination query parameters are being appended to the URL with a leading `?` even if a query string is already there.

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: HTTP status client error (400 Bad Request) for url (http://192.168.20.2/v1/system/networking/address-lot/blocks?address_lot=parkinglot?page_token=eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7InNvcnRfYnkiOiJpZF9hc2NlbmRpbmciLCJhZGRyZXNzX2xvdCI6InBhcmtpbmdsb3QiLCJsYXN0X3NlZW4iOiJjMmZkYWI2Ni0xN2UxLTQ5ZTItYTZlMC03MjUwYmE0ZDhiZDIifX0=)', cli/src/main.rs:127:35
```

This patch checks for query parameters in subsequent pagination API calls and removes them if they are present, leaving just the pagination query parameter.