### PR TITLE
explicitly enable the "git2" feature of built

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 anyhow = "1.0.70"
 assert_cmd = "2.0.10"
 base64 = "0.21.0"
-built = "0.6.0"
+built = { version = "0.6.0", features = ["git2"] }
 chrono = { version = "0.4.24", features = ["serde"] }
 clap = { version = "4.2", features = ["derive", "string", "env"] }
 dialoguer = "0.10.3"


### PR DESCRIPTION
On current main, trying to build the CLI package on its own fails because `built` is built without the git2 feature. This wasn't caught in CI because building the entire workspace brings in progenitor's use of built, which enables git2.

```
$ cargo version
cargo 1.68.2 (6feb7c9cf 2023-03-26)

$ cargo build --release
    Finished release [optimized] target(s) in 0.16s

$ cargo build --release -p oxide
   Compiling reqwest v0.11.16
   Compiling oxide v0.1.0 (/Users/iliana/git/oxide-sdk-and-cli/cli)
error[E0425]: cannot find function `get_repo_head` in module `built::util`
 --> cli/build.rs:9:24
  |
9 |     match built::util::get_repo_head(src.as_ref()) {
  |                        ^^^^^^^^^^^^^ not found in `built::util`

For more information about this error, try `rustc --explain E0425`.
error: could not compile `oxide` due to previous error
warning: build failed, waiting for other jobs to finish...
```