### PR TITLE
Commit updated docs during integration

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -69,7 +69,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Detect specific changes that are will be committed back
+          # Detect specific changes that will be committed back
           git diff --quiet cli/docs/cli.json || docsUpdate=$?
           echo "docs=${docsUpdate}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -57,6 +57,10 @@ jobs:
         run: |
           cargo run -p xtask generate
 
+      - name: Generate docs
+        run: |
+          cargo run -p oxide docs > cli/docs/cli.json
+
       - name: Report changes
         run: git status
 
@@ -64,11 +68,17 @@ jobs:
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Detect specific changes that are will be committed back
+          git diff --quiet cli/docs/cli.json || docsUpdate=$?
+          echo "docs=${docsUpdate}" >> $GITHUB_OUTPUT
+
           git add .
           git commit -m "Rebuilt with latest dependency updates" || echo "Nothing to commit"
           git push origin main:integration --force
           # Reset back to the original main
           git reset --hard origin/main
+        id: committed
 
       - name: Update pull request
         env:
@@ -126,6 +136,13 @@ jobs:
             schemaUrl="https://github.com/oxidecomputer/omicron/blob/${{ steps.schema_sha.outputs.full }}/openapi/nexus.json"
 
             echo "Generated code against [$schemaLabel]($schemaUrl)" >> body
+            echo "" >> body
+
+            if [ ${{ steps.committed.outputs.docs }} ]
+            then
+              echo "CLI docs updated against the updated CLI" >> body
+              echo "" >> body
+            fi
 
             if [ -z "$prNumber" ]
             then


### PR DESCRIPTION
Integration commits that update the `oxide.json` file will (in most cases) fail during subsequent tests that check the contents of `docs/cli.json` against the `oxide docs` output.

This change updates the integration action to run the `oxide docs` command and commit back the `cli.json` file (if necessary).