### PR TITLE
Automated PRs for dependency updates

### DIFF
--- a/.github/reflector/integrate.toml
+++ b/.github/reflector/integrate.toml
@@ -1,0 +1,19 @@
+workflow = "integrate.yml"
+branch = "main"
+
+[[on]]
+repository = "oxidecomputer/omicron"
+paths = [
+  "openapi/nexus.json",
+]
+
+[[on]]
+repository = "oxidecomputer/progenitor"
+paths = [
+  "progenitor-client/**",
+  "progenitor-impl/**",
+  "progenitor-macro/**",
+  "progenitor/**",
+  "Cargo.toml",
+  "Cargo.lock"
+]

--- a/.github/reflector/integrate.toml
+++ b/.github/reflector/integrate.toml
@@ -1,5 +1,12 @@
+# Reflector configuration (oxidecompuer/reflector)
+
+# When any of the listeners configured below activate, run .github/workflows/integate.yml targeting main
+
 workflow = "integrate.yml"
 branch = "main"
+
+# Listen for pushes to the nexus.json file in oxidecomputer/omicron and multiple source paths in
+# oxidecomputer/progenitor (on each repository's respective default branch).
 
 [[on]]
 repository = "oxidecomputer/omicron"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,6 +1,9 @@
 name: Integration
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
 
 permissions:
   contents: write

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,0 +1,75 @@
+name: Integration
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-update:
+    concurrency:
+      group: integration
+      cancel-in-progress: true
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.5.0
+        with:
+          ref: main
+      - name: Install nightly rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+          default: false
+      - name: Report cargo version
+        run: cargo --version
+      - name: Report rustfmt version
+        run: cargo fmt -- --version
+
+      - name: Update schema
+        run: curl -s https://raw.githubusercontent.com/oxidecomputer/omicron/main/openapi/nexus.json --output schema.json
+
+      - name: Update progenitor
+        run: |
+          cargo update -p progenitor
+          cargo update -p progenitor-client
+
+      - name: Report changes
+        run: git status
+
+      - name: Commit changes
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update with latest schema" || echo "Nothing to commit"
+          git push origin main:integration --force
+          # Reset back to the original main
+          git reset --hard origin/main
+
+      - name: Update pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git checkout integration
+          git pull origin integration
+          mainToIntegration="$(git rev-list --count main..integration)"
+          integrationToMain="$(git rev-list --count integration..main)"
+          prUrl=$(gh search prs --head integration --base main --state open --repo oxidecomputer/oxide-sdk-and-cli --json url --jq .[].url)
+          if [ "$mainToIntegration" -eq 0 -a "$integrationToMain" -eq 0 ]
+          then
+            echo "Main is up to date with integration. No pull request needed"
+          elif [ "$mainToIntegration" -gt 0 ]
+          then
+            echo "Main behind integration ($mainToIntegration)"
+            if [ -z "$prUrl" ]
+            then
+              gh pr create -B main -H integration --title 'Integration' --body 'Integrating dependency update'
+            else
+              echo "PR already exists: $prUrl"
+            fi
+          else
+            echo "Integration is behind main ($integrationToMain). This is likely an error"
+            exit 1
+          fi

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -31,7 +31,13 @@ jobs:
         run: cargo fmt -- --version
 
       - name: Update schema
-        run: curl -s https://raw.githubusercontent.com/oxidecomputer/omicron/main/openapi/nexus.json --output schema.json
+        run: |
+          curl -s https://raw.githubusercontent.com/oxidecomputer/omicron/main/openapi/nexus.json --output schema.json
+
+          SHA=$(curl -s "https://api.github.com/repos/oxidecomputer/omicron/commits?path=openapi/nexus.json&per_page=1" | jq -r '.[].sha')
+          echo "full=${SHA}" >> $GITHUB_OUTPUT
+          echo "short=${SHA:0:8}" >> $GITHUB_OUTPUT
+        id: schema_sha
 
       - name: Update progenitor
         run: |
@@ -56,7 +62,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Update with latest dependency updates" || echo "Nothing to commit"
+          git commit -m "Rebuilt with latest dependency updates" || echo "Nothing to commit"
           git push origin main:integration --force
           # Reset back to the original main
           git reset --hard origin/main
@@ -67,10 +73,18 @@ jobs:
         run: |
           git checkout integration
           git pull origin integration
+
           mainToIntegration="$(git rev-list --count main..integration)"
           integrationToMain="$(git rev-list --count integration..main)"
+
           prUrl=$(gh search prs --head integration --base main --state open --repo $GITHUB_REPOSITORY --json url --jq .[].url)
+
+          # Sleep to help prevent GitHub cli from tripping over itself
+          sleep 2
+
           prNumber=$(gh search prs --head integration --base main --state open --repo $GITHUB_REPOSITORY --json number --jq .[].number)
+
+          sleep 2
 
           progenitorDiffUrl=""
 
@@ -92,7 +106,7 @@ jobs:
           then
             echo "Main is behind integration ($mainToIntegration)"
 
-            echo "Integration dependency update" >> body
+            echo "Integration dependency update" > body
             echo "" >> body
 
             if [ "$progenitorDiffUrl" != "" ]
@@ -102,7 +116,10 @@ jobs:
               echo "" >> body
             fi
 
-            echo "Generated code against latest nexus.json" >> body
+            schemaLabel="nexus.json \`${{ steps.schema_sha.outputs.short }}\`"
+            schemaUrl="https://github.com/oxidecomputer/omicron/blob/${{ steps.schema_sha.outputs.full }}/openapi/nexus.json"
+
+            echo "Generated code against [$schemaLabel]($schemaUrl)" >> body
 
             if [ -z "$prNumber" ]
             then

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -35,6 +35,10 @@ jobs:
           cargo update -p progenitor
           cargo update -p progenitor-client
 
+      - name: Rebuild client
+        run: |
+          cargo run -p xtask generate
+
       - name: Report changes
         run: git status
 
@@ -43,7 +47,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Update with latest schema" || echo "Nothing to commit"
+          git commit -m "Update with latest dependency updates" || echo "Nothing to commit"
           git push origin main:integration --force
           # Reset back to the original main
           git reset --hard origin/main

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -5,6 +5,9 @@ on: workflow_dispatch
 permissions:
   contents: write
   pull-requests: write
+  # This is a workaround for the GitHub cli requiring excessive permissions when updating a pull
+  # request (https://github.com/cli/cli/discussions/5307)
+  repository-projects: read
 
 jobs:
   generate-update:
@@ -32,8 +35,14 @@ jobs:
 
       - name: Update progenitor
         run: |
+          FROM=$(cargo tree -i progenitor | grep -Eo '#([0-9a-z]+)')
           cargo update -p progenitor
           cargo update -p progenitor-client
+          TO=$(cargo tree -i progenitor | grep -Eo '#([0-9a-z]+)')
+
+          echo "from=${FROM:1}" >> $GITHUB_OUTPUT
+          echo "to=${TO:1}" >> $GITHUB_OUTPUT
+        id: progenitor_versions
 
       - name: Rebuild client
         run: |
@@ -60,18 +69,47 @@ jobs:
           git pull origin integration
           mainToIntegration="$(git rev-list --count main..integration)"
           integrationToMain="$(git rev-list --count integration..main)"
-          prUrl=$(gh search prs --head integration --base main --state open --repo oxidecomputer/oxide-sdk-and-cli --json url --jq .[].url)
+          prUrl=$(gh search prs --head integration --base main --state open --repo $GITHUB_REPOSITORY --json url --jq .[].url)
+          prNumber=$(gh search prs --head integration --base main --state open --repo $GITHUB_REPOSITORY --json number --jq .[].number)
+
+          progenitorDiffUrl=""
+
+          if [ "${{ steps.progenitor_versions.outputs.from }}" != "${{ steps.progenitor_versions.outputs.to }}" ]
+          then
+            progenitorDiffUrl="https://github.com/oxidecomputer/progenitor/compare/${{ steps.progenitor_versions.outputs.from }}...${{ steps.progenitor_versions.outputs.to }}"
+          fi
+
           if [ "$mainToIntegration" -eq 0 -a "$integrationToMain" -eq 0 ]
           then
             echo "Main is up to date with integration. No pull request needed"
+
+            if [ -z "$prNumber" ]
+            then
+              echo "Closing existing PR"
+              gh pr close $prNumber
+            fi
           elif [ "$mainToIntegration" -gt 0 ]
           then
-            echo "Main behind integration ($mainToIntegration)"
-            if [ -z "$prUrl" ]
+            echo "Main is behind integration ($mainToIntegration)"
+
+            echo "Integration dependency update" >> body
+            echo "" >> body
+
+            if [ "$progenitorDiffUrl" != "" ]
             then
-              gh pr create -B main -H integration --title 'Integration' --body 'Integrating dependency update'
+              echo "Bump [progenitor](https://github.com/oxidecomputer/progenitor) from \`${{ steps.progenitor_versions.outputs.from }}\` to \`${{ steps.progenitor_versions.outputs.to }}\`" >> body
+              echo "Changes: ${progenitorDiffUrl}" >> body
+              echo "" >> body
+            fi
+
+            echo "Generated code against latest nexus.json" >> body
+
+            if [ -z "$prNumber" ]
+            then
+              gh pr create -B main -H integration --title 'Integration' --body-file body
             else
-              echo "PR already exists: $prUrl"
+              echo "PR already exists: ($prNumber) $prUrl . Updating..."
+              gh pr edit "$prNumber" --body-file body
             fi
           else
             echo "Integration is behind main ($integrationToMain). This is likely an error"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -106,11 +106,14 @@ jobs:
           then
             echo "Main is behind integration ($mainToIntegration)"
 
+            title="Bump schema.json to omicron:${{ steps.schema_sha.outputs.short }}"
+
             echo "Integration dependency update" > body
             echo "" >> body
 
             if [ "$progenitorDiffUrl" != "" ]
             then
+              title+=" and progenitor to ${{ steps.progenitor_versions.outputs.to }}"
               echo "Bump [progenitor](https://github.com/oxidecomputer/progenitor) from \`${{ steps.progenitor_versions.outputs.from }}\` to \`${{ steps.progenitor_versions.outputs.to }}\`" >> body
               echo "Changes: ${progenitorDiffUrl}" >> body
               echo "" >> body
@@ -123,10 +126,10 @@ jobs:
 
             if [ -z "$prNumber" ]
             then
-              gh pr create -B main -H integration --title 'Integration' --body-file body
+              gh pr create -B main -H integration --title "$title" --body-file body
             else
               echo "PR already exists: ($prNumber) $prUrl . Updating..."
-              gh pr edit "$prNumber" --body-file body
+              gh pr edit "$prNumber" --title "$title" --body-file body
             fi
           else
             echo "Integration is behind main ($integrationToMain). This is likely an error"


### PR DESCRIPTION
* Adds rough wiring to listen for updates to `nexus.json` and `progenitor` (on `main` for both) and generating an integration branch when needed.
  * Changes will be applied over top of the `main` branch of `oxide-sdk-and-cli` and pushed to the `integration` branch.
  * If as a result integration ends up ahead of main then a PR named "Integration" will be created (if it does not yet exist)

The PR will have a description that looks like:
```
Integration dependency update

Bump [progenitor](https://github.com/oxidecomputer/progenitor) from a4abdf60 to 3a5fe998
Changes: https://github.com/oxidecomputer/progenitor/compare/a4abdf60...3a5fe998

Generated code against [nexus.json a9680cbe](https://github.com/oxidecomputer/omicron/blob/a9680cbe49b40361559e68b26fe82207cbcde69a/openapi/nexus.json)
```