### PR TITLE
All docs generation step to fail

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -63,7 +63,13 @@ jobs:
         run: |
           cargo run -p xtask generate
 
+      # Doc generation is allowed to fail so that a partial PR can at least be generated. This is
+      # likely to occur when updating the oxide.json schema file and new types that are not yet
+      # handled by the CLI are introduced. The result of this should be a PR that has the updated
+      # schema and corresponding generated code that will fail due to compilation errors during
+      # test.
       - name: Generate docs
+        continue-on-error: true
         run: |
           cargo run -p oxide docs > cli/docs/cli.json
 


### PR DESCRIPTION
* During the integration of schema updates, it is likely that doc generation fails. This allows for those failures in favor of getting a PR generated that can fail during test workflows.