### PR TITLE
Integrate updates

### DIFF
--- a/.github/buildomat/config.toml
+++ b/.github/buildomat/config.toml
@@ -16,5 +16,6 @@ org_only = true
 #
 allow_users = [
 	"dependabot[bot]",
+	"oxide-reflector-bot[bot]",
 	"renovate[bot]",
 ]

--- a/.github/reflector/integrate.toml
+++ b/.github/reflector/integrate.toml
@@ -12,11 +12,15 @@ requires_token = true
 # Listen for pushes to the nexus.json file in oxidecomputer/omicron and multiple source paths in
 # oxidecomputer/progenitor (on each repository's respective default branch).
 
+# Debounce values are used to batch together multiple pushes that occur in a relatively short
+# timeframe
+
 [[on]]
 repository = "oxidecomputer/omicron"
 paths = [
   "openapi/nexus.json",
 ]
+debounce = 60
 
 [[on]]
 repository = "oxidecomputer/progenitor"
@@ -28,11 +32,10 @@ paths = [
   "Cargo.toml",
   "Cargo.lock"
 ]
+debounce = 300
 
-# Listen for changes on the repo's own main branch. This ensures that the integration  branch is
-# always built on top of the latest code. Actions triggered by this location are run with a
-# 5 minute delay. This allows for multiple pushes to the main branch to be batched together into
-# a single run.
+# Listen for changes on the repo's own main branch. This ensures that the integration branch is
+# always built on top of the latest code.
 [[on]]
 repository = "oxidecomputer/oxide.rs"
 paths = [

--- a/.github/reflector/integrate.toml
+++ b/.github/reflector/integrate.toml
@@ -28,3 +28,14 @@ paths = [
   "Cargo.toml",
   "Cargo.lock"
 ]
+
+# Listen for changes on the repo's own main branch. This ensures that the integration  branch is
+# always built on top of the latest code. Actions triggered by this location are run with a
+# 5 minute delay. This allows for multiple pushes to the main branch to be batched together into
+# a single run.
+[[on]]
+repository = "oxidecomputer/oxide.rs"
+paths = [
+  "**",
+]
+debounce = 300

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -77,8 +77,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --local user.name "reflector[bot]"
-          git config --local user.email "${{ inputs.reflector_user_id }}+reflector[bot]@users.noreply.github.com"
+          git config --local user.name "oxide-reflector-bot[bot]"
+          git config --local user.email "${{ inputs.reflector_user_id }}+oxide-reflector-bot[bot]@users.noreply.github.com"
 
           # Detect specific changes that will be committed back
           git diff --quiet cli/docs/cli.json || docsUpdate=$?


### PR DESCRIPTION
* Add Reflector as a pre-authorized user for executing Buildomat jobs. This may need additional support in Reflector to fully enable.
* Re-enable listening to changes on main to trigger updates to the integration branch. This ensures that tests on the integration branch are getting run against the combination of the latest of all three sources (oxide.rs, progenitor, omicron).
* Adds debounce delays to the source locations. These are used to throttle the rate at which integration actions are run. While duplicate actions will be cancelled, this results in a spam of cancellation emails.