### PR TITLE
Implement auth logout command

### DIFF
--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -314,7 +314,7 @@ impl CmdAuthLogin {
     }
 }
 
-/// Removes authentication information saved in the hosts.toml file.
+/// Removes saved authentication information.
 ///
 /// This command does not invalidate any tokens from the hosts.
 #[derive(Parser, Debug, Clone)]
@@ -375,10 +375,10 @@ impl CmdAuthLogout {
                 let mut dir = dirs::home_dir().unwrap();
                 dir.push(".config");
                 dir.push("oxide");
-                dir.push("hosts.toml");
+                let hosts_path = dir.join("hosts.toml");
 
                 // Clear the entire file for users who want to reset their known hosts.
-                let _ = File::create(dir).unwrap();
+                let _ = File::create(hosts_path)?;
                 println!("Removed all authentication information");
             }
         }

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -367,7 +367,9 @@ impl CmdAuthLogout {
             }
             None => {
                 let mut dir = dirs::home_dir().unwrap();
-                dir.push(".config/oxide/hosts.toml");
+                dir.push(".config");
+                dir.push("oxide");
+                dir.push("hosts.toml");
 
                 // Clear the entire file for users who want to reset their known hosts.
                 let mut f = File::create(dir).unwrap();

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -316,8 +316,9 @@ impl CmdAuthLogin {
 
 /// Removes authentication information saved in the hosts.toml file.
 ///
-/// This command does not invalidate any tokens from the hosts, nor removes
-/// any authentication information saved in environment variables.
+/// This command does not invalidate any tokens from the hosts, nor unset
+/// any authentication information saved in $OXIDE_HOST or $OXIDE_TOKEN
+/// environment variables.
 #[derive(Parser, Debug, Clone)]
 #[clap(verbatim_doc_comment)]
 pub struct CmdAuthLogout {

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -321,8 +321,8 @@ impl CmdAuthLogin {
 #[derive(Parser, Debug, Clone)]
 #[clap(verbatim_doc_comment)]
 pub struct CmdAuthLogout {
-    /// Remove authentication information for a single host. If unset, authentication
-    /// information for all hosts will be deleted.
+    /// Remove authentication information for a single host. If unset, all known
+    /// hosts and authentication information will be deleted from the hosts.toml file.
     #[clap(short = 'H', long, value_parser = parse_host)]
     pub host: Option<url::Url>,
     /// Skip confirmation prompt.
@@ -350,12 +350,13 @@ impl CmdAuthLogout {
 
         match &self.host {
             Some(host) => {
+                // Setting the host with empty parameters so it will now be listed as
+                // "unauthenticated" when running `$ oxide auth status`.
                 let host_entry = Host {
                     token: String::from(""),
                     user: String::from(""),
                     default: false,
                 };
-
                 ctx.config().update_host(host.to_string(), host_entry)?;
 
                 println!(
@@ -367,6 +368,7 @@ impl CmdAuthLogout {
                 let mut dir = dirs::home_dir().unwrap();
                 dir.push(".config/oxide/hosts.toml");
 
+                // Clear the entire file for users who want to reset their known hosts.
                 let mut f = File::create(dir).unwrap();
                 println!("Removed all authentication information from hosts.toml file.");
             }

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -314,14 +314,15 @@ impl CmdAuthLogin {
     }
 }
 
-/// Removes all authentication information saved in the hosts.toml file.
+/// Removes authentication information saved in the hosts.toml file.
 ///
 /// This command does not invalidate any tokens from the hosts, nor removes
 /// any authentication information saved in environment variables.
 #[derive(Parser, Debug, Clone)]
 #[clap(verbatim_doc_comment)]
 pub struct CmdAuthLogout {
-    /// Remove authentication information for a single host.
+    /// Remove authentication information for a single host. If unset, authentication
+    /// information for all hosts will be deleted.
     #[clap(short = 'H', long, value_parser = parse_host)]
     pub host: Option<url::Url>,
     /// Skip confirmation prompt.
@@ -357,7 +358,10 @@ impl CmdAuthLogout {
 
                 ctx.config().update_host(host.to_string(), host_entry)?;
 
-                println!("Removed authentication information from: {}", host);
+                println!(
+                    "Removed authentication information from hosts.toml file for: {}",
+                    host
+                );
             }
             None => {
                 let mut dir = dirs::home_dir().unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,8 +14,6 @@ use generated_cli::{Cli, CliCommand, CliOverride};
 use oxide_api::types::{IpRange, Ipv4Range, Ipv6Range};
 
 mod cmd_api;
-#[allow(unused_mut)] // TODO
-#[allow(unused)] // TODO
 mod cmd_auth;
 mod cmd_version;
 mod config;


### PR DESCRIPTION
Simplifying this one a lot.

```console
$ oxide auth logout --help
Removes authentication information saved in the hosts.toml file.

This command does not invalidate any tokens from the hosts, nor removes
any authentication information saved in environment variables.

Usage: oxide auth logout [OPTIONS]

Options:
  -H, --host <HOST>
          Remove authentication information for a single host. If unset, all known hosts and 
          authentication information will be deleted from the hosts.toml file

  -f, --force
          Skip confirmation prompt

  -h, --help
          Print help (see a summary with '-h')
```

Summary of changes:

- In the help text I clarify that this command does NOT revoke any tokens, but merely removes them from the hosts.toml file
- The old command had checks around env vars. This isn't necessary. Users shouldn't have to unset env vars to make changes to their configuration files. I removed all that.
- Prompt is now only used to confirm that the user wishes to perform a destructive action (this can be overridden with the new `--force` flag). I expect our users to know how to use flags, so no other prompts appear.
- New functionality for users who wish to log out of everything and reset the config file (this is a pretty common use case). No need to unset hosts one by one.