### PR TITLE
Integration commits as app

### DIFF
--- a/.github/reflector/integrate.toml
+++ b/.github/reflector/integrate.toml
@@ -5,6 +5,10 @@
 workflow = "integrate.yml"
 branch = "main"
 
+# Request an installation token when running this workflow
+
+requires_token = true
+
 # Listen for pushes to the nexus.json file in oxidecomputer/omicron and multiple source paths in
 # oxidecomputer/progenitor (on each repository's respective default branch).
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -2,8 +2,6 @@ name: Integration
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
 
 permissions:
   contents: write

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -110,7 +110,7 @@ jobs:
           then
             echo "Main is up to date with integration. No pull request needed"
 
-            if [ -z "$prNumber" ]
+            if [ "$prNumber" != "" ]
             then
               echo "Closing existing PR"
               gh pr close $prNumber

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -2,6 +2,12 @@ name: Integration
 
 on:
   workflow_dispatch:
+    reflector_access_token:
+      description: Access token for use in authenticating as the Reflector bot
+      type: string
+    reflector_user_id:
+      description: User id of the Reflector bot
+      type: string
   push:
     branches: [main]
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.0
         with:
+          token: ${{ inputs.reflector_access_token }}
           ref: main
       - name: Install nightly rustfmt
         uses: actions-rs/toolchain@v1
@@ -66,8 +67,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "reflector[bot]"
+          git config --local user.email "${{ inputs.reflector_user_id }}+reflector[bot]@users.noreply.github.com"
 
           # Detect specific changes that will be committed back
           git diff --quiet cli/docs/cli.json || docsUpdate=$?


### PR DESCRIPTION
This PR updates the integration workflow so that checking out code, and creating new commits is performed as the Reflector bot instead of as the default GitHub Actions bot. This will allow the normal Rust build / test / style actions to run on commits made by the bot to the integration branch. Additionally this is the precursor to enabling Buildomat jobs for bot commits.

These changes are dependent on #108 that disables running the action in response to changes on main. This functionality can be reintroduced with upcoming changes to Reflector.