### PR TITLE
Integration workflow fixes

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -2,8 +2,6 @@ name: Integration
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
 
 permissions:
   contents: write

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -110,7 +110,7 @@ jobs:
           then
             echo "Main is up to date with integration. No pull request needed"
 
-            if [ -z "$prNumber" ]
+            if [ "$prNumber" != "" ]
             then
               echo "Closing existing PR"
               gh pr close $prNumber


### PR DESCRIPTION
Two changes here:
* The conditional checking if there was an open PR to close was incorrect
* Removed the condition for running the workflow in response to changes on `main`. While this is behavior that is needed (to keep the integration branch up to date), running it every time (with cancellation) via an actions trigger isn't ideal. I'll have another PR (later today / tomorrow) to reintroduce this functionality via a better method.