### PR TITLE
Generate JSON CLI docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "expectorate"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a483344b06e0a8183209bdf1c2e23b834d04dcdec591d2f617cc60b6c1298b"
+dependencies = [
+ "console",
+ "newline-converter",
+ "similar",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1686,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "dirs",
+ "expectorate",
  "futures",
  "http",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4.24", features = ["serde"] }
 clap = { version = "4.2", features = ["derive", "string", "env"] }
 dialoguer = "0.10.3"
 dirs = "4.0.0"
+expectorate = "1.0.6"
 futures = "0.3.27"
 http = "0.2.9"
 httpmock = "0.6.7"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
+expectorate = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 httpmock = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,6 @@ chrono = { workspace = true }
 clap = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
-expectorate = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 oauth2 = { workspace = true }
@@ -35,6 +34,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+expectorate = { workspace = true }
 httpmock = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -3,16 +3,98 @@
   "excerpt": "",
   "subcommands": [
     {
+      "title": "certificate",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "create",
+          "excerpt": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "service",
+              "help": "The service using this certificate"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
+          "args": [
+            {
+              "long": "certificate"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a certificate\n\nReturns the details of a specific certificate",
+          "args": [
+            {
+              "long": "certificate"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "title": "current-user",
       "excerpt": "",
       "subcommands": [
+        {
+          "title": "groups",
+          "excerpt": "Fetch the silo groups the current user belongs to",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
         {
           "title": "ssh-key",
           "excerpt": "",
           "subcommands": [
             {
-              "title": "view",
-              "excerpt": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
+              "title": "create",
+              "excerpt": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "public-key",
+                  "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
+                }
+              ]
+            },
+            {
+              "title": "delete",
+              "excerpt": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
               "args": [
                 {
                   "long": "ssh-key"
@@ -33,42 +115,13 @@
               ]
             },
             {
-              "title": "delete",
-              "excerpt": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
+              "title": "view",
+              "excerpt": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
               "args": [
                 {
                   "long": "ssh-key"
                 }
               ]
-            },
-            {
-              "title": "create",
-              "excerpt": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "public-key",
-                  "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "title": "groups",
-          "excerpt": "Fetch the silo groups the current user belongs to",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
             }
           ]
         },
@@ -79,114 +132,34 @@
       ]
     },
     {
-      "title": "policy",
+      "title": "disk",
       "excerpt": "",
       "subcommands": [
         {
-          "title": "view",
-          "excerpt": "Fetch the current silo's IAM policy"
-        },
-        {
-          "title": "update",
-          "excerpt": "Update the current silo's IAM policy"
-        }
-      ]
-    },
-    {
-      "title": "instance",
-      "excerpt": "",
-      "subcommands": [
-        {
-          "title": "start",
-          "excerpt": "Boot an instance",
+          "title": "create",
+          "excerpt": "Create a disk",
           "args": [
-            {
-              "long": "instance"
-            },
             {
               "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "external-ip",
-          "excerpt": "",
-          "subcommands": [
-            {
-              "title": "list",
-              "excerpt": "List external IP addresses",
-              "args": [
-                {
-                  "long": "instance"
-                },
-                {
-                  "long": "project"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "title": "disk",
-          "excerpt": "",
-          "subcommands": [
-            {
-              "title": "list",
-              "excerpt": "List an instance's disks",
-              "args": [
-                {
-                  "long": "instance"
-                },
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "sort-by"
-                }
-              ]
             },
             {
-              "title": "detach",
-              "excerpt": "Detach a disk from an instance",
-              "args": [
-                {
-                  "long": "instance"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "disk"
-                }
-              ]
+              "long": "description"
             },
             {
-              "title": "attach",
-              "excerpt": "Attach a disk to an instance",
-              "args": [
-                {
-                  "long": "instance"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "disk"
-                }
-              ]
+              "long": "name"
+            },
+            {
+              "long": "size",
+              "help": "total size of the Disk in bytes"
             }
           ]
         },
         {
-          "title": "reboot",
-          "excerpt": "Reboot an instance",
+          "title": "delete",
+          "excerpt": "Delete a disk",
           "args": [
             {
-              "long": "instance"
+              "long": "disk"
             },
             {
               "long": "project"
@@ -195,7 +168,7 @@
         },
         {
           "title": "list",
-          "excerpt": "List instances",
+          "excerpt": "List disks",
           "args": [
             {
               "long": "limit",
@@ -210,17 +183,144 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete an instance",
+          "title": "metrics",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "list",
+              "excerpt": "Fetch disk metrics",
+              "args": [
+                {
+                  "long": "disk"
+                },
+                {
+                  "long": "metric"
+                },
+                {
+                  "long": "end-time",
+                  "help": "An exclusive end time of metrics."
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "start-time",
+                  "help": "An inclusive start time of metrics."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a disk",
           "args": [
             {
-              "long": "instance"
+              "long": "disk"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "group",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List groups",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "image",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "create",
+          "excerpt": "Create an image\n\nCreate a new image in a project.",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "os",
+              "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
+            },
+            {
+              "long": "version",
+              "help": "The version of the operating system (e.g. 18.04, 20.04, etc.)"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
+          "args": [
+            {
+              "long": "image"
             },
             {
               "long": "project"
             }
           ]
         },
+        {
+          "title": "list",
+          "excerpt": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch an image\n\nFetch the details for a specific image in a project.",
+          "args": [
+            {
+              "long": "image"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "instance",
+      "excerpt": "",
+      "subcommands": [
         {
           "title": "create",
           "excerpt": "Create an instance",
@@ -254,8 +354,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch an instance",
+          "title": "delete",
+          "excerpt": "Delete an instance",
           "args": [
             {
               "long": "instance"
@@ -266,28 +366,13 @@
           ]
         },
         {
-          "title": "stop",
-          "excerpt": "Stop an instance",
-          "args": [
-            {
-              "long": "instance"
-            },
-            {
-              "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "nic",
+          "title": "disk",
           "excerpt": "",
           "subcommands": [
             {
-              "title": "update",
-              "excerpt": "Update a network interface",
+              "title": "attach",
+              "excerpt": "Attach a disk to an instance",
               "args": [
-                {
-                  "long": "interface"
-                },
                 {
                   "long": "instance"
                 },
@@ -295,35 +380,28 @@
                   "long": "project"
                 },
                 {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "primary",
-                  "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
+                  "long": "disk"
                 }
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Fetch a network interface",
+              "title": "detach",
+              "excerpt": "Detach a disk from an instance",
               "args": [
-                {
-                  "long": "interface"
-                },
                 {
                   "long": "instance"
                 },
                 {
                   "long": "project"
+                },
+                {
+                  "long": "disk"
                 }
               ]
             },
             {
               "title": "list",
-              "excerpt": "List network interfaces",
+              "excerpt": "List an instance's disks",
               "args": [
                 {
                   "long": "instance"
@@ -339,7 +417,47 @@
                   "long": "sort-by"
                 }
               ]
+            }
+          ]
+        },
+        {
+          "title": "external-ip",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "list",
+              "excerpt": "List external IP addresses",
+              "args": [
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List instances",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
             },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "nic",
+          "excerpt": "",
+          "subcommands": [
             {
               "title": "create",
               "excerpt": "Create a network interface",
@@ -384,229 +502,14 @@
                   "long": "project"
                 }
               ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "vpc",
-      "excerpt": "",
-      "subcommands": [
-        {
-          "title": "list",
-          "excerpt": "List VPCs",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "title": "view",
-          "excerpt": "Fetch a VPC",
-          "args": [
-            {
-              "long": "vpc"
-            },
-            {
-              "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "router",
-          "excerpt": "",
-          "subcommands": [
-            {
-              "title": "update",
-              "excerpt": "Update a router",
-              "args": [
-                {
-                  "long": "router"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "vpc"
-                },
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                }
-              ]
-            },
-            {
-              "title": "create",
-              "excerpt": "Create a VPC router",
-              "args": [
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "vpc"
-                },
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                }
-              ]
-            },
-            {
-              "title": "view",
-              "excerpt": "Get a router",
-              "args": [
-                {
-                  "long": "router"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "vpc"
-                }
-              ]
-            },
-            {
-              "title": "route",
-              "excerpt": "",
-              "subcommands": [
-                {
-                  "title": "update",
-                  "excerpt": "Update a route",
-                  "args": [
-                    {
-                      "long": "route"
-                    },
-                    {
-                      "long": "project"
-                    },
-                    {
-                      "long": "router"
-                    },
-                    {
-                      "long": "vpc"
-                    },
-                    {
-                      "long": "description"
-                    },
-                    {
-                      "long": "name"
-                    }
-                  ]
-                },
-                {
-                  "title": "list",
-                  "excerpt": "List routes\n\nList the routes associated with a router in a particular VPC.",
-                  "args": [
-                    {
-                      "long": "limit",
-                      "help": "Maximum number of items returned by a single call"
-                    },
-                    {
-                      "long": "project"
-                    },
-                    {
-                      "long": "router"
-                    },
-                    {
-                      "long": "sort-by"
-                    },
-                    {
-                      "long": "vpc"
-                    }
-                  ]
-                },
-                {
-                  "title": "create",
-                  "excerpt": "Create a router",
-                  "args": [
-                    {
-                      "long": "project"
-                    },
-                    {
-                      "long": "router"
-                    },
-                    {
-                      "long": "vpc"
-                    },
-                    {
-                      "long": "description"
-                    },
-                    {
-                      "long": "name"
-                    }
-                  ]
-                },
-                {
-                  "title": "delete",
-                  "excerpt": "Delete a route",
-                  "args": [
-                    {
-                      "long": "route"
-                    },
-                    {
-                      "long": "project"
-                    },
-                    {
-                      "long": "router"
-                    },
-                    {
-                      "long": "vpc"
-                    }
-                  ]
-                },
-                {
-                  "title": "view",
-                  "excerpt": "Fetch a route",
-                  "args": [
-                    {
-                      "long": "route"
-                    },
-                    {
-                      "long": "project"
-                    },
-                    {
-                      "long": "router"
-                    },
-                    {
-                      "long": "vpc"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "title": "delete",
-              "excerpt": "Delete a router",
-              "args": [
-                {
-                  "long": "router"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "vpc"
-                }
-              ]
             },
             {
               "title": "list",
-              "excerpt": "List routers",
+              "excerpt": "List network interfaces",
               "args": [
+                {
+                  "long": "instance"
+                },
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
@@ -616,291 +519,96 @@
                 },
                 {
                   "long": "sort-by"
-                },
-                {
-                  "long": "vpc"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "title": "subnet",
-          "excerpt": "",
-          "subcommands": [
-            {
-              "title": "view",
-              "excerpt": "Fetch a subnet",
-              "args": [
-                {
-                  "long": "subnet"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "vpc"
-                }
-              ]
-            },
-            {
-              "title": "create",
-              "excerpt": "Create a subnet",
-              "args": [
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "vpc"
-                },
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "ipv4-block",
-                  "help": "The IPv4 address range for this subnet.\n\nIt must be allocated from an RFC 1918 private address range, and must not overlap with any other existing subnet in the VPC."
-                },
-                {
-                  "long": "ipv6-block",
-                  "help": "The IPv6 address range for this subnet.\n\nIt must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC."
-                },
-                {
-                  "long": "name"
-                }
-              ]
-            },
-            {
-              "title": "list",
-              "excerpt": "Fetch a subnet",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "sort-by"
-                },
-                {
-                  "long": "vpc"
                 }
               ]
             },
             {
               "title": "update",
-              "excerpt": "Update a subnet",
+              "excerpt": "Update a network interface",
               "args": [
                 {
-                  "long": "subnet"
+                  "long": "interface"
+                },
+                {
+                  "long": "instance"
                 },
                 {
                   "long": "project"
-                },
-                {
-                  "long": "vpc"
                 },
                 {
                   "long": "description"
                 },
                 {
                   "long": "name"
-                }
-              ]
-            },
-            {
-              "title": "nic",
-              "excerpt": "",
-              "subcommands": [
-                {
-                  "title": "list",
-                  "excerpt": "List network interfaces",
-                  "args": [
-                    {
-                      "long": "subnet"
-                    },
-                    {
-                      "long": "limit",
-                      "help": "Maximum number of items returned by a single call"
-                    },
-                    {
-                      "long": "project"
-                    },
-                    {
-                      "long": "sort-by"
-                    },
-                    {
-                      "long": "vpc"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "title": "delete",
-              "excerpt": "Delete a subnet",
-              "args": [
-                {
-                  "long": "subnet"
                 },
                 {
-                  "long": "project"
-                },
-                {
-                  "long": "vpc"
+                  "long": "primary",
+                  "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
                 }
               ]
-            }
-          ]
-        },
-        {
-          "title": "create",
-          "excerpt": "Create a VPC",
-          "args": [
-            {
-              "long": "project"
             },
-            {
-              "long": "description"
-            },
-            {
-              "long": "dns-name"
-            },
-            {
-              "long": "ipv6-prefix",
-              "help": "The IPv6 prefix for this VPC.\n\nAll IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix."
-            },
-            {
-              "long": "name"
-            }
-          ]
-        },
-        {
-          "title": "firewall-rules",
-          "excerpt": "",
-          "subcommands": [
             {
               "title": "view",
-              "excerpt": "List firewall rules",
+              "excerpt": "Fetch a network interface",
               "args": [
                 {
-                  "long": "project"
+                  "long": "interface"
                 },
                 {
-                  "long": "vpc"
-                }
-              ]
-            },
-            {
-              "title": "update",
-              "excerpt": "Replace firewall rules",
-              "args": [
-                {
-                  "long": "project"
+                  "long": "instance"
                 },
                 {
-                  "long": "vpc"
+                  "long": "project"
                 }
               ]
             }
           ]
         },
         {
-          "title": "update",
-          "excerpt": "Update a VPC",
+          "title": "reboot",
+          "excerpt": "Reboot an instance",
           "args": [
             {
-              "long": "vpc"
+              "long": "instance"
             },
             {
               "long": "project"
-            },
-            {
-              "long": "description"
-            },
-            {
-              "long": "dns-name"
-            },
-            {
-              "long": "name"
             }
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a VPC",
+          "title": "start",
+          "excerpt": "Boot an instance",
           "args": [
             {
-              "long": "vpc"
+              "long": "instance"
             },
             {
               "long": "project"
             }
           ]
-        }
-      ]
-    },
-    {
-      "title": "snapshot",
-      "excerpt": "",
-      "subcommands": [
+        },
+        {
+          "title": "stop",
+          "excerpt": "Stop an instance",
+          "args": [
+            {
+              "long": "instance"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
         {
           "title": "view",
-          "excerpt": "Fetch a snapshot",
+          "excerpt": "Fetch an instance",
           "args": [
             {
-              "long": "snapshot"
+              "long": "instance"
             },
             {
               "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "delete",
-          "excerpt": "Delete a snapshot",
-          "args": [
-            {
-              "long": "snapshot"
-            },
-            {
-              "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "list",
-          "excerpt": "List snapshots",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "title": "create",
-          "excerpt": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
-          "args": [
-            {
-              "long": "project"
-            },
-            {
-              "long": "description"
-            },
-            {
-              "long": "disk",
-              "help": "The name of the disk to be snapshotted"
-            },
-            {
-              "long": "name"
             }
           ]
         }
@@ -911,25 +619,9 @@
       "excerpt": "",
       "subcommands": [
         {
-          "title": "list",
-          "excerpt": "List IP pools",
+          "title": "create",
+          "excerpt": "Create an IP pool",
           "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "title": "update",
-          "excerpt": "Update an IP Pool",
-          "args": [
-            {
-              "long": "pool"
-            },
             {
               "long": "description"
             },
@@ -939,36 +631,24 @@
           ]
         },
         {
-          "title": "service",
-          "excerpt": "",
-          "subcommands": [
+          "title": "delete",
+          "excerpt": "Delete an IP Pool",
+          "args": [
             {
-              "title": "remove",
-              "excerpt": "Remove a range from an IP pool used for Oxide services."
+              "long": "pool"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List IP pools",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
             },
             {
-              "title": "view",
-              "excerpt": "Fetch the IP pool used for Oxide services."
-            },
-            {
-              "title": "range",
-              "excerpt": "",
-              "subcommands": [
-                {
-                  "title": "list",
-                  "excerpt": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
-                  "args": [
-                    {
-                      "long": "limit",
-                      "help": "Maximum number of items returned by a single call"
-                    }
-                  ]
-                },
-                {
-                  "title": "add",
-                  "excerpt": "Add a range to an IP pool used for Oxide services."
-                }
-              ]
+              "long": "sort-by"
             }
           ]
         },
@@ -992,15 +672,6 @@
               ]
             },
             {
-              "title": "remove",
-              "excerpt": "Remove a range from an IP pool",
-              "args": [
-                {
-                  "long": "pool"
-                }
-              ]
-            },
-            {
               "title": "list",
               "excerpt": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
               "args": [
@@ -1012,22 +683,59 @@
                   "help": "Maximum number of items returned by a single call"
                 }
               ]
+            },
+            {
+              "title": "remove",
+              "excerpt": "Remove a range from an IP pool",
+              "args": [
+                {
+                  "long": "pool"
+                }
+              ]
             }
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete an IP Pool",
+          "title": "service",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "range",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "add",
+                  "excerpt": "Add a range to an IP pool used for Oxide services."
+                },
+                {
+                  "title": "list",
+                  "excerpt": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "remove",
+              "excerpt": "Remove a range from an IP pool used for Oxide services."
+            },
+            {
+              "title": "view",
+              "excerpt": "Fetch the IP pool used for Oxide services."
+            }
+          ]
+        },
+        {
+          "title": "update",
+          "excerpt": "Update an IP Pool",
           "args": [
             {
               "long": "pool"
-            }
-          ]
-        },
-        {
-          "title": "create",
-          "excerpt": "Create an IP pool",
-          "args": [
+            },
             {
               "long": "description"
             },
@@ -1067,19 +775,51 @@
       ]
     },
     {
-      "title": "disk",
+      "title": "policy",
       "excerpt": "",
       "subcommands": [
         {
+          "title": "update",
+          "excerpt": "Update the current silo's IAM policy"
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch the current silo's IAM policy"
+        }
+      ]
+    },
+    {
+      "title": "project",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "create",
+          "excerpt": "Create a project",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a project",
+          "args": [
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
           "title": "list",
-          "excerpt": "List disks",
+          "excerpt": "List projects",
           "args": [
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project"
             },
             {
               "long": "sort-by"
@@ -1087,20 +827,32 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a disk",
-          "args": [
+          "title": "policy",
+          "excerpt": "",
+          "subcommands": [
             {
-              "long": "disk"
+              "title": "update",
+              "excerpt": "Update a project's IAM policy",
+              "args": [
+                {
+                  "long": "project"
+                }
+              ]
             },
             {
-              "long": "project"
+              "title": "view",
+              "excerpt": "Fetch a project's IAM policy",
+              "args": [
+                {
+                  "long": "project"
+                }
+              ]
             }
           ]
         },
         {
-          "title": "create",
-          "excerpt": "Create a disk",
+          "title": "update",
+          "excerpt": "Update a project",
           "args": [
             {
               "long": "project"
@@ -1110,67 +862,27 @@
             },
             {
               "long": "name"
-            },
-            {
-              "long": "size",
-              "help": "total size of the Disk in bytes"
             }
           ]
         },
         {
           "title": "view",
-          "excerpt": "Fetch a disk",
+          "excerpt": "Fetch a project",
           "args": [
             {
-              "long": "disk"
-            },
-            {
               "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "metrics",
-          "excerpt": "",
-          "subcommands": [
-            {
-              "title": "list",
-              "excerpt": "Fetch disk metrics",
-              "args": [
-                {
-                  "long": "disk"
-                },
-                {
-                  "long": "metric"
-                },
-                {
-                  "long": "end-time",
-                  "help": "An exclusive end time of metrics."
-                },
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "project"
-                },
-                {
-                  "long": "start-time",
-                  "help": "An inclusive start time of metrics."
-                }
-              ]
             }
           ]
         }
       ]
     },
     {
-      "title": "group",
+      "title": "rack",
       "excerpt": "",
       "subcommands": [
         {
           "title": "list",
-          "excerpt": "List groups",
+          "excerpt": "List racks",
           "args": [
             {
               "long": "limit",
@@ -1178,6 +890,44 @@
             },
             {
               "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a rack",
+          "args": [
+            {
+              "long": "rack-id",
+              "help": "The rack's unique ID."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "saga",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List sagas",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a saga",
+          "args": [
+            {
+              "long": "saga-id"
             }
           ]
         }
@@ -1188,15 +938,33 @@
       "excerpt": "",
       "subcommands": [
         {
-          "title": "list",
-          "excerpt": "List silos\n\nLists silos that are discoverable based on the current permissions.",
+          "title": "create",
+          "excerpt": "Create a silo",
           "args": [
             {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
+              "long": "admin-group-name",
+              "help": "If set, this group will be created during Silo creation and granted the \"Silo Admin\" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.\n\nNote that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information."
             },
             {
-              "long": "sort-by"
+              "long": "description"
+            },
+            {
+              "long": "discoverable"
+            },
+            {
+              "long": "identity-mode"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a silo\n\nDelete a silo by name.",
+          "args": [
+            {
+              "long": "silo"
             }
           ]
         },
@@ -1204,6 +972,22 @@
           "title": "idp",
           "excerpt": "",
           "subcommands": [
+            {
+              "title": "list",
+              "excerpt": "List a silo's IDPs_name",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "silo"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
             {
               "title": "local",
               "excerpt": "",
@@ -1226,19 +1010,6 @@
                       ]
                     },
                     {
-                      "title": "set-password",
-                      "excerpt": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
-                      "args": [
-                        {
-                          "long": "user-id",
-                          "help": "The user's internal id"
-                        },
-                        {
-                          "long": "silo"
-                        }
-                      ]
-                    },
-                    {
                       "title": "delete",
                       "excerpt": "Delete a user",
                       "args": [
@@ -1250,24 +1021,21 @@
                           "long": "silo"
                         }
                       ]
+                    },
+                    {
+                      "title": "set-password",
+                      "excerpt": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
+                      "args": [
+                        {
+                          "long": "user-id",
+                          "help": "The user's internal id"
+                        },
+                        {
+                          "long": "silo"
+                        }
+                      ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "title": "list",
-              "excerpt": "List a silo's IDPs_name",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "silo"
-                },
-                {
-                  "long": "sort-by"
                 }
               ]
             },
@@ -1331,33 +1099,15 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a silo\n\nDelete a silo by name.",
+          "title": "list",
+          "excerpt": "List silos\n\nLists silos that are discoverable based on the current permissions.",
           "args": [
             {
-              "long": "silo"
-            }
-          ]
-        },
-        {
-          "title": "create",
-          "excerpt": "Create a silo",
-          "args": [
-            {
-              "long": "admin-group-name",
-              "help": "If set, this group will be created during Silo creation and granted the \"Silo Admin\" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.\n\nNote that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information."
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
             },
             {
-              "long": "description"
-            },
-            {
-              "long": "discoverable"
-            },
-            {
-              "long": "identity-mode"
-            },
-            {
-              "long": "name"
+              "long": "sort-by"
             }
           ]
         },
@@ -1386,31 +1136,9 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a silo\n\nFetch a silo by name.",
-          "args": [
-            {
-              "long": "silo"
-            }
-          ]
-        },
-        {
           "title": "user",
           "excerpt": "",
           "subcommands": [
-            {
-              "title": "view",
-              "excerpt": "Fetch a user",
-              "args": [
-                {
-                  "long": "user-id",
-                  "help": "The user's internal id"
-                },
-                {
-                  "long": "silo"
-                }
-              ]
-            },
             {
               "title": "list",
               "excerpt": "List users in a silo",
@@ -1426,6 +1154,139 @@
                   "long": "sort-by"
                 }
               ]
+            },
+            {
+              "title": "view",
+              "excerpt": "Fetch a user",
+              "args": [
+                {
+                  "long": "user-id",
+                  "help": "The user's internal id"
+                },
+                {
+                  "long": "silo"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a silo\n\nFetch a silo by name.",
+          "args": [
+            {
+              "long": "silo"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "sled",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "disk-led",
+          "excerpt": "List physical disks attached to sleds",
+          "args": [
+            {
+              "long": "sled-id",
+              "help": "The sled's unique ID."
+            },
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List sleds",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a sled",
+          "args": [
+            {
+              "long": "sled-id",
+              "help": "The sled's unique ID."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "snapshot",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "create",
+          "excerpt": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "disk",
+              "help": "The name of the disk to be snapshotted"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a snapshot",
+          "args": [
+            {
+              "long": "snapshot"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List snapshots",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a snapshot",
+          "args": [
+            {
+              "long": "snapshot"
+            },
+            {
+              "long": "project"
             }
           ]
         }
@@ -1440,153 +1301,12 @@
           "excerpt": "",
           "subcommands": [
             {
-              "title": "view",
-              "excerpt": "Fetch the top-level IAM policy"
-            },
-            {
               "title": "update",
               "excerpt": "Update the top-level IAM policy"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "project",
-      "excerpt": "",
-      "subcommands": [
-        {
-          "title": "update",
-          "excerpt": "Update a project",
-          "args": [
-            {
-              "long": "project"
-            },
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            }
-          ]
-        },
-        {
-          "title": "list",
-          "excerpt": "List projects",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "title": "view",
-          "excerpt": "Fetch a project",
-          "args": [
-            {
-              "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "delete",
-          "excerpt": "Delete a project",
-          "args": [
-            {
-              "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "policy",
-          "excerpt": "",
-          "subcommands": [
-            {
-              "title": "update",
-              "excerpt": "Update a project's IAM policy",
-              "args": [
-                {
-                  "long": "project"
-                }
-              ]
             },
             {
               "title": "view",
-              "excerpt": "Fetch a project's IAM policy",
-              "args": [
-                {
-                  "long": "project"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "title": "create",
-          "excerpt": "Create a project",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "certificate",
-      "excerpt": "",
-      "subcommands": [
-        {
-          "title": "view",
-          "excerpt": "Fetch a certificate\n\nReturns the details of a specific certificate",
-          "args": [
-            {
-              "long": "certificate"
-            }
-          ]
-        },
-        {
-          "title": "create",
-          "excerpt": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "service",
-              "help": "The service using this certificate"
-            }
-          ]
-        },
-        {
-          "title": "delete",
-          "excerpt": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
-          "args": [
-            {
-              "long": "certificate"
-            }
-          ]
-        },
-        {
-          "title": "list",
-          "excerpt": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
+              "excerpt": "Fetch the top-level IAM policy"
             }
           ]
         }
@@ -1615,109 +1335,12 @@
       ]
     },
     {
-      "title": "rack",
+      "title": "vpc",
       "excerpt": "",
       "subcommands": [
-        {
-          "title": "view",
-          "excerpt": "Fetch a rack",
-          "args": [
-            {
-              "long": "rack-id",
-              "help": "The rack's unique ID."
-            }
-          ]
-        },
-        {
-          "title": "list",
-          "excerpt": "List racks",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "saga",
-      "excerpt": "",
-      "subcommands": [
-        {
-          "title": "list",
-          "excerpt": "List sagas",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "title": "view",
-          "excerpt": "Fetch a saga",
-          "args": [
-            {
-              "long": "saga-id"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "image",
-      "excerpt": "",
-      "subcommands": [
-        {
-          "title": "view",
-          "excerpt": "Fetch an image\n\nFetch the details for a specific image in a project.",
-          "args": [
-            {
-              "long": "image"
-            },
-            {
-              "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "delete",
-          "excerpt": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
-          "args": [
-            {
-              "long": "image"
-            },
-            {
-              "long": "project"
-            }
-          ]
-        },
-        {
-          "title": "list",
-          "excerpt": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
         {
           "title": "create",
-          "excerpt": "Create an image\n\nCreate a new image in a project.",
+          "excerpt": "Create a VPC",
           "args": [
             {
               "long": "project"
@@ -1726,61 +1349,438 @@
               "long": "description"
             },
             {
+              "long": "dns-name"
+            },
+            {
+              "long": "ipv6-prefix",
+              "help": "The IPv6 prefix for this VPC.\n\nAll IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix."
+            },
+            {
               "long": "name"
-            },
-            {
-              "long": "os",
-              "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
-            },
-            {
-              "long": "version",
-              "help": "The version of the operating system (e.g. 18.04, 20.04, etc.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "sled",
-      "excerpt": "",
-      "subcommands": [
-        {
-          "title": "view",
-          "excerpt": "Fetch a sled",
-          "args": [
-            {
-              "long": "sled-id",
-              "help": "The sled's unique ID."
             }
           ]
         },
         {
-          "title": "disk-led",
-          "excerpt": "List physical disks attached to sleds",
+          "title": "delete",
+          "excerpt": "Delete a VPC",
           "args": [
             {
-              "long": "sled-id",
-              "help": "The sled's unique ID."
+              "long": "vpc"
             },
             {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "firewall-rules",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "update",
+              "excerpt": "Replace firewall rules",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
             },
             {
-              "long": "sort-by"
+              "title": "view",
+              "excerpt": "List firewall rules",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
             }
           ]
         },
         {
           "title": "list",
-          "excerpt": "List sleds",
+          "excerpt": "List VPCs",
           "args": [
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
             {
+              "long": "project"
+            },
+            {
               "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "router",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "create",
+              "excerpt": "Create a VPC router",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "delete",
+              "excerpt": "Delete a router",
+              "args": [
+                {
+                  "long": "router"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "List routers",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "sort-by"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "route",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "create",
+                  "excerpt": "Create a router",
+                  "args": [
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    },
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "name"
+                    }
+                  ]
+                },
+                {
+                  "title": "delete",
+                  "excerpt": "Delete a route",
+                  "args": [
+                    {
+                      "long": "route"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                },
+                {
+                  "title": "list",
+                  "excerpt": "List routes\n\nList the routes associated with a router in a particular VPC.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "sort-by"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                },
+                {
+                  "title": "update",
+                  "excerpt": "Update a route",
+                  "args": [
+                    {
+                      "long": "route"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    },
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "name"
+                    }
+                  ]
+                },
+                {
+                  "title": "view",
+                  "excerpt": "Fetch a route",
+                  "args": [
+                    {
+                      "long": "route"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "update",
+              "excerpt": "Update a router",
+              "args": [
+                {
+                  "long": "router"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "view",
+              "excerpt": "Get a router",
+              "args": [
+                {
+                  "long": "router"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "subnet",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "create",
+              "excerpt": "Create a subnet",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "ipv4-block",
+                  "help": "The IPv4 address range for this subnet.\n\nIt must be allocated from an RFC 1918 private address range, and must not overlap with any other existing subnet in the VPC."
+                },
+                {
+                  "long": "ipv6-block",
+                  "help": "The IPv6 address range for this subnet.\n\nIt must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC."
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "delete",
+              "excerpt": "Delete a subnet",
+              "args": [
+                {
+                  "long": "subnet"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "Fetch a subnet",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "sort-by"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "nic",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "list",
+                  "excerpt": "List network interfaces",
+                  "args": [
+                    {
+                      "long": "subnet"
+                    },
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "sort-by"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "update",
+              "excerpt": "Update a subnet",
+              "args": [
+                {
+                  "long": "subnet"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "view",
+              "excerpt": "Fetch a subnet",
+              "args": [
+                {
+                  "long": "subnet"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "update",
+          "excerpt": "Update a VPC",
+          "args": [
+            {
+              "long": "vpc"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "dns-name"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a VPC",
+          "args": [
+            {
+              "long": "vpc"
+            },
+            {
+              "long": "project"
             }
           ]
         }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1,0 +1,1897 @@
+{
+  "title": "oxide",
+  "excerpt": "",
+  "subcommands": [
+    {
+      "title": "current-user",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "ssh-key",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "view",
+              "excerpt": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
+              "args": [
+                {
+                  "long": "ssh-key"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "List SSH public keys\n\nLists SSH public keys for the currently authenticated user.",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "title": "delete",
+              "excerpt": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
+              "args": [
+                {
+                  "long": "ssh-key"
+                }
+              ]
+            },
+            {
+              "title": "create",
+              "excerpt": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "public-key",
+                  "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "groups",
+          "excerpt": "Fetch the silo groups the current user belongs to",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch the user associated with the current session"
+        }
+      ]
+    },
+    {
+      "title": "policy",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "view",
+          "excerpt": "Fetch the current silo's IAM policy"
+        },
+        {
+          "title": "update",
+          "excerpt": "Update the current silo's IAM policy"
+        }
+      ]
+    },
+    {
+      "title": "instance",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "start",
+          "excerpt": "Boot an instance",
+          "args": [
+            {
+              "long": "instance"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "external-ip",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "list",
+              "excerpt": "List external IP addresses",
+              "args": [
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "disk",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "list",
+              "excerpt": "List an instance's disks",
+              "args": [
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "title": "detach",
+              "excerpt": "Detach a disk from an instance",
+              "args": [
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "disk"
+                }
+              ]
+            },
+            {
+              "title": "attach",
+              "excerpt": "Attach a disk to an instance",
+              "args": [
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "disk"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "reboot",
+          "excerpt": "Reboot an instance",
+          "args": [
+            {
+              "long": "instance"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List instances",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete an instance",
+          "args": [
+            {
+              "long": "instance"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create an instance",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "hostname"
+            },
+            {
+              "long": "memory"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "ncpus"
+            },
+            {
+              "long": "start",
+              "help": "Should this instance be started upon creation; true by default."
+            },
+            {
+              "long": "user-data",
+              "help": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data."
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch an instance",
+          "args": [
+            {
+              "long": "instance"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "stop",
+          "excerpt": "Stop an instance",
+          "args": [
+            {
+              "long": "instance"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "nic",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "update",
+              "excerpt": "Update a network interface",
+              "args": [
+                {
+                  "long": "interface"
+                },
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "primary",
+                  "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
+                }
+              ]
+            },
+            {
+              "title": "view",
+              "excerpt": "Fetch a network interface",
+              "args": [
+                {
+                  "long": "interface"
+                },
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "List network interfaces",
+              "args": [
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "title": "create",
+              "excerpt": "Create a network interface",
+              "args": [
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "ip",
+                  "help": "The IP address for the interface. One will be auto-assigned if not provided."
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "subnet-name",
+                  "help": "The VPC Subnet in which to create the interface."
+                },
+                {
+                  "long": "vpc-name",
+                  "help": "The VPC in which to create the interface."
+                }
+              ]
+            },
+            {
+              "title": "delete",
+              "excerpt": "Delete a network interface\n\nNote that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
+              "args": [
+                {
+                  "long": "interface"
+                },
+                {
+                  "long": "instance"
+                },
+                {
+                  "long": "project"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "vpc",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List VPCs",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a VPC",
+          "args": [
+            {
+              "long": "vpc"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "router",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "update",
+              "excerpt": "Update a router",
+              "args": [
+                {
+                  "long": "router"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "create",
+              "excerpt": "Create a VPC router",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "view",
+              "excerpt": "Get a router",
+              "args": [
+                {
+                  "long": "router"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "route",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "update",
+                  "excerpt": "Update a route",
+                  "args": [
+                    {
+                      "long": "route"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    },
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "name"
+                    }
+                  ]
+                },
+                {
+                  "title": "list",
+                  "excerpt": "List routes\n\nList the routes associated with a router in a particular VPC.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "sort-by"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                },
+                {
+                  "title": "create",
+                  "excerpt": "Create a router",
+                  "args": [
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    },
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "name"
+                    }
+                  ]
+                },
+                {
+                  "title": "delete",
+                  "excerpt": "Delete a route",
+                  "args": [
+                    {
+                      "long": "route"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                },
+                {
+                  "title": "view",
+                  "excerpt": "Fetch a route",
+                  "args": [
+                    {
+                      "long": "route"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "router"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "delete",
+              "excerpt": "Delete a router",
+              "args": [
+                {
+                  "long": "router"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "List routers",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "sort-by"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "subnet",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "view",
+              "excerpt": "Fetch a subnet",
+              "args": [
+                {
+                  "long": "subnet"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "create",
+              "excerpt": "Create a subnet",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "ipv4-block",
+                  "help": "The IPv4 address range for this subnet.\n\nIt must be allocated from an RFC 1918 private address range, and must not overlap with any other existing subnet in the VPC."
+                },
+                {
+                  "long": "ipv6-block",
+                  "help": "The IPv6 address range for this subnet.\n\nIt must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC."
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "Fetch a subnet",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "sort-by"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "update",
+              "excerpt": "Update a subnet",
+              "args": [
+                {
+                  "long": "subnet"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                }
+              ]
+            },
+            {
+              "title": "nic",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "list",
+                  "excerpt": "List network interfaces",
+                  "args": [
+                    {
+                      "long": "subnet"
+                    },
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "project"
+                    },
+                    {
+                      "long": "sort-by"
+                    },
+                    {
+                      "long": "vpc"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "delete",
+              "excerpt": "Delete a subnet",
+              "args": [
+                {
+                  "long": "subnet"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create a VPC",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "dns-name"
+            },
+            {
+              "long": "ipv6-prefix",
+              "help": "The IPv6 prefix for this VPC.\n\nAll IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix."
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "firewall-rules",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "view",
+              "excerpt": "List firewall rules",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            },
+            {
+              "title": "update",
+              "excerpt": "Replace firewall rules",
+              "args": [
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "vpc"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "update",
+          "excerpt": "Update a VPC",
+          "args": [
+            {
+              "long": "vpc"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "dns-name"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a VPC",
+          "args": [
+            {
+              "long": "vpc"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "snapshot",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "view",
+          "excerpt": "Fetch a snapshot",
+          "args": [
+            {
+              "long": "snapshot"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a snapshot",
+          "args": [
+            {
+              "long": "snapshot"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List snapshots",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "disk",
+              "help": "The name of the disk to be snapshotted"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "ip-pool",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List IP pools",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "update",
+          "excerpt": "Update an IP Pool",
+          "args": [
+            {
+              "long": "pool"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "service",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "remove",
+              "excerpt": "Remove a range from an IP pool used for Oxide services."
+            },
+            {
+              "title": "view",
+              "excerpt": "Fetch the IP pool used for Oxide services."
+            },
+            {
+              "title": "range",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "list",
+                  "excerpt": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    }
+                  ]
+                },
+                {
+                  "title": "add",
+                  "excerpt": "Add a range to an IP pool used for Oxide services."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "range",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "add",
+              "excerpt": "Add a range to an IP pool",
+              "args": [
+                {
+                  "long": "pool"
+                },
+                {
+                  "long": "first"
+                },
+                {
+                  "long": "last"
+                }
+              ]
+            },
+            {
+              "title": "remove",
+              "excerpt": "Remove a range from an IP pool",
+              "args": [
+                {
+                  "long": "pool"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
+              "args": [
+                {
+                  "long": "pool"
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete an IP Pool",
+          "args": [
+            {
+              "long": "pool"
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create an IP pool",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch an IP pool",
+          "args": [
+            {
+              "long": "pool"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "physical-disk",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List physical disks",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "disk",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List disks",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a disk",
+          "args": [
+            {
+              "long": "disk"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create a disk",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "size",
+              "help": "total size of the Disk in bytes"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a disk",
+          "args": [
+            {
+              "long": "disk"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "metrics",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "list",
+              "excerpt": "Fetch disk metrics",
+              "args": [
+                {
+                  "long": "disk"
+                },
+                {
+                  "long": "metric"
+                },
+                {
+                  "long": "end-time",
+                  "help": "An exclusive end time of metrics."
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project"
+                },
+                {
+                  "long": "start-time",
+                  "help": "An inclusive start time of metrics."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "group",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List groups",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "silo",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List silos\n\nLists silos that are discoverable based on the current permissions.",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "idp",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "local",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "user",
+                  "excerpt": "",
+                  "subcommands": [
+                    {
+                      "title": "create",
+                      "excerpt": "Create a user\n\nUsers can only be created in Silos with `provision_type` == `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user first logs in using an external Identity Provider.",
+                      "args": [
+                        {
+                          "long": "silo"
+                        },
+                        {
+                          "long": "external-id",
+                          "help": "username used to log in"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "set-password",
+                      "excerpt": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
+                      "args": [
+                        {
+                          "long": "user-id",
+                          "help": "The user's internal id"
+                        },
+                        {
+                          "long": "silo"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "delete",
+                      "excerpt": "Delete a user",
+                      "args": [
+                        {
+                          "long": "user-id",
+                          "help": "The user's internal id"
+                        },
+                        {
+                          "long": "silo"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "List a silo's IDPs_name",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "silo"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "title": "saml",
+              "excerpt": "",
+              "subcommands": [
+                {
+                  "title": "create",
+                  "excerpt": "Create a SAML IDP",
+                  "args": [
+                    {
+                      "long": "silo"
+                    },
+                    {
+                      "long": "acs-url",
+                      "help": "service provider endpoint where the response will be sent"
+                    },
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "group-attribute-name",
+                      "help": "If set, SAML attributes with this name will be considered to denote a user's group membership, where the attribute value(s) should be a comma-separated list of group names."
+                    },
+                    {
+                      "long": "idp-entity-id",
+                      "help": "idp's entity id"
+                    },
+                    {
+                      "long": "name"
+                    },
+                    {
+                      "long": "slo-url",
+                      "help": "service provider endpoint where the idp should send log out requests"
+                    },
+                    {
+                      "long": "sp-client-id",
+                      "help": "sp's client id"
+                    },
+                    {
+                      "long": "technical-contact-email",
+                      "help": "customer's technical contact for saml configuration"
+                    }
+                  ]
+                },
+                {
+                  "title": "view",
+                  "excerpt": "Fetch a SAML IDP",
+                  "args": [
+                    {
+                      "long": "provider"
+                    },
+                    {
+                      "long": "silo"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a silo\n\nDelete a silo by name.",
+          "args": [
+            {
+              "long": "silo"
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create a silo",
+          "args": [
+            {
+              "long": "admin-group-name",
+              "help": "If set, this group will be created during Silo creation and granted the \"Silo Admin\" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.\n\nNote that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information."
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "discoverable"
+            },
+            {
+              "long": "identity-mode"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "policy",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "update",
+              "excerpt": "Update a silo's IAM policy",
+              "args": [
+                {
+                  "long": "silo"
+                }
+              ]
+            },
+            {
+              "title": "view",
+              "excerpt": "Fetch a silo's IAM policy",
+              "args": [
+                {
+                  "long": "silo"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a silo\n\nFetch a silo by name.",
+          "args": [
+            {
+              "long": "silo"
+            }
+          ]
+        },
+        {
+          "title": "user",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "view",
+              "excerpt": "Fetch a user",
+              "args": [
+                {
+                  "long": "user-id",
+                  "help": "The user's internal id"
+                },
+                {
+                  "long": "silo"
+                }
+              ]
+            },
+            {
+              "title": "list",
+              "excerpt": "List users in a silo",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "silo"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "system",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "policy",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "view",
+              "excerpt": "Fetch the top-level IAM policy"
+            },
+            {
+              "title": "update",
+              "excerpt": "Update the top-level IAM policy"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "project",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "update",
+          "excerpt": "Update a project",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List projects",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a project",
+          "args": [
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a project",
+          "args": [
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "policy",
+          "excerpt": "",
+          "subcommands": [
+            {
+              "title": "update",
+              "excerpt": "Update a project's IAM policy",
+              "args": [
+                {
+                  "long": "project"
+                }
+              ]
+            },
+            {
+              "title": "view",
+              "excerpt": "Fetch a project's IAM policy",
+              "args": [
+                {
+                  "long": "project"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create a project",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "certificate",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "view",
+          "excerpt": "Fetch a certificate\n\nReturns the details of a specific certificate",
+          "args": [
+            {
+              "long": "certificate"
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "service",
+              "help": "The service using this certificate"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
+          "args": [
+            {
+              "long": "certificate"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "user",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List users",
+          "args": [
+            {
+              "long": "group"
+            },
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "rack",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "view",
+          "excerpt": "Fetch a rack",
+          "args": [
+            {
+              "long": "rack-id",
+              "help": "The rack's unique ID."
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List racks",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "saga",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "list",
+          "excerpt": "List sagas",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "view",
+          "excerpt": "Fetch a saga",
+          "args": [
+            {
+              "long": "saga-id"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "image",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "view",
+          "excerpt": "Fetch an image\n\nFetch the details for a specific image in a project.",
+          "args": [
+            {
+              "long": "image"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "delete",
+          "excerpt": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
+          "args": [
+            {
+              "long": "image"
+            },
+            {
+              "long": "project"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "create",
+          "excerpt": "Create an image\n\nCreate a new image in a project.",
+          "args": [
+            {
+              "long": "project"
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "os",
+              "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
+            },
+            {
+              "long": "version",
+              "help": "The version of the operating system (e.g. 18.04, 20.04, etc.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "sled",
+      "excerpt": "",
+      "subcommands": [
+        {
+          "title": "view",
+          "excerpt": "Fetch a sled",
+          "args": [
+            {
+              "long": "sled-id",
+              "help": "The sled's unique ID."
+            }
+          ]
+        },
+        {
+          "title": "disk-led",
+          "excerpt": "List physical disks attached to sleds",
+          "args": [
+            {
+              "long": "sled-id",
+              "help": "The sled's unique ID."
+            },
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "title": "list",
+          "excerpt": "List sleds",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "auth",
+      "excerpt": "Login, logout, and get the status of your authentication.",
+      "about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
+      "subcommands": [
+        {
+          "title": "login",
+          "excerpt": "Authenticate with an Oxide host.",
+          "about": "Authenticate with an Oxide host.\n\nAlternatively, pass in a token on standard input by using `--with-token`.\n\n    # start interactive setup\n    $ oxide auth login\n\n    # authenticate against a specific Oxide instance by reading the token\n    # from a file\n    $ oxide auth login --with-token --host oxide.internal < mytoken.txt\n\n    # authenticate with a specific Oxide instance\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide instance (not recommended)\n    $ oxide auth login --host http://oxide.internal",
+          "args": [
+            {
+              "long": "with-token",
+              "help": "Read token from standard input"
+            },
+            {
+              "short": "H",
+              "long": "host",
+              "help": "The host of the Oxide instance to authenticate with. This assumes http; specify an `http://` prefix if needed"
+            },
+            {
+              "long": "browser",
+              "help": "Override the default browser when opening the authentication URL"
+            },
+            {
+              "long": "no-browser",
+              "help": "Print the authentication URL rather than opening a browser window"
+            }
+          ]
+        },
+        {
+          "title": "logout",
+          "excerpt": "Log out of an Oxide host.",
+          "about": "Log out of an Oxide host.\n\nThis command removes the authentication configuration for a host either specified\ninteractively or via `--host`.\n\n    $ oxide auth logout\n    # => select what host to log out of via a prompt\n\n    $ oxide auth logout --host oxide.internal\n    # => log out of specified host",
+          "args": [
+            {
+              "short": "H",
+              "long": "host",
+              "help": "The hostname of the Oxide instance to log out of"
+            }
+          ]
+        },
+        {
+          "title": "status",
+          "excerpt": "Verifies and displays information about your authentication state.\nThis command validates the authentication state for each Oxide environment in the current configuration. These hosts may be from your hosts.toml file and/or\n$OXIDE_HOST environment variable.",
+          "args": [
+            {
+              "short": "t",
+              "long": "show-token",
+              "help": "Display the auth token"
+            },
+            {
+              "short": "H",
+              "long": "host",
+              "help": "Specific hostname to validate"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "api",
+      "excerpt": "Makes an authenticated HTTP request to the Oxide API and prints the response.",
+      "about": "Makes an authenticated HTTP request to the Oxide API and prints the response.\n\nThe endpoint argument should be a path of a Oxide API endpoint.\n\nThe default HTTP request method is \"GET\" normally and \"POST\" if any\nparameters were added. Override the method with `--method`.\n\nPass one or more `-f/--raw-field` values in \"key=value\" format to add\nstatic string parameters to the request payload. To add non-string or\notherwise dynamic values, see `--field` below. Note that adding request\nparameters will automatically switch the request method to POST. To send\nthe parameters as a GET query string instead, use `--method GET`.\n\nThe `-F/--field` flag has magic type conversion based on the format of the\nvalue:\n\n- literal values \"true\", \"false\", \"null\", and integer/float numbers get\n  converted to appropriate JSON types;\n- if the value starts with \"@\", the rest of the value is interpreted as a\n  filename to read the value from. Pass \"-\" to read from standard input.\n\nRaw request body may be passed from the outside via a file specified by\n`--input`. Pass \"-\" to read from standard input. In this mode, parameters\nspecified via `--field` flags are serialized into URL query parameters.\n\nIn `--paginate` mode, all pages of results will sequentially be requested\nuntil there are no more pages of results.",
+      "args": [
+        {
+          "short": "X",
+          "long": "method",
+          "help": "The HTTP method for the request"
+        },
+        {
+          "long": "paginate",
+          "help": "Make additional HTTP requests to fetch all pages of results"
+        },
+        {
+          "short": "F",
+          "long": "field",
+          "help": "Add a typed parameter in key=value format"
+        },
+        {
+          "short": "f",
+          "long": "raw-field",
+          "help": "Add a string parameter in key=value format"
+        },
+        {
+          "long": "input",
+          "help": "The file to use as body for the HTTP request (use \"-\" to read from standard input)"
+        },
+        {
+          "short": "i",
+          "long": "include",
+          "help": "Include HTTP response headers in the output"
+        },
+        {
+          "short": "H",
+          "long": "header",
+          "help": "Add a HTTP request header in `key:value` format"
+        }
+      ]
+    },
+    {
+      "title": "docs",
+      "excerpt": "Generate CLI docs in JSON format"
+    },
+    {
+      "title": "version",
+      "excerpt": "Prints version information about the CLI."
+    }
+  ]
+}

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1,14 +1,12 @@
 {
-  "title": "oxide",
-  "excerpt": "",
+  "name": "oxide",
   "subcommands": [
     {
-      "title": "certificate",
-      "excerpt": "",
+      "name": "certificate",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
+          "name": "create",
+          "about": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
           "args": [
             {
               "long": "description"
@@ -23,8 +21,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
+          "name": "delete",
+          "about": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
           "args": [
             {
               "long": "certificate"
@@ -32,8 +30,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
+          "name": "list",
+          "about": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
           "args": [
             {
               "long": "limit",
@@ -45,8 +43,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a certificate\n\nReturns the details of a specific certificate",
+          "name": "view",
+          "about": "Fetch a certificate\n\nReturns the details of a specific certificate",
           "args": [
             {
               "long": "certificate"
@@ -56,12 +54,11 @@
       ]
     },
     {
-      "title": "current-user",
-      "excerpt": "",
+      "name": "current-user",
       "subcommands": [
         {
-          "title": "groups",
-          "excerpt": "Fetch the silo groups the current user belongs to",
+          "name": "groups",
+          "about": "Fetch the silo groups the current user belongs to",
           "args": [
             {
               "long": "limit",
@@ -73,12 +70,11 @@
           ]
         },
         {
-          "title": "ssh-key",
-          "excerpt": "",
+          "name": "ssh-key",
           "subcommands": [
             {
-              "title": "create",
-              "excerpt": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
+              "name": "create",
+              "about": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
               "args": [
                 {
                   "long": "description"
@@ -93,8 +89,8 @@
               ]
             },
             {
-              "title": "delete",
-              "excerpt": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
+              "name": "delete",
+              "about": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
               "args": [
                 {
                   "long": "ssh-key"
@@ -102,8 +98,8 @@
               ]
             },
             {
-              "title": "list",
-              "excerpt": "List SSH public keys\n\nLists SSH public keys for the currently authenticated user.",
+              "name": "list",
+              "about": "List SSH public keys\n\nLists SSH public keys for the currently authenticated user.",
               "args": [
                 {
                   "long": "limit",
@@ -115,8 +111,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
+              "name": "view",
+              "about": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
               "args": [
                 {
                   "long": "ssh-key"
@@ -126,18 +122,17 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch the user associated with the current session"
+          "name": "view",
+          "about": "Fetch the user associated with the current session"
         }
       ]
     },
     {
-      "title": "disk",
-      "excerpt": "",
+      "name": "disk",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create a disk",
+          "name": "create",
+          "about": "Create a disk",
           "args": [
             {
               "long": "project"
@@ -155,8 +150,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a disk",
+          "name": "delete",
+          "about": "Delete a disk",
           "args": [
             {
               "long": "disk"
@@ -167,8 +162,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List disks",
+          "name": "list",
+          "about": "List disks",
           "args": [
             {
               "long": "limit",
@@ -183,12 +178,11 @@
           ]
         },
         {
-          "title": "metrics",
-          "excerpt": "",
+          "name": "metrics",
           "subcommands": [
             {
-              "title": "list",
-              "excerpt": "Fetch disk metrics",
+              "name": "list",
+              "about": "Fetch disk metrics",
               "args": [
                 {
                   "long": "disk"
@@ -216,8 +210,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a disk",
+          "name": "view",
+          "about": "Fetch a disk",
           "args": [
             {
               "long": "disk"
@@ -230,12 +224,11 @@
       ]
     },
     {
-      "title": "group",
-      "excerpt": "",
+      "name": "group",
       "subcommands": [
         {
-          "title": "list",
-          "excerpt": "List groups",
+          "name": "list",
+          "about": "List groups",
           "args": [
             {
               "long": "limit",
@@ -249,12 +242,11 @@
       ]
     },
     {
-      "title": "image",
-      "excerpt": "",
+      "name": "image",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create an image\n\nCreate a new image in a project.",
+          "name": "create",
+          "about": "Create an image\n\nCreate a new image in a project.",
           "args": [
             {
               "long": "project"
@@ -276,8 +268,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
+          "name": "delete",
+          "about": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
           "args": [
             {
               "long": "image"
@@ -288,8 +280,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
+          "name": "list",
+          "about": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
           "args": [
             {
               "long": "limit",
@@ -304,8 +296,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch an image\n\nFetch the details for a specific image in a project.",
+          "name": "view",
+          "about": "Fetch an image\n\nFetch the details for a specific image in a project.",
           "args": [
             {
               "long": "image"
@@ -318,12 +310,11 @@
       ]
     },
     {
-      "title": "instance",
-      "excerpt": "",
+      "name": "instance",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create an instance",
+          "name": "create",
+          "about": "Create an instance",
           "args": [
             {
               "long": "project"
@@ -354,8 +345,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete an instance",
+          "name": "delete",
+          "about": "Delete an instance",
           "args": [
             {
               "long": "instance"
@@ -366,12 +357,11 @@
           ]
         },
         {
-          "title": "disk",
-          "excerpt": "",
+          "name": "disk",
           "subcommands": [
             {
-              "title": "attach",
-              "excerpt": "Attach a disk to an instance",
+              "name": "attach",
+              "about": "Attach a disk to an instance",
               "args": [
                 {
                   "long": "instance"
@@ -385,8 +375,8 @@
               ]
             },
             {
-              "title": "detach",
-              "excerpt": "Detach a disk from an instance",
+              "name": "detach",
+              "about": "Detach a disk from an instance",
               "args": [
                 {
                   "long": "instance"
@@ -400,8 +390,8 @@
               ]
             },
             {
-              "title": "list",
-              "excerpt": "List an instance's disks",
+              "name": "list",
+              "about": "List an instance's disks",
               "args": [
                 {
                   "long": "instance"
@@ -421,12 +411,11 @@
           ]
         },
         {
-          "title": "external-ip",
-          "excerpt": "",
+          "name": "external-ip",
           "subcommands": [
             {
-              "title": "list",
-              "excerpt": "List external IP addresses",
+              "name": "list",
+              "about": "List external IP addresses",
               "args": [
                 {
                   "long": "instance"
@@ -439,8 +428,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List instances",
+          "name": "list",
+          "about": "List instances",
           "args": [
             {
               "long": "limit",
@@ -455,12 +444,11 @@
           ]
         },
         {
-          "title": "nic",
-          "excerpt": "",
+          "name": "nic",
           "subcommands": [
             {
-              "title": "create",
-              "excerpt": "Create a network interface",
+              "name": "create",
+              "about": "Create a network interface",
               "args": [
                 {
                   "long": "instance"
@@ -489,8 +477,8 @@
               ]
             },
             {
-              "title": "delete",
-              "excerpt": "Delete a network interface\n\nNote that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
+              "name": "delete",
+              "about": "Delete a network interface\n\nNote that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
               "args": [
                 {
                   "long": "interface"
@@ -504,8 +492,8 @@
               ]
             },
             {
-              "title": "list",
-              "excerpt": "List network interfaces",
+              "name": "list",
+              "about": "List network interfaces",
               "args": [
                 {
                   "long": "instance"
@@ -523,8 +511,8 @@
               ]
             },
             {
-              "title": "update",
-              "excerpt": "Update a network interface",
+              "name": "update",
+              "about": "Update a network interface",
               "args": [
                 {
                   "long": "interface"
@@ -548,8 +536,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Fetch a network interface",
+              "name": "view",
+              "about": "Fetch a network interface",
               "args": [
                 {
                   "long": "interface"
@@ -565,8 +553,8 @@
           ]
         },
         {
-          "title": "reboot",
-          "excerpt": "Reboot an instance",
+          "name": "reboot",
+          "about": "Reboot an instance",
           "args": [
             {
               "long": "instance"
@@ -577,8 +565,8 @@
           ]
         },
         {
-          "title": "start",
-          "excerpt": "Boot an instance",
+          "name": "start",
+          "about": "Boot an instance",
           "args": [
             {
               "long": "instance"
@@ -589,8 +577,8 @@
           ]
         },
         {
-          "title": "stop",
-          "excerpt": "Stop an instance",
+          "name": "stop",
+          "about": "Stop an instance",
           "args": [
             {
               "long": "instance"
@@ -601,8 +589,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch an instance",
+          "name": "view",
+          "about": "Fetch an instance",
           "args": [
             {
               "long": "instance"
@@ -615,12 +603,11 @@
       ]
     },
     {
-      "title": "ip-pool",
-      "excerpt": "",
+      "name": "ip-pool",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create an IP pool",
+          "name": "create",
+          "about": "Create an IP pool",
           "args": [
             {
               "long": "description"
@@ -631,8 +618,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete an IP Pool",
+          "name": "delete",
+          "about": "Delete an IP Pool",
           "args": [
             {
               "long": "pool"
@@ -640,8 +627,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List IP pools",
+          "name": "list",
+          "about": "List IP pools",
           "args": [
             {
               "long": "limit",
@@ -653,12 +640,11 @@
           ]
         },
         {
-          "title": "range",
-          "excerpt": "",
+          "name": "range",
           "subcommands": [
             {
-              "title": "add",
-              "excerpt": "Add a range to an IP pool",
+              "name": "add",
+              "about": "Add a range to an IP pool",
               "args": [
                 {
                   "long": "pool"
@@ -672,8 +658,8 @@
               ]
             },
             {
-              "title": "list",
-              "excerpt": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
+              "name": "list",
+              "about": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
               "args": [
                 {
                   "long": "pool"
@@ -685,8 +671,8 @@
               ]
             },
             {
-              "title": "remove",
-              "excerpt": "Remove a range from an IP pool",
+              "name": "remove",
+              "about": "Remove a range from an IP pool",
               "args": [
                 {
                   "long": "pool"
@@ -696,20 +682,18 @@
           ]
         },
         {
-          "title": "service",
-          "excerpt": "",
+          "name": "service",
           "subcommands": [
             {
-              "title": "range",
-              "excerpt": "",
+              "name": "range",
               "subcommands": [
                 {
-                  "title": "add",
-                  "excerpt": "Add a range to an IP pool used for Oxide services."
+                  "name": "add",
+                  "about": "Add a range to an IP pool used for Oxide services."
                 },
                 {
-                  "title": "list",
-                  "excerpt": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
+                  "name": "list",
+                  "about": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
                   "args": [
                     {
                       "long": "limit",
@@ -720,18 +704,18 @@
               ]
             },
             {
-              "title": "remove",
-              "excerpt": "Remove a range from an IP pool used for Oxide services."
+              "name": "remove",
+              "about": "Remove a range from an IP pool used for Oxide services."
             },
             {
-              "title": "view",
-              "excerpt": "Fetch the IP pool used for Oxide services."
+              "name": "view",
+              "about": "Fetch the IP pool used for Oxide services."
             }
           ]
         },
         {
-          "title": "update",
-          "excerpt": "Update an IP Pool",
+          "name": "update",
+          "about": "Update an IP Pool",
           "args": [
             {
               "long": "pool"
@@ -745,8 +729,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch an IP pool",
+          "name": "view",
+          "about": "Fetch an IP pool",
           "args": [
             {
               "long": "pool"
@@ -756,12 +740,11 @@
       ]
     },
     {
-      "title": "physical-disk",
-      "excerpt": "",
+      "name": "physical-disk",
       "subcommands": [
         {
-          "title": "list",
-          "excerpt": "List physical disks",
+          "name": "list",
+          "about": "List physical disks",
           "args": [
             {
               "long": "limit",
@@ -775,26 +758,24 @@
       ]
     },
     {
-      "title": "policy",
-      "excerpt": "",
+      "name": "policy",
       "subcommands": [
         {
-          "title": "update",
-          "excerpt": "Update the current silo's IAM policy"
+          "name": "update",
+          "about": "Update the current silo's IAM policy"
         },
         {
-          "title": "view",
-          "excerpt": "Fetch the current silo's IAM policy"
+          "name": "view",
+          "about": "Fetch the current silo's IAM policy"
         }
       ]
     },
     {
-      "title": "project",
-      "excerpt": "",
+      "name": "project",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create a project",
+          "name": "create",
+          "about": "Create a project",
           "args": [
             {
               "long": "description"
@@ -805,8 +786,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a project",
+          "name": "delete",
+          "about": "Delete a project",
           "args": [
             {
               "long": "project"
@@ -814,8 +795,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List projects",
+          "name": "list",
+          "about": "List projects",
           "args": [
             {
               "long": "limit",
@@ -827,12 +808,11 @@
           ]
         },
         {
-          "title": "policy",
-          "excerpt": "",
+          "name": "policy",
           "subcommands": [
             {
-              "title": "update",
-              "excerpt": "Update a project's IAM policy",
+              "name": "update",
+              "about": "Update a project's IAM policy",
               "args": [
                 {
                   "long": "project"
@@ -840,8 +820,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Fetch a project's IAM policy",
+              "name": "view",
+              "about": "Fetch a project's IAM policy",
               "args": [
                 {
                   "long": "project"
@@ -851,8 +831,8 @@
           ]
         },
         {
-          "title": "update",
-          "excerpt": "Update a project",
+          "name": "update",
+          "about": "Update a project",
           "args": [
             {
               "long": "project"
@@ -866,8 +846,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a project",
+          "name": "view",
+          "about": "Fetch a project",
           "args": [
             {
               "long": "project"
@@ -877,12 +857,11 @@
       ]
     },
     {
-      "title": "rack",
-      "excerpt": "",
+      "name": "rack",
       "subcommands": [
         {
-          "title": "list",
-          "excerpt": "List racks",
+          "name": "list",
+          "about": "List racks",
           "args": [
             {
               "long": "limit",
@@ -894,8 +873,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a rack",
+          "name": "view",
+          "about": "Fetch a rack",
           "args": [
             {
               "long": "rack-id",
@@ -906,12 +885,11 @@
       ]
     },
     {
-      "title": "saga",
-      "excerpt": "",
+      "name": "saga",
       "subcommands": [
         {
-          "title": "list",
-          "excerpt": "List sagas",
+          "name": "list",
+          "about": "List sagas",
           "args": [
             {
               "long": "limit",
@@ -923,8 +901,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a saga",
+          "name": "view",
+          "about": "Fetch a saga",
           "args": [
             {
               "long": "saga-id"
@@ -934,12 +912,11 @@
       ]
     },
     {
-      "title": "silo",
-      "excerpt": "",
+      "name": "silo",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create a silo",
+          "name": "create",
+          "about": "Create a silo",
           "args": [
             {
               "long": "admin-group-name",
@@ -960,8 +937,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a silo\n\nDelete a silo by name.",
+          "name": "delete",
+          "about": "Delete a silo\n\nDelete a silo by name.",
           "args": [
             {
               "long": "silo"
@@ -969,12 +946,11 @@
           ]
         },
         {
-          "title": "idp",
-          "excerpt": "",
+          "name": "idp",
           "subcommands": [
             {
-              "title": "list",
-              "excerpt": "List a silo's IDPs_name",
+              "name": "list",
+              "about": "List a silo's IDPs_name",
               "args": [
                 {
                   "long": "limit",
@@ -989,16 +965,14 @@
               ]
             },
             {
-              "title": "local",
-              "excerpt": "",
+              "name": "local",
               "subcommands": [
                 {
-                  "title": "user",
-                  "excerpt": "",
+                  "name": "user",
                   "subcommands": [
                     {
-                      "title": "create",
-                      "excerpt": "Create a user\n\nUsers can only be created in Silos with `provision_type` == `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user first logs in using an external Identity Provider.",
+                      "name": "create",
+                      "about": "Create a user\n\nUsers can only be created in Silos with `provision_type` == `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user first logs in using an external Identity Provider.",
                       "args": [
                         {
                           "long": "silo"
@@ -1010,8 +984,8 @@
                       ]
                     },
                     {
-                      "title": "delete",
-                      "excerpt": "Delete a user",
+                      "name": "delete",
+                      "about": "Delete a user",
                       "args": [
                         {
                           "long": "user-id",
@@ -1023,8 +997,8 @@
                       ]
                     },
                     {
-                      "title": "set-password",
-                      "excerpt": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
+                      "name": "set-password",
+                      "about": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
                       "args": [
                         {
                           "long": "user-id",
@@ -1040,12 +1014,11 @@
               ]
             },
             {
-              "title": "saml",
-              "excerpt": "",
+              "name": "saml",
               "subcommands": [
                 {
-                  "title": "create",
-                  "excerpt": "Create a SAML IDP",
+                  "name": "create",
+                  "about": "Create a SAML IDP",
                   "args": [
                     {
                       "long": "silo"
@@ -1083,8 +1056,8 @@
                   ]
                 },
                 {
-                  "title": "view",
-                  "excerpt": "Fetch a SAML IDP",
+                  "name": "view",
+                  "about": "Fetch a SAML IDP",
                   "args": [
                     {
                       "long": "provider"
@@ -1099,8 +1072,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List silos\n\nLists silos that are discoverable based on the current permissions.",
+          "name": "list",
+          "about": "List silos\n\nLists silos that are discoverable based on the current permissions.",
           "args": [
             {
               "long": "limit",
@@ -1112,12 +1085,11 @@
           ]
         },
         {
-          "title": "policy",
-          "excerpt": "",
+          "name": "policy",
           "subcommands": [
             {
-              "title": "update",
-              "excerpt": "Update a silo's IAM policy",
+              "name": "update",
+              "about": "Update a silo's IAM policy",
               "args": [
                 {
                   "long": "silo"
@@ -1125,8 +1097,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Fetch a silo's IAM policy",
+              "name": "view",
+              "about": "Fetch a silo's IAM policy",
               "args": [
                 {
                   "long": "silo"
@@ -1136,12 +1108,11 @@
           ]
         },
         {
-          "title": "user",
-          "excerpt": "",
+          "name": "user",
           "subcommands": [
             {
-              "title": "list",
-              "excerpt": "List users in a silo",
+              "name": "list",
+              "about": "List users in a silo",
               "args": [
                 {
                   "long": "limit",
@@ -1156,8 +1127,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Fetch a user",
+              "name": "view",
+              "about": "Fetch a user",
               "args": [
                 {
                   "long": "user-id",
@@ -1171,8 +1142,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a silo\n\nFetch a silo by name.",
+          "name": "view",
+          "about": "Fetch a silo\n\nFetch a silo by name.",
           "args": [
             {
               "long": "silo"
@@ -1182,12 +1153,11 @@
       ]
     },
     {
-      "title": "sled",
-      "excerpt": "",
+      "name": "sled",
       "subcommands": [
         {
-          "title": "disk-led",
-          "excerpt": "List physical disks attached to sleds",
+          "name": "disk-led",
+          "about": "List physical disks attached to sleds",
           "args": [
             {
               "long": "sled-id",
@@ -1203,8 +1173,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List sleds",
+          "name": "list",
+          "about": "List sleds",
           "args": [
             {
               "long": "limit",
@@ -1216,8 +1186,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a sled",
+          "name": "view",
+          "about": "Fetch a sled",
           "args": [
             {
               "long": "sled-id",
@@ -1228,12 +1198,11 @@
       ]
     },
     {
-      "title": "snapshot",
-      "excerpt": "",
+      "name": "snapshot",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
+          "name": "create",
+          "about": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
           "args": [
             {
               "long": "project"
@@ -1251,8 +1220,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a snapshot",
+          "name": "delete",
+          "about": "Delete a snapshot",
           "args": [
             {
               "long": "snapshot"
@@ -1263,8 +1232,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List snapshots",
+          "name": "list",
+          "about": "List snapshots",
           "args": [
             {
               "long": "limit",
@@ -1279,8 +1248,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a snapshot",
+          "name": "view",
+          "about": "Fetch a snapshot",
           "args": [
             {
               "long": "snapshot"
@@ -1293,32 +1262,29 @@
       ]
     },
     {
-      "title": "system",
-      "excerpt": "",
+      "name": "system",
       "subcommands": [
         {
-          "title": "policy",
-          "excerpt": "",
+          "name": "policy",
           "subcommands": [
             {
-              "title": "update",
-              "excerpt": "Update the top-level IAM policy"
+              "name": "update",
+              "about": "Update the top-level IAM policy"
             },
             {
-              "title": "view",
-              "excerpt": "Fetch the top-level IAM policy"
+              "name": "view",
+              "about": "Fetch the top-level IAM policy"
             }
           ]
         }
       ]
     },
     {
-      "title": "user",
-      "excerpt": "",
+      "name": "user",
       "subcommands": [
         {
-          "title": "list",
-          "excerpt": "List users",
+          "name": "list",
+          "about": "List users",
           "args": [
             {
               "long": "group"
@@ -1335,12 +1301,11 @@
       ]
     },
     {
-      "title": "vpc",
-      "excerpt": "",
+      "name": "vpc",
       "subcommands": [
         {
-          "title": "create",
-          "excerpt": "Create a VPC",
+          "name": "create",
+          "about": "Create a VPC",
           "args": [
             {
               "long": "project"
@@ -1361,8 +1326,8 @@
           ]
         },
         {
-          "title": "delete",
-          "excerpt": "Delete a VPC",
+          "name": "delete",
+          "about": "Delete a VPC",
           "args": [
             {
               "long": "vpc"
@@ -1373,12 +1338,11 @@
           ]
         },
         {
-          "title": "firewall-rules",
-          "excerpt": "",
+          "name": "firewall-rules",
           "subcommands": [
             {
-              "title": "update",
-              "excerpt": "Replace firewall rules",
+              "name": "update",
+              "about": "Replace firewall rules",
               "args": [
                 {
                   "long": "project"
@@ -1389,8 +1353,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "List firewall rules",
+              "name": "view",
+              "about": "List firewall rules",
               "args": [
                 {
                   "long": "project"
@@ -1403,8 +1367,8 @@
           ]
         },
         {
-          "title": "list",
-          "excerpt": "List VPCs",
+          "name": "list",
+          "about": "List VPCs",
           "args": [
             {
               "long": "limit",
@@ -1419,12 +1383,11 @@
           ]
         },
         {
-          "title": "router",
-          "excerpt": "",
+          "name": "router",
           "subcommands": [
             {
-              "title": "create",
-              "excerpt": "Create a VPC router",
+              "name": "create",
+              "about": "Create a VPC router",
               "args": [
                 {
                   "long": "project"
@@ -1441,8 +1404,8 @@
               ]
             },
             {
-              "title": "delete",
-              "excerpt": "Delete a router",
+              "name": "delete",
+              "about": "Delete a router",
               "args": [
                 {
                   "long": "router"
@@ -1456,8 +1419,8 @@
               ]
             },
             {
-              "title": "list",
-              "excerpt": "List routers",
+              "name": "list",
+              "about": "List routers",
               "args": [
                 {
                   "long": "limit",
@@ -1475,12 +1438,11 @@
               ]
             },
             {
-              "title": "route",
-              "excerpt": "",
+              "name": "route",
               "subcommands": [
                 {
-                  "title": "create",
-                  "excerpt": "Create a router",
+                  "name": "create",
+                  "about": "Create a router",
                   "args": [
                     {
                       "long": "project"
@@ -1500,8 +1462,8 @@
                   ]
                 },
                 {
-                  "title": "delete",
-                  "excerpt": "Delete a route",
+                  "name": "delete",
+                  "about": "Delete a route",
                   "args": [
                     {
                       "long": "route"
@@ -1518,8 +1480,8 @@
                   ]
                 },
                 {
-                  "title": "list",
-                  "excerpt": "List routes\n\nList the routes associated with a router in a particular VPC.",
+                  "name": "list",
+                  "about": "List routes\n\nList the routes associated with a router in a particular VPC.",
                   "args": [
                     {
                       "long": "limit",
@@ -1540,8 +1502,8 @@
                   ]
                 },
                 {
-                  "title": "update",
-                  "excerpt": "Update a route",
+                  "name": "update",
+                  "about": "Update a route",
                   "args": [
                     {
                       "long": "route"
@@ -1564,8 +1526,8 @@
                   ]
                 },
                 {
-                  "title": "view",
-                  "excerpt": "Fetch a route",
+                  "name": "view",
+                  "about": "Fetch a route",
                   "args": [
                     {
                       "long": "route"
@@ -1584,8 +1546,8 @@
               ]
             },
             {
-              "title": "update",
-              "excerpt": "Update a router",
+              "name": "update",
+              "about": "Update a router",
               "args": [
                 {
                   "long": "router"
@@ -1605,8 +1567,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Get a router",
+              "name": "view",
+              "about": "Get a router",
               "args": [
                 {
                   "long": "router"
@@ -1622,12 +1584,11 @@
           ]
         },
         {
-          "title": "subnet",
-          "excerpt": "",
+          "name": "subnet",
           "subcommands": [
             {
-              "title": "create",
-              "excerpt": "Create a subnet",
+              "name": "create",
+              "about": "Create a subnet",
               "args": [
                 {
                   "long": "project"
@@ -1652,8 +1613,8 @@
               ]
             },
             {
-              "title": "delete",
-              "excerpt": "Delete a subnet",
+              "name": "delete",
+              "about": "Delete a subnet",
               "args": [
                 {
                   "long": "subnet"
@@ -1667,8 +1628,8 @@
               ]
             },
             {
-              "title": "list",
-              "excerpt": "Fetch a subnet",
+              "name": "list",
+              "about": "Fetch a subnet",
               "args": [
                 {
                   "long": "limit",
@@ -1686,12 +1647,11 @@
               ]
             },
             {
-              "title": "nic",
-              "excerpt": "",
+              "name": "nic",
               "subcommands": [
                 {
-                  "title": "list",
-                  "excerpt": "List network interfaces",
+                  "name": "list",
+                  "about": "List network interfaces",
                   "args": [
                     {
                       "long": "subnet"
@@ -1714,8 +1674,8 @@
               ]
             },
             {
-              "title": "update",
-              "excerpt": "Update a subnet",
+              "name": "update",
+              "about": "Update a subnet",
               "args": [
                 {
                   "long": "subnet"
@@ -1735,8 +1695,8 @@
               ]
             },
             {
-              "title": "view",
-              "excerpt": "Fetch a subnet",
+              "name": "view",
+              "about": "Fetch a subnet",
               "args": [
                 {
                   "long": "subnet"
@@ -1752,8 +1712,8 @@
           ]
         },
         {
-          "title": "update",
-          "excerpt": "Update a VPC",
+          "name": "update",
+          "about": "Update a VPC",
           "args": [
             {
               "long": "vpc"
@@ -1773,8 +1733,8 @@
           ]
         },
         {
-          "title": "view",
-          "excerpt": "Fetch a VPC",
+          "name": "view",
+          "about": "Fetch a VPC",
           "args": [
             {
               "long": "vpc"
@@ -1787,14 +1747,14 @@
       ]
     },
     {
-      "title": "auth",
-      "excerpt": "Login, logout, and get the status of your authentication.",
-      "about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
+      "name": "auth",
+      "about": "Login, logout, and get the status of your authentication.",
+      "long_about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
       "subcommands": [
         {
-          "title": "login",
-          "excerpt": "Authenticate with an Oxide host.",
-          "about": "Authenticate with an Oxide host.\n\nAlternatively, pass in a token on standard input by using `--with-token`.\n\n    # start interactive setup\n    $ oxide auth login\n\n    # authenticate against a specific Oxide instance by reading the token\n    # from a file\n    $ oxide auth login --with-token --host oxide.internal < mytoken.txt\n\n    # authenticate with a specific Oxide instance\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide instance (not recommended)\n    $ oxide auth login --host http://oxide.internal",
+          "name": "login",
+          "about": "Authenticate with an Oxide host.",
+          "long_about": "Authenticate with an Oxide host.\n\nAlternatively, pass in a token on standard input by using `--with-token`.\n\n    # start interactive setup\n    $ oxide auth login\n\n    # authenticate against a specific Oxide instance by reading the token\n    # from a file\n    $ oxide auth login --with-token --host oxide.internal < mytoken.txt\n\n    # authenticate with a specific Oxide instance\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide instance (not recommended)\n    $ oxide auth login --host http://oxide.internal",
           "args": [
             {
               "long": "with-token",
@@ -1816,9 +1776,9 @@
           ]
         },
         {
-          "title": "logout",
-          "excerpt": "Log out of an Oxide host.",
-          "about": "Log out of an Oxide host.\n\nThis command removes the authentication configuration for a host either specified\ninteractively or via `--host`.\n\n    $ oxide auth logout\n    # => select what host to log out of via a prompt\n\n    $ oxide auth logout --host oxide.internal\n    # => log out of specified host",
+          "name": "logout",
+          "about": "Log out of an Oxide host.",
+          "long_about": "Log out of an Oxide host.\n\nThis command removes the authentication configuration for a host either specified\ninteractively or via `--host`.\n\n    $ oxide auth logout\n    # => select what host to log out of via a prompt\n\n    $ oxide auth logout --host oxide.internal\n    # => log out of specified host",
           "args": [
             {
               "short": "H",
@@ -1828,8 +1788,8 @@
           ]
         },
         {
-          "title": "status",
-          "excerpt": "Verifies and displays information about your authentication state.\nThis command validates the authentication state for each Oxide environment in the current configuration. These hosts may be from your hosts.toml file and/or\n$OXIDE_HOST environment variable.",
+          "name": "status",
+          "about": "Verifies and displays information about your authentication state.\nThis command validates the authentication state for each Oxide environment in the current configuration. These hosts may be from your hosts.toml file and/or\n$OXIDE_HOST environment variable.",
           "args": [
             {
               "short": "t",
@@ -1846,9 +1806,9 @@
       ]
     },
     {
-      "title": "api",
-      "excerpt": "Makes an authenticated HTTP request to the Oxide API and prints the response.",
-      "about": "Makes an authenticated HTTP request to the Oxide API and prints the response.\n\nThe endpoint argument should be a path of a Oxide API endpoint.\n\nThe default HTTP request method is \"GET\" normally and \"POST\" if any\nparameters were added. Override the method with `--method`.\n\nPass one or more `-f/--raw-field` values in \"key=value\" format to add\nstatic string parameters to the request payload. To add non-string or\notherwise dynamic values, see `--field` below. Note that adding request\nparameters will automatically switch the request method to POST. To send\nthe parameters as a GET query string instead, use `--method GET`.\n\nThe `-F/--field` flag has magic type conversion based on the format of the\nvalue:\n\n- literal values \"true\", \"false\", \"null\", and integer/float numbers get\n  converted to appropriate JSON types;\n- if the value starts with \"@\", the rest of the value is interpreted as a\n  filename to read the value from. Pass \"-\" to read from standard input.\n\nRaw request body may be passed from the outside via a file specified by\n`--input`. Pass \"-\" to read from standard input. In this mode, parameters\nspecified via `--field` flags are serialized into URL query parameters.\n\nIn `--paginate` mode, all pages of results will sequentially be requested\nuntil there are no more pages of results.",
+      "name": "api",
+      "about": "Makes an authenticated HTTP request to the Oxide API and prints the response.",
+      "long_about": "Makes an authenticated HTTP request to the Oxide API and prints the response.\n\nThe endpoint argument should be a path of a Oxide API endpoint.\n\nThe default HTTP request method is \"GET\" normally and \"POST\" if any\nparameters were added. Override the method with `--method`.\n\nPass one or more `-f/--raw-field` values in \"key=value\" format to add\nstatic string parameters to the request payload. To add non-string or\notherwise dynamic values, see `--field` below. Note that adding request\nparameters will automatically switch the request method to POST. To send\nthe parameters as a GET query string instead, use `--method GET`.\n\nThe `-F/--field` flag has magic type conversion based on the format of the\nvalue:\n\n- literal values \"true\", \"false\", \"null\", and integer/float numbers get\n  converted to appropriate JSON types;\n- if the value starts with \"@\", the rest of the value is interpreted as a\n  filename to read the value from. Pass \"-\" to read from standard input.\n\nRaw request body may be passed from the outside via a file specified by\n`--input`. Pass \"-\" to read from standard input. In this mode, parameters\nspecified via `--field` flags are serialized into URL query parameters.\n\nIn `--paginate` mode, all pages of results will sequentially be requested\nuntil there are no more pages of results.",
       "args": [
         {
           "short": "X",
@@ -1886,12 +1846,12 @@
       ]
     },
     {
-      "title": "docs",
-      "excerpt": "Generate CLI docs in JSON format"
+      "name": "docs",
+      "about": "Generate CLI docs in JSON format"
     },
     {
-      "title": "version",
-      "excerpt": "Prints version information about the CLI."
+      "name": "version",
+      "about": "Prints version information about the CLI."
     }
   ]
 }

--- a/cli/src/cmd_docs.rs
+++ b/cli/src/cmd_docs.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+use anyhow::Result;
+use clap::{Command, Parser};
+use serde::Serialize;
+
+/// Generate CLI docs in JSON format
+#[derive(Parser, Debug, Clone)]
+#[clap(verbatim_doc_comment)]
+#[clap(name = "docs")]
+pub struct CmdDocs;
+
+/// Arg to CLI command for the JSON doc
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct JsonArg {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    short: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    long: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    help: Option<String>,
+}
+
+/// CLI docs in JSON format
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct JsonDoc {
+    title: String,
+    excerpt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    about: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<JsonArg>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    subcommands: Vec<JsonDoc>,
+}
+
+impl CmdDocs {
+    pub async fn run(&self, app: &Command) -> Result<()> {
+        println!("Writing docs.json");
+
+        // let title = app.get_name().to_string();
+        // let filename = format!("{}.json", title);
+
+        let json = self.generate_json(app)?;
+        let pretty_json = serde_json::to_string_pretty(&json)?;
+        println!("{}", pretty_json);
+
+        Ok(())
+    }
+
+    fn generate_json(&self, cmd: &Command) -> Result<JsonDoc> {
+        let title = cmd.get_name().to_string().replace('_', " ");
+        let excerpt = cmd.get_about().unwrap_or_default().to_string();
+
+        Ok(JsonDoc {
+            title,
+            excerpt,
+            about: cmd.get_long_about().map(|s| s.to_string()),
+            args: cmd
+                .get_arguments()
+                .filter(|arg| arg.get_short().is_some() || arg.get_long().is_some())
+                .map(|arg| JsonArg {
+                    short: arg.get_short().map(|char| char.to_string()),
+                    long: arg.get_long().map(String::from),
+                    help: arg.get_help().map(|s| s.to_string()),
+                })
+                .collect(),
+            subcommands: cmd
+                .get_subcommands()
+                .filter_map(|subcmd| self.generate_json(subcmd).ok())
+                .collect(),
+        })
+    }
+}
+
+#[test]
+fn docs_success() {
+    use assert_cmd::Command;
+
+    let mut cmd = Command::cargo_bin("oxide").unwrap();
+
+    cmd.arg("docs");
+    cmd.assert().success().stdout(format!("Writing docs.json",));
+}

--- a/cli/src/cmd_docs.rs
+++ b/cli/src/cmd_docs.rs
@@ -64,28 +64,9 @@ fn generate_json(cmd: &Command) -> Result<JsonDoc> {
 
 impl CmdDocs {
     pub async fn run(&self, app: &Command) -> Result<()> {
-        println!("Writing docs.json");
-
-        // let title = app.get_name().to_string();
-        // let filename = format!("{}.json", title);
-
         let json = generate_json(app)?;
         let pretty_json = serde_json::to_string_pretty(&json)?;
         println!("{}", pretty_json);
-
         Ok(())
     }
-}
-
-#[test]
-fn docs_success() {
-    use assert_cmd::Command;
-    use predicates::prelude::predicate;
-
-    let mut cmd = Command::cargo_bin("oxide").unwrap();
-
-    cmd.arg("docs");
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("\"title\": \"oxide\""));
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@
 
 // Copyright 2023 Oxide Computer Company
 
-use std::{collections::HashMap, net::IpAddr};
+use std::{collections::BTreeMap, net::IpAddr};
 
 use clap::{Command, CommandFactory, FromArgMatches};
 
@@ -29,7 +29,7 @@ mod generated_cli;
 
 #[derive(Debug, Default)]
 struct Tree<'a> {
-    children: HashMap<&'a str, Tree<'a>>,
+    children: BTreeMap<&'a str, Tree<'a>>,
     cmd: Option<CliCommand>,
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,7 @@ mod cmd_api;
 #[allow(unused_mut)] // TODO
 #[allow(unused)] // TODO
 mod cmd_auth;
+mod cmd_docs;
 mod cmd_version;
 mod config;
 mod context;
@@ -101,16 +102,15 @@ async fn main() {
         }
     }
 
-    let mut cmd = root.cmd("oxide");
-    cmd = cmd.bin_name("oxide");
+    let cmd = root
+        .cmd("oxide")
+        .bin_name("oxide")
+        .subcommand(cmd_auth::CmdAuth::command())
+        .subcommand(cmd_api::CmdApi::command())
+        .subcommand(cmd_docs::CmdDocs::command())
+        .subcommand(cmd_version::CmdVersion::command());
 
-    // TODO Example of how to build a fully custom sub-command. Note that this
-    // could be placed under another subcommand if needed.
-    cmd = cmd.subcommand(cmd_auth::CmdAuth::command());
-    cmd = cmd.subcommand(cmd_api::CmdApi::command());
-    cmd = cmd.subcommand(cmd_version::CmdVersion::command());
-
-    let matches = cmd.get_matches();
+    let matches = cmd.clone().get_matches();
 
     // Construct the global config. We do this **after** parsing options,
     // anticipating that top-level options may impact e.g. where we look for
@@ -133,6 +133,12 @@ async fn main() {
                 .await
         }
 
+        Some(("docs", sub_matches)) => {
+            cmd_docs::CmdDocs::from_arg_matches(sub_matches)
+                .unwrap()
+                .run(&cmd)
+                .await
+        }
         Some(("version", sub_matches)) => {
             cmd_version::CmdVersion::from_arg_matches(sub_matches)
                 .unwrap()

--- a/cli/tests/test_docs.rs
+++ b/cli/tests/test_docs.rs
@@ -1,0 +1,14 @@
+use expectorate::assert_contents;
+
+#[test]
+fn test_docs_json() {
+    use assert_cmd::Command;
+
+    let output = Command::cargo_bin("oxide")
+        .unwrap()
+        .arg("docs")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_contents("./docs/cli.json", &stdout);
+}


### PR DESCRIPTION
I was hoping to put this in an xtask, but it needs the clap command itself, and I wasn't sure if it was appropriate to pull that over into the xtask crate. I'm on the fence about whether it's useful or pure noise to have it be part of the CLI itself. Nobody but us would want to do anything with this JSON.

So far I'm just printing the output instead of writing it to a file, on the assumption that @ahl and @karencfv have an opinion on how that should be done. Also, in the old CLI we had an expectorate test that made sure the docs were up to date. We're not currently using expectorate for anything in this repo.

Implementation is lifted [straight](https://github.com/oxidecomputer/cli/blob/77747d127bb63af1ca5e0a64ce76ea7e2cd65ccc/src/cmd_generate.rs#L96-L118) from the old CLI.

