### PR TITLE
Add package version to `cli.json`

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1,2028 +1,2031 @@
 {
-  "name": "oxide",
-  "subcommands": [
-    {
-      "name": "api",
-      "about": "Makes an authenticated HTTP request to the Oxide API and prints the response.",
-      "long_about": "Makes an authenticated HTTP request to the Oxide API and prints the response.\n\nThe endpoint argument should be a path of a Oxide API endpoint.\n\nThe default HTTP request method is \"GET\" normally and \"POST\" if any\nparameters were added. Override the method with `--method`.\n\nPass one or more `-f/--raw-field` values in \"key=value\" format to add\nstatic string parameters to the request payload. To add non-string or\notherwise dynamic values, see `--field` below. Note that adding request\nparameters will automatically switch the request method to POST. To send\nthe parameters as a GET query string instead, use `--method GET`.\n\nThe `-F/--field` flag has magic type conversion based on the format of the\nvalue:\n\n- literal values \"true\", \"false\", \"null\", and integer/float numbers get\n  converted to appropriate JSON types;\n- if the value starts with \"@\", the rest of the value is interpreted as a\n  filename to read the value from. Pass \"-\" to read from standard input.\n\nRaw request body may be passed from the outside via a file specified by\n`--input`. Pass \"-\" to read from standard input. In this mode, parameters\nspecified via `--field` flags are serialized into URL query parameters.\n\nIn `--paginate` mode, all pages of results will sequentially be requested\nuntil there are no more pages of results.",
-      "args": [
-        {
-          "long": "field",
-          "short": "F",
-          "help": "Add a typed parameter in key=value format"
-        },
-        {
-          "long": "header",
-          "short": "H",
-          "help": "Add a HTTP request header in `key:value` format"
-        },
-        {
-          "long": "include",
-          "short": "i",
-          "help": "Include HTTP response headers in the output"
-        },
-        {
-          "long": "input",
-          "help": "The file to use as body for the HTTP request (use \"-\" to read from standard input)"
-        },
-        {
-          "long": "method",
-          "short": "X",
-          "help": "The HTTP method for the request"
-        },
-        {
-          "long": "paginate",
-          "help": "Make additional HTTP requests to fetch all pages of results"
-        },
-        {
-          "long": "raw-field",
-          "short": "f",
-          "help": "Add a string parameter in key=value format"
-        }
-      ]
-    },
-    {
-      "name": "auth",
-      "about": "Login, logout, and get the status of your authentication.",
-      "long_about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
-      "subcommands": [
-        {
-          "name": "login",
-          "about": "Authenticate with an Oxide host.",
-          "long_about": "Authenticate with an Oxide host.\n\nAlternatively, pass in a token on standard input by using `--with-token`.\n\n    # start interactive setup\n    $ oxide auth login\n\n    # authenticate against a specific Oxide instance by reading the token\n    # from a file\n    $ oxide auth login --with-token --host oxide.internal < mytoken.txt\n\n    # authenticate with a specific Oxide instance\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide instance (not recommended)\n    $ oxide auth login --host http://oxide.internal",
-          "args": [
-            {
-              "long": "browser",
-              "help": "Override the default browser when opening the authentication URL"
-            },
-            {
-              "long": "host",
-              "short": "H",
-              "help": "The host of the Oxide instance to authenticate with. This assumes http; specify an `http://` prefix if needed"
-            },
-            {
-              "long": "no-browser",
-              "help": "Print the authentication URL rather than opening a browser window"
-            },
-            {
-              "long": "with-token",
-              "help": "Read token from standard input"
-            }
-          ]
-        },
-        {
-          "name": "logout",
-          "about": "Removes saved authentication information.",
-          "long_about": "Removes saved authentication information.\n\nThis command does not invalidate any tokens from the hosts.",
-          "args": [
-            {
-              "long": "all",
-              "short": "a",
-              "help": "If set, all known hosts and authentication information will be deleted"
-            },
-            {
-              "long": "force",
-              "short": "f",
-              "help": "Skip confirmation prompt"
-            },
-            {
-              "long": "host",
-              "short": "H",
-              "help": "Remove authentication information for a single host"
-            }
-          ]
-        },
-        {
-          "name": "status",
-          "about": "Verifies and displays information about your authentication state.",
-          "long_about": "Verifies and displays information about your authentication state.\n\nThis command validates the authentication state for each Oxide environment\nin the current configuration. These hosts may be from your hosts.toml file\nand/or $OXIDE_HOST environment variable.",
-          "args": [
-            {
-              "long": "host",
-              "short": "H",
-              "help": "Specific hostname to validate"
-            },
-            {
-              "long": "show-token",
-              "short": "t",
-              "help": "Display the auth token"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "certificate",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "service",
-              "help": "The service using this certificate"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
-          "args": [
-            {
-              "long": "certificate"
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a certificate\n\nReturns the details of a specific certificate",
-          "args": [
-            {
-              "long": "certificate"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "current-user",
-      "subcommands": [
-        {
-          "name": "groups",
-          "about": "Fetch the silo groups the current user belongs to",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "ssh-key",
-          "subcommands": [
-            {
-              "name": "create",
-              "about": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "public-key",
-                  "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
-                }
-              ]
-            },
-            {
-              "name": "delete",
-              "about": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
-              "args": [
-                {
-                  "long": "ssh-key",
-                  "help": "Name or ID of the SSH key"
-                }
-              ]
-            },
-            {
-              "name": "list",
-              "about": "List SSH public keys\n\nLists SSH public keys for the currently authenticated user.",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "sort-by"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
-              "args": [
-                {
-                  "long": "ssh-key",
-                  "help": "Name or ID of the SSH key"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch the user associated with the current session"
-        }
-      ]
-    },
-    {
-      "name": "disk",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create a disk",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "size",
-              "help": "total size of the Disk in bytes"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete a disk",
-          "args": [
-            {
-              "long": "disk",
-              "help": "Name or ID of the disk"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "import"
-        },
-        {
-          "name": "list",
-          "about": "List disks",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "metrics",
-          "subcommands": [
-            {
-              "name": "list",
-              "about": "Fetch disk metrics",
-              "args": [
-                {
-                  "long": "disk"
-                },
-                {
-                  "long": "end-time",
-                  "help": "An exclusive end time of metrics."
-                },
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "metric"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project"
-                },
-                {
-                  "long": "start-time",
-                  "help": "An inclusive start time of metrics."
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a disk",
-          "args": [
-            {
-              "long": "disk",
-              "help": "Name or ID of the disk"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "docs",
-      "about": "Generate CLI docs in JSON format"
-    },
-    {
-      "name": "group",
-      "subcommands": [
-        {
-          "name": "list",
-          "about": "List groups",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "image",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create an image\n\nCreate a new image in a project.",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "os",
-              "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "version",
-              "help": "The version of the operating system (e.g. 18.04, 20.04, etc.)"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
-          "args": [
-            {
-              "long": "image",
-              "help": "Name or ID of the image"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
-          "args": [
-            {
-              "long": "include-silo-images",
-              "help": "Flag used to indicate if silo scoped images should be included when listing project images. Only valid when `project` is provided."
-            },
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "promote",
-          "about": "Promote a project image to be visible to all projects in the silo",
-          "args": [
-            {
-              "long": "image",
-              "help": "Name or ID of the image"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch an image\n\nFetch the details for a specific image in a project.",
-          "args": [
-            {
-              "long": "image",
-              "help": "Name or ID of the image"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "instance",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create an instance",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "hostname"
-            },
-            {
-              "long": "memory"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "ncpus"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "start",
-              "help": "Should this instance be started upon creation; true by default."
-            },
-            {
-              "long": "user-data",
-              "help": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data."
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete an instance",
-          "args": [
-            {
-              "long": "instance",
-              "help": "Name or ID of the instance"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "disk",
-          "subcommands": [
-            {
-              "name": "attach",
-              "about": "Attach a disk to an instance",
-              "args": [
-                {
-                  "long": "disk",
-                  "help": "Name or ID of the disk"
-                },
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project"
-                }
-              ]
-            },
-            {
-              "name": "detach",
-              "about": "Detach a disk from an instance",
-              "args": [
-                {
-                  "long": "disk",
-                  "help": "Name or ID of the disk"
-                },
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project"
-                }
-              ]
-            },
-            {
-              "name": "list",
-              "about": "List an instance's disks",
-              "args": [
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project"
-                },
-                {
-                  "long": "sort-by"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "external-ip",
-          "subcommands": [
-            {
-              "name": "list",
-              "about": "List external IP addresses",
-              "args": [
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List instances",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "nic",
-          "subcommands": [
-            {
-              "name": "create",
-              "about": "Create a network interface",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "ip",
-                  "help": "The IP address for the interface. One will be auto-assigned if not provided."
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                },
-                {
-                  "long": "subnet-name",
-                  "help": "The VPC Subnet in which to create the interface."
-                },
-                {
-                  "long": "vpc-name",
-                  "help": "The VPC in which to create the interface."
-                }
-              ]
-            },
-            {
-              "name": "delete",
-              "about": "Delete a network interface\n\nNote that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
-              "args": [
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "interface",
-                  "help": "Name or ID of the network interface"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                }
-              ]
-            },
-            {
-              "name": "list",
-              "about": "List network interfaces",
-              "args": [
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                },
-                {
-                  "long": "sort-by"
-                }
-              ]
-            },
-            {
-              "name": "update",
-              "about": "Update a network interface",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "interface",
-                  "help": "Name or ID of the network interface"
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "primary",
-                  "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "Fetch a network interface",
-              "args": [
-                {
-                  "long": "instance",
-                  "help": "Name or ID of the instance"
-                },
-                {
-                  "long": "interface",
-                  "help": "Name or ID of the network interface"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "reboot",
-          "about": "Reboot an instance",
-          "args": [
-            {
-              "long": "instance",
-              "help": "Name or ID of the instance"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "start",
-          "about": "Boot an instance",
-          "args": [
-            {
-              "long": "instance",
-              "help": "Name or ID of the instance"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "stop",
-          "about": "Stop an instance",
-          "args": [
-            {
-              "long": "instance",
-              "help": "Name or ID of the instance"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch an instance",
-          "args": [
-            {
-              "long": "instance",
-              "help": "Name or ID of the instance"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "ip-pool",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create an IP pool",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete an IP Pool",
-          "args": [
-            {
-              "long": "pool",
-              "help": "Name or ID of the IP pool"
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List IP pools",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "range",
-          "subcommands": [
-            {
-              "name": "add",
-              "about": "Add a range to an IP pool",
-              "args": [
-                {
-                  "long": "first"
-                },
-                {
-                  "long": "last"
-                },
-                {
-                  "long": "pool",
-                  "help": "Name or ID of the IP pool"
-                }
-              ]
-            },
-            {
-              "name": "list",
-              "about": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "pool",
-                  "help": "Name or ID of the IP pool"
-                }
-              ]
-            },
-            {
-              "name": "remove",
-              "about": "Remove a range from an IP pool",
-              "args": [
-                {
-                  "long": "pool",
-                  "help": "Name or ID of the IP pool"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "service",
-          "subcommands": [
-            {
-              "name": "range",
-              "subcommands": [
-                {
-                  "name": "add",
-                  "about": "Add a range to an IP pool used for Oxide services."
-                },
-                {
-                  "name": "list",
-                  "about": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
-                  "args": [
-                    {
-                      "long": "limit",
-                      "help": "Maximum number of items returned by a single call"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "remove",
-              "about": "Remove a range from an IP pool used for Oxide services."
-            },
-            {
-              "name": "view",
-              "about": "Fetch the IP pool used for Oxide services."
-            }
-          ]
-        },
-        {
-          "name": "update",
-          "about": "Update an IP Pool",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "pool",
-              "help": "Name or ID of the IP pool"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch an IP pool",
-          "args": [
-            {
-              "long": "pool",
-              "help": "Name or ID of the IP pool"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "physical-disk",
-      "subcommands": [
-        {
-          "name": "list",
-          "about": "List physical disks",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "policy",
-      "subcommands": [
-        {
-          "name": "update",
-          "about": "Update the current silo's IAM policy"
-        },
-        {
-          "name": "view",
-          "about": "Fetch the current silo's IAM policy"
-        }
-      ]
-    },
-    {
-      "name": "project",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create a project",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete a project",
-          "args": [
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List projects",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "policy",
-          "subcommands": [
-            {
-              "name": "update",
-              "about": "Update a project's IAM policy",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "Fetch a project's IAM policy",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "update",
-          "about": "Update a project",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a project",
-          "args": [
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "rack",
-      "subcommands": [
-        {
-          "name": "list",
-          "about": "List racks",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a rack",
-          "args": [
-            {
-              "long": "rack-id",
-              "help": "The rack's unique ID."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "saga",
-      "subcommands": [
-        {
-          "name": "list",
-          "about": "List sagas",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a saga",
-          "args": [
-            {
-              "long": "saga-id"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "silo",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create a silo",
-          "args": [
-            {
-              "long": "admin-group-name",
-              "help": "If set, this group will be created during Silo creation and granted the \"Silo Admin\" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.\n\nNote that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information."
-            },
-            {
-              "long": "description"
-            },
-            {
-              "long": "discoverable"
-            },
-            {
-              "long": "identity-mode"
-            },
-            {
-              "long": "name"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete a silo\n\nDelete a silo by name.",
-          "args": [
-            {
-              "long": "silo",
-              "help": "Name or ID of the silo"
-            }
-          ]
-        },
-        {
-          "name": "idp",
-          "subcommands": [
-            {
-              "name": "list",
-              "about": "List a silo's IDPs_name",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "silo",
-                  "help": "Name or ID of the silo"
-                },
-                {
-                  "long": "sort-by"
-                }
-              ]
-            },
-            {
-              "name": "local",
-              "subcommands": [
-                {
-                  "name": "user",
-                  "subcommands": [
-                    {
-                      "name": "create",
-                      "about": "Create a user\n\nUsers can only be created in Silos with `provision_type` == `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user first logs in using an external Identity Provider.",
-                      "args": [
-                        {
-                          "long": "external-id",
-                          "help": "username used to log in"
-                        },
-                        {
-                          "long": "silo",
-                          "help": "Name or ID of the silo"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "delete",
-                      "about": "Delete a user",
-                      "args": [
-                        {
-                          "long": "silo",
-                          "help": "Name or ID of the silo"
-                        },
-                        {
-                          "long": "user-id",
-                          "help": "The user's internal id"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "set-password",
-                      "about": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
-                      "args": [
-                        {
-                          "long": "silo",
-                          "help": "Name or ID of the silo"
-                        },
-                        {
-                          "long": "user-id",
-                          "help": "The user's internal id"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "saml",
-              "subcommands": [
-                {
-                  "name": "create",
-                  "about": "Create a SAML IDP",
-                  "args": [
-                    {
-                      "long": "acs-url",
-                      "help": "service provider endpoint where the response will be sent"
-                    },
-                    {
-                      "long": "description"
-                    },
-                    {
-                      "long": "group-attribute-name",
-                      "help": "If set, SAML attributes with this name will be considered to denote a user's group membership, where the attribute value(s) should be a comma-separated list of group names."
-                    },
-                    {
-                      "long": "idp-entity-id",
-                      "help": "idp's entity id"
-                    },
-                    {
-                      "long": "name"
-                    },
-                    {
-                      "long": "silo",
-                      "help": "Name or ID of the silo"
-                    },
-                    {
-                      "long": "slo-url",
-                      "help": "service provider endpoint where the idp should send log out requests"
-                    },
-                    {
-                      "long": "sp-client-id",
-                      "help": "sp's client id"
-                    },
-                    {
-                      "long": "technical-contact-email",
-                      "help": "customer's technical contact for saml configuration"
-                    }
-                  ]
-                },
-                {
-                  "name": "view",
-                  "about": "Fetch a SAML IDP",
-                  "args": [
-                    {
-                      "long": "provider",
-                      "help": "Name or ID of the SAML identity provider"
-                    },
-                    {
-                      "long": "silo",
-                      "help": "Name or ID of the silo"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List silos\n\nLists silos that are discoverable based on the current permissions.",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "policy",
-          "subcommands": [
-            {
-              "name": "update",
-              "about": "Update a silo's IAM policy",
-              "args": [
-                {
-                  "long": "silo",
-                  "help": "Name or ID of the silo"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "Fetch a silo's IAM policy",
-              "args": [
-                {
-                  "long": "silo",
-                  "help": "Name or ID of the silo"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "user",
-          "subcommands": [
-            {
-              "name": "list",
-              "about": "List users in a silo",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "silo",
-                  "help": "Name or ID of the silo"
-                },
-                {
-                  "long": "sort-by"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "Fetch a user",
-              "args": [
-                {
-                  "long": "silo",
-                  "help": "Name or ID of the silo"
-                },
-                {
-                  "long": "user-id",
-                  "help": "The user's internal id"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a silo\n\nFetch a silo by name.",
-          "args": [
-            {
-              "long": "silo",
-              "help": "Name or ID of the silo"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "sled",
-      "subcommands": [
-        {
-          "name": "disk-led",
-          "about": "List physical disks attached to sleds",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sled-id",
-              "help": "The sled's unique ID."
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List sleds",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a sled",
-          "args": [
-            {
-              "long": "sled-id",
-              "help": "The sled's unique ID."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "snapshot",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "disk",
-              "help": "The name of the disk to be snapshotted"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete a snapshot",
-          "args": [
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "snapshot",
-              "help": "Name or ID of the snapshot"
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List snapshots",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a snapshot",
-          "args": [
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "snapshot",
-              "help": "Name or ID of the snapshot"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "system",
-      "subcommands": [
-        {
-          "name": "policy",
-          "subcommands": [
-            {
-              "name": "update",
-              "about": "Update the top-level IAM policy"
-            },
-            {
-              "name": "view",
-              "about": "Fetch the top-level IAM policy"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "user",
-      "subcommands": [
-        {
-          "name": "list",
-          "about": "List users",
-          "args": [
-            {
-              "long": "group"
-            },
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "version",
-      "about": "Prints version information about the CLI."
-    },
-    {
-      "name": "vpc",
-      "subcommands": [
-        {
-          "name": "create",
-          "about": "Create a VPC",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "dns-name"
-            },
-            {
-              "long": "ipv6-prefix",
-              "help": "The IPv6 prefix for this VPC.\n\nAll IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix."
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            }
-          ]
-        },
-        {
-          "name": "delete",
-          "about": "Delete a VPC",
-          "args": [
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "vpc",
-              "help": "Name or ID of the VPC"
-            }
-          ]
-        },
-        {
-          "name": "firewall-rules",
-          "subcommands": [
-            {
-              "name": "update",
-              "about": "Replace firewall rules",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "List firewall rules",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "about": "List VPCs",
-          "args": [
-            {
-              "long": "limit",
-              "help": "Maximum number of items returned by a single call"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "sort-by"
-            }
-          ]
-        },
-        {
-          "name": "router",
-          "subcommands": [
-            {
-              "name": "create",
-              "about": "Create a VPC router",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "delete",
-              "about": "Delete a router",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "router",
-                  "help": "Name or ID of the router"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "list",
-              "about": "List routers",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "sort-by"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "route",
-              "subcommands": [
-                {
-                  "name": "create",
-                  "about": "Create a router",
-                  "args": [
-                    {
-                      "long": "description"
-                    },
-                    {
-                      "long": "name"
-                    },
-                    {
-                      "long": "project",
-                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                    },
-                    {
-                      "long": "router",
-                      "help": "Name or ID of the router"
-                    },
-                    {
-                      "long": "vpc",
-                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                    }
-                  ]
-                },
-                {
-                  "name": "delete",
-                  "about": "Delete a route",
-                  "args": [
-                    {
-                      "long": "project",
-                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                    },
-                    {
-                      "long": "route",
-                      "help": "Name or ID of the route"
-                    },
-                    {
-                      "long": "router",
-                      "help": "Name or ID of the router"
-                    },
-                    {
-                      "long": "vpc",
-                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                    }
-                  ]
-                },
-                {
-                  "name": "list",
-                  "about": "List routes\n\nList the routes associated with a router in a particular VPC.",
-                  "args": [
-                    {
-                      "long": "limit",
-                      "help": "Maximum number of items returned by a single call"
-                    },
-                    {
-                      "long": "project",
-                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                    },
-                    {
-                      "long": "router",
-                      "help": "Name or ID of the router"
-                    },
-                    {
-                      "long": "sort-by"
-                    },
-                    {
-                      "long": "vpc",
-                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                    }
-                  ]
-                },
-                {
-                  "name": "update",
-                  "about": "Update a route",
-                  "args": [
-                    {
-                      "long": "description"
-                    },
-                    {
-                      "long": "name"
-                    },
-                    {
-                      "long": "project",
-                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                    },
-                    {
-                      "long": "route",
-                      "help": "Name or ID of the route"
-                    },
-                    {
-                      "long": "router",
-                      "help": "Name or ID of the router"
-                    },
-                    {
-                      "long": "vpc",
-                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                    }
-                  ]
-                },
-                {
-                  "name": "view",
-                  "about": "Fetch a route",
-                  "args": [
-                    {
-                      "long": "project",
-                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                    },
-                    {
-                      "long": "route",
-                      "help": "Name or ID of the route"
-                    },
-                    {
-                      "long": "router",
-                      "help": "Name or ID of the router"
-                    },
-                    {
-                      "long": "vpc",
-                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "update",
-              "about": "Update a router",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "router",
-                  "help": "Name or ID of the router"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "Get a router",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "router",
-                  "help": "Name or ID of the router"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "subnet",
-          "subcommands": [
-            {
-              "name": "create",
-              "about": "Create a subnet",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "ipv4-block",
-                  "help": "The IPv4 address range for this subnet.\n\nIt must be allocated from an RFC 1918 private address range, and must not overlap with any other existing subnet in the VPC."
-                },
-                {
-                  "long": "ipv6-block",
-                  "help": "The IPv6 address range for this subnet.\n\nIt must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC."
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "delete",
-              "about": "Delete a subnet",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "subnet",
-                  "help": "Name or ID of the subnet"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "list",
-              "about": "Fetch a subnet",
-              "args": [
-                {
-                  "long": "limit",
-                  "help": "Maximum number of items returned by a single call"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "sort-by"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "nic",
-              "subcommands": [
-                {
-                  "name": "list",
-                  "about": "List network interfaces",
-                  "args": [
-                    {
-                      "long": "limit",
-                      "help": "Maximum number of items returned by a single call"
-                    },
-                    {
-                      "long": "project",
-                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                    },
-                    {
-                      "long": "sort-by"
-                    },
-                    {
-                      "long": "subnet",
-                      "help": "Name or ID of the subnet"
-                    },
-                    {
-                      "long": "vpc",
-                      "help": "Name or ID of the VPC"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "update",
-              "about": "Update a subnet",
-              "args": [
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "name"
-                },
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "subnet",
-                  "help": "Name or ID of the subnet"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            },
-            {
-              "name": "view",
-              "about": "Fetch a subnet",
-              "args": [
-                {
-                  "long": "project",
-                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                },
-                {
-                  "long": "subnet",
-                  "help": "Name or ID of the subnet"
-                },
-                {
-                  "long": "vpc",
-                  "help": "Name or ID of the VPC"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "update",
-          "about": "Update a VPC",
-          "args": [
-            {
-              "long": "description"
-            },
-            {
-              "long": "dns-name"
-            },
-            {
-              "long": "name"
-            },
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "vpc",
-              "help": "Name or ID of the VPC"
-            }
-          ]
-        },
-        {
-          "name": "view",
-          "about": "Fetch a VPC",
-          "args": [
-            {
-              "long": "project",
-              "help": "Name or ID of the project"
-            },
-            {
-              "long": "vpc",
-              "help": "Name or ID of the VPC"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "version": "0.1.0",
+  "commands": {
+    "name": "oxide",
+    "subcommands": [
+      {
+        "name": "api",
+        "about": "Makes an authenticated HTTP request to the Oxide API and prints the response.",
+        "long_about": "Makes an authenticated HTTP request to the Oxide API and prints the response.\n\nThe endpoint argument should be a path of a Oxide API endpoint.\n\nThe default HTTP request method is \"GET\" normally and \"POST\" if any\nparameters were added. Override the method with `--method`.\n\nPass one or more `-f/--raw-field` values in \"key=value\" format to add\nstatic string parameters to the request payload. To add non-string or\notherwise dynamic values, see `--field` below. Note that adding request\nparameters will automatically switch the request method to POST. To send\nthe parameters as a GET query string instead, use `--method GET`.\n\nThe `-F/--field` flag has magic type conversion based on the format of the\nvalue:\n\n- literal values \"true\", \"false\", \"null\", and integer/float numbers get\n  converted to appropriate JSON types;\n- if the value starts with \"@\", the rest of the value is interpreted as a\n  filename to read the value from. Pass \"-\" to read from standard input.\n\nRaw request body may be passed from the outside via a file specified by\n`--input`. Pass \"-\" to read from standard input. In this mode, parameters\nspecified via `--field` flags are serialized into URL query parameters.\n\nIn `--paginate` mode, all pages of results will sequentially be requested\nuntil there are no more pages of results.",
+        "args": [
+          {
+            "long": "field",
+            "short": "F",
+            "help": "Add a typed parameter in key=value format"
+          },
+          {
+            "long": "header",
+            "short": "H",
+            "help": "Add a HTTP request header in `key:value` format"
+          },
+          {
+            "long": "include",
+            "short": "i",
+            "help": "Include HTTP response headers in the output"
+          },
+          {
+            "long": "input",
+            "help": "The file to use as body for the HTTP request (use \"-\" to read from standard input)"
+          },
+          {
+            "long": "method",
+            "short": "X",
+            "help": "The HTTP method for the request"
+          },
+          {
+            "long": "paginate",
+            "help": "Make additional HTTP requests to fetch all pages of results"
+          },
+          {
+            "long": "raw-field",
+            "short": "f",
+            "help": "Add a string parameter in key=value format"
+          }
+        ]
+      },
+      {
+        "name": "auth",
+        "about": "Login, logout, and get the status of your authentication.",
+        "long_about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
+        "subcommands": [
+          {
+            "name": "login",
+            "about": "Authenticate with an Oxide host.",
+            "long_about": "Authenticate with an Oxide host.\n\nAlternatively, pass in a token on standard input by using `--with-token`.\n\n    # start interactive setup\n    $ oxide auth login\n\n    # authenticate against a specific Oxide instance by reading the token\n    # from a file\n    $ oxide auth login --with-token --host oxide.internal < mytoken.txt\n\n    # authenticate with a specific Oxide instance\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide instance (not recommended)\n    $ oxide auth login --host http://oxide.internal",
+            "args": [
+              {
+                "long": "browser",
+                "help": "Override the default browser when opening the authentication URL"
+              },
+              {
+                "long": "host",
+                "short": "H",
+                "help": "The host of the Oxide instance to authenticate with. This assumes http; specify an `http://` prefix if needed"
+              },
+              {
+                "long": "no-browser",
+                "help": "Print the authentication URL rather than opening a browser window"
+              },
+              {
+                "long": "with-token",
+                "help": "Read token from standard input"
+              }
+            ]
+          },
+          {
+            "name": "logout",
+            "about": "Removes saved authentication information.",
+            "long_about": "Removes saved authentication information.\n\nThis command does not invalidate any tokens from the hosts.",
+            "args": [
+              {
+                "long": "all",
+                "short": "a",
+                "help": "If set, all known hosts and authentication information will be deleted"
+              },
+              {
+                "long": "force",
+                "short": "f",
+                "help": "Skip confirmation prompt"
+              },
+              {
+                "long": "host",
+                "short": "H",
+                "help": "Remove authentication information for a single host"
+              }
+            ]
+          },
+          {
+            "name": "status",
+            "about": "Verifies and displays information about your authentication state.",
+            "long_about": "Verifies and displays information about your authentication state.\n\nThis command validates the authentication state for each Oxide environment\nin the current configuration. These hosts may be from your hosts.toml file\nand/or $OXIDE_HOST environment variable.",
+            "args": [
+              {
+                "long": "host",
+                "short": "H",
+                "help": "Specific hostname to validate"
+              },
+              {
+                "long": "show-token",
+                "short": "t",
+                "help": "Display the auth token"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "certificate",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "service",
+                "help": "The service using this certificate"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
+            "args": [
+              {
+                "long": "certificate"
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a certificate\n\nReturns the details of a specific certificate",
+            "args": [
+              {
+                "long": "certificate"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "current-user",
+        "subcommands": [
+          {
+            "name": "groups",
+            "about": "Fetch the silo groups the current user belongs to",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "ssh-key",
+            "subcommands": [
+              {
+                "name": "create",
+                "about": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
+                "args": [
+                  {
+                    "long": "description"
+                  },
+                  {
+                    "long": "name"
+                  },
+                  {
+                    "long": "public-key",
+                    "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
+                  }
+                ]
+              },
+              {
+                "name": "delete",
+                "about": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
+                "args": [
+                  {
+                    "long": "ssh-key",
+                    "help": "Name or ID of the SSH key"
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "about": "List SSH public keys\n\nLists SSH public keys for the currently authenticated user.",
+                "args": [
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "sort-by"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
+                "args": [
+                  {
+                    "long": "ssh-key",
+                    "help": "Name or ID of the SSH key"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch the user associated with the current session"
+          }
+        ]
+      },
+      {
+        "name": "disk",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create a disk",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "size",
+                "help": "total size of the Disk in bytes"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete a disk",
+            "args": [
+              {
+                "long": "disk",
+                "help": "Name or ID of the disk"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "import"
+          },
+          {
+            "name": "list",
+            "about": "List disks",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "metrics",
+            "subcommands": [
+              {
+                "name": "list",
+                "about": "Fetch disk metrics",
+                "args": [
+                  {
+                    "long": "disk"
+                  },
+                  {
+                    "long": "end-time",
+                    "help": "An exclusive end time of metrics."
+                  },
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "metric"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project"
+                  },
+                  {
+                    "long": "start-time",
+                    "help": "An inclusive start time of metrics."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a disk",
+            "args": [
+              {
+                "long": "disk",
+                "help": "Name or ID of the disk"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "docs",
+        "about": "Generate CLI docs in JSON format"
+      },
+      {
+        "name": "group",
+        "subcommands": [
+          {
+            "name": "list",
+            "about": "List groups",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create an image\n\nCreate a new image in a project.",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "os",
+                "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "version",
+                "help": "The version of the operating system (e.g. 18.04, 20.04, etc.)"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
+            "args": [
+              {
+                "long": "image",
+                "help": "Name or ID of the image"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
+            "args": [
+              {
+                "long": "include-silo-images",
+                "help": "Flag used to indicate if silo scoped images should be included when listing project images. Only valid when `project` is provided."
+              },
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "promote",
+            "about": "Promote a project image to be visible to all projects in the silo",
+            "args": [
+              {
+                "long": "image",
+                "help": "Name or ID of the image"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch an image\n\nFetch the details for a specific image in a project.",
+            "args": [
+              {
+                "long": "image",
+                "help": "Name or ID of the image"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "instance",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create an instance",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "hostname"
+              },
+              {
+                "long": "memory"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "ncpus"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "start",
+                "help": "Should this instance be started upon creation; true by default."
+              },
+              {
+                "long": "user-data",
+                "help": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data."
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete an instance",
+            "args": [
+              {
+                "long": "instance",
+                "help": "Name or ID of the instance"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "disk",
+            "subcommands": [
+              {
+                "name": "attach",
+                "about": "Attach a disk to an instance",
+                "args": [
+                  {
+                    "long": "disk",
+                    "help": "Name or ID of the disk"
+                  },
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project"
+                  }
+                ]
+              },
+              {
+                "name": "detach",
+                "about": "Detach a disk from an instance",
+                "args": [
+                  {
+                    "long": "disk",
+                    "help": "Name or ID of the disk"
+                  },
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project"
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "about": "List an instance's disks",
+                "args": [
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project"
+                  },
+                  {
+                    "long": "sort-by"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "external-ip",
+            "subcommands": [
+              {
+                "name": "list",
+                "about": "List external IP addresses",
+                "args": [
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List instances",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "nic",
+            "subcommands": [
+              {
+                "name": "create",
+                "about": "Create a network interface",
+                "args": [
+                  {
+                    "long": "description"
+                  },
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "ip",
+                    "help": "The IP address for the interface. One will be auto-assigned if not provided."
+                  },
+                  {
+                    "long": "name"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                  },
+                  {
+                    "long": "subnet-name",
+                    "help": "The VPC Subnet in which to create the interface."
+                  },
+                  {
+                    "long": "vpc-name",
+                    "help": "The VPC in which to create the interface."
+                  }
+                ]
+              },
+              {
+                "name": "delete",
+                "about": "Delete a network interface\n\nNote that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
+                "args": [
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "interface",
+                    "help": "Name or ID of the network interface"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "about": "List network interfaces",
+                "args": [
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                  },
+                  {
+                    "long": "sort-by"
+                  }
+                ]
+              },
+              {
+                "name": "update",
+                "about": "Update a network interface",
+                "args": [
+                  {
+                    "long": "description"
+                  },
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "interface",
+                    "help": "Name or ID of the network interface"
+                  },
+                  {
+                    "long": "name"
+                  },
+                  {
+                    "long": "primary",
+                    "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "Fetch a network interface",
+                "args": [
+                  {
+                    "long": "instance",
+                    "help": "Name or ID of the instance"
+                  },
+                  {
+                    "long": "interface",
+                    "help": "Name or ID of the network interface"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "reboot",
+            "about": "Reboot an instance",
+            "args": [
+              {
+                "long": "instance",
+                "help": "Name or ID of the instance"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "start",
+            "about": "Boot an instance",
+            "args": [
+              {
+                "long": "instance",
+                "help": "Name or ID of the instance"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "stop",
+            "about": "Stop an instance",
+            "args": [
+              {
+                "long": "instance",
+                "help": "Name or ID of the instance"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch an instance",
+            "args": [
+              {
+                "long": "instance",
+                "help": "Name or ID of the instance"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "ip-pool",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create an IP pool",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "name"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete an IP Pool",
+            "args": [
+              {
+                "long": "pool",
+                "help": "Name or ID of the IP pool"
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List IP pools",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "range",
+            "subcommands": [
+              {
+                "name": "add",
+                "about": "Add a range to an IP pool",
+                "args": [
+                  {
+                    "long": "first"
+                  },
+                  {
+                    "long": "last"
+                  },
+                  {
+                    "long": "pool",
+                    "help": "Name or ID of the IP pool"
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "about": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
+                "args": [
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "pool",
+                    "help": "Name or ID of the IP pool"
+                  }
+                ]
+              },
+              {
+                "name": "remove",
+                "about": "Remove a range from an IP pool",
+                "args": [
+                  {
+                    "long": "pool",
+                    "help": "Name or ID of the IP pool"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "service",
+            "subcommands": [
+              {
+                "name": "range",
+                "subcommands": [
+                  {
+                    "name": "add",
+                    "about": "Add a range to an IP pool used for Oxide services."
+                  },
+                  {
+                    "name": "list",
+                    "about": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
+                    "args": [
+                      {
+                        "long": "limit",
+                        "help": "Maximum number of items returned by a single call"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "remove",
+                "about": "Remove a range from an IP pool used for Oxide services."
+              },
+              {
+                "name": "view",
+                "about": "Fetch the IP pool used for Oxide services."
+              }
+            ]
+          },
+          {
+            "name": "update",
+            "about": "Update an IP Pool",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "pool",
+                "help": "Name or ID of the IP pool"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch an IP pool",
+            "args": [
+              {
+                "long": "pool",
+                "help": "Name or ID of the IP pool"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "physical-disk",
+        "subcommands": [
+          {
+            "name": "list",
+            "about": "List physical disks",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "policy",
+        "subcommands": [
+          {
+            "name": "update",
+            "about": "Update the current silo's IAM policy"
+          },
+          {
+            "name": "view",
+            "about": "Fetch the current silo's IAM policy"
+          }
+        ]
+      },
+      {
+        "name": "project",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create a project",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "name"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete a project",
+            "args": [
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List projects",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "policy",
+            "subcommands": [
+              {
+                "name": "update",
+                "about": "Update a project's IAM policy",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "Fetch a project's IAM policy",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "update",
+            "about": "Update a project",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a project",
+            "args": [
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "rack",
+        "subcommands": [
+          {
+            "name": "list",
+            "about": "List racks",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a rack",
+            "args": [
+              {
+                "long": "rack-id",
+                "help": "The rack's unique ID."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "saga",
+        "subcommands": [
+          {
+            "name": "list",
+            "about": "List sagas",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a saga",
+            "args": [
+              {
+                "long": "saga-id"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "silo",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create a silo",
+            "args": [
+              {
+                "long": "admin-group-name",
+                "help": "If set, this group will be created during Silo creation and granted the \"Silo Admin\" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.\n\nNote that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information."
+              },
+              {
+                "long": "description"
+              },
+              {
+                "long": "discoverable"
+              },
+              {
+                "long": "identity-mode"
+              },
+              {
+                "long": "name"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete a silo\n\nDelete a silo by name.",
+            "args": [
+              {
+                "long": "silo",
+                "help": "Name or ID of the silo"
+              }
+            ]
+          },
+          {
+            "name": "idp",
+            "subcommands": [
+              {
+                "name": "list",
+                "about": "List a silo's IDPs_name",
+                "args": [
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "silo",
+                    "help": "Name or ID of the silo"
+                  },
+                  {
+                    "long": "sort-by"
+                  }
+                ]
+              },
+              {
+                "name": "local",
+                "subcommands": [
+                  {
+                    "name": "user",
+                    "subcommands": [
+                      {
+                        "name": "create",
+                        "about": "Create a user\n\nUsers can only be created in Silos with `provision_type` == `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user first logs in using an external Identity Provider.",
+                        "args": [
+                          {
+                            "long": "external-id",
+                            "help": "username used to log in"
+                          },
+                          {
+                            "long": "silo",
+                            "help": "Name or ID of the silo"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "delete",
+                        "about": "Delete a user",
+                        "args": [
+                          {
+                            "long": "silo",
+                            "help": "Name or ID of the silo"
+                          },
+                          {
+                            "long": "user-id",
+                            "help": "The user's internal id"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "set-password",
+                        "about": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
+                        "args": [
+                          {
+                            "long": "silo",
+                            "help": "Name or ID of the silo"
+                          },
+                          {
+                            "long": "user-id",
+                            "help": "The user's internal id"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "saml",
+                "subcommands": [
+                  {
+                    "name": "create",
+                    "about": "Create a SAML IDP",
+                    "args": [
+                      {
+                        "long": "acs-url",
+                        "help": "service provider endpoint where the response will be sent"
+                      },
+                      {
+                        "long": "description"
+                      },
+                      {
+                        "long": "group-attribute-name",
+                        "help": "If set, SAML attributes with this name will be considered to denote a user's group membership, where the attribute value(s) should be a comma-separated list of group names."
+                      },
+                      {
+                        "long": "idp-entity-id",
+                        "help": "idp's entity id"
+                      },
+                      {
+                        "long": "name"
+                      },
+                      {
+                        "long": "silo",
+                        "help": "Name or ID of the silo"
+                      },
+                      {
+                        "long": "slo-url",
+                        "help": "service provider endpoint where the idp should send log out requests"
+                      },
+                      {
+                        "long": "sp-client-id",
+                        "help": "sp's client id"
+                      },
+                      {
+                        "long": "technical-contact-email",
+                        "help": "customer's technical contact for saml configuration"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "view",
+                    "about": "Fetch a SAML IDP",
+                    "args": [
+                      {
+                        "long": "provider",
+                        "help": "Name or ID of the SAML identity provider"
+                      },
+                      {
+                        "long": "silo",
+                        "help": "Name or ID of the silo"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List silos\n\nLists silos that are discoverable based on the current permissions.",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "policy",
+            "subcommands": [
+              {
+                "name": "update",
+                "about": "Update a silo's IAM policy",
+                "args": [
+                  {
+                    "long": "silo",
+                    "help": "Name or ID of the silo"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "Fetch a silo's IAM policy",
+                "args": [
+                  {
+                    "long": "silo",
+                    "help": "Name or ID of the silo"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "user",
+            "subcommands": [
+              {
+                "name": "list",
+                "about": "List users in a silo",
+                "args": [
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "silo",
+                    "help": "Name or ID of the silo"
+                  },
+                  {
+                    "long": "sort-by"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "Fetch a user",
+                "args": [
+                  {
+                    "long": "silo",
+                    "help": "Name or ID of the silo"
+                  },
+                  {
+                    "long": "user-id",
+                    "help": "The user's internal id"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a silo\n\nFetch a silo by name.",
+            "args": [
+              {
+                "long": "silo",
+                "help": "Name or ID of the silo"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "sled",
+        "subcommands": [
+          {
+            "name": "disk-led",
+            "about": "List physical disks attached to sleds",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sled-id",
+                "help": "The sled's unique ID."
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List sleds",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a sled",
+            "args": [
+              {
+                "long": "sled-id",
+                "help": "The sled's unique ID."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "snapshot",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "disk",
+                "help": "The name of the disk to be snapshotted"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete a snapshot",
+            "args": [
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "snapshot",
+                "help": "Name or ID of the snapshot"
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List snapshots",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a snapshot",
+            "args": [
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "snapshot",
+                "help": "Name or ID of the snapshot"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "system",
+        "subcommands": [
+          {
+            "name": "policy",
+            "subcommands": [
+              {
+                "name": "update",
+                "about": "Update the top-level IAM policy"
+              },
+              {
+                "name": "view",
+                "about": "Fetch the top-level IAM policy"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "user",
+        "subcommands": [
+          {
+            "name": "list",
+            "about": "List users",
+            "args": [
+              {
+                "long": "group"
+              },
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "version",
+        "about": "Prints version information about the CLI."
+      },
+      {
+        "name": "vpc",
+        "subcommands": [
+          {
+            "name": "create",
+            "about": "Create a VPC",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "dns-name"
+              },
+              {
+                "long": "ipv6-prefix",
+                "help": "The IPv6 prefix for this VPC.\n\nAll IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix."
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              }
+            ]
+          },
+          {
+            "name": "delete",
+            "about": "Delete a VPC",
+            "args": [
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "vpc",
+                "help": "Name or ID of the VPC"
+              }
+            ]
+          },
+          {
+            "name": "firewall-rules",
+            "subcommands": [
+              {
+                "name": "update",
+                "about": "Replace firewall rules",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "List firewall rules",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "list",
+            "about": "List VPCs",
+            "args": [
+              {
+                "long": "limit",
+                "help": "Maximum number of items returned by a single call"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "sort-by"
+              }
+            ]
+          },
+          {
+            "name": "router",
+            "subcommands": [
+              {
+                "name": "create",
+                "about": "Create a VPC router",
+                "args": [
+                  {
+                    "long": "description"
+                  },
+                  {
+                    "long": "name"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "delete",
+                "about": "Delete a router",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "router",
+                    "help": "Name or ID of the router"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "about": "List routers",
+                "args": [
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "sort-by"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "route",
+                "subcommands": [
+                  {
+                    "name": "create",
+                    "about": "Create a router",
+                    "args": [
+                      {
+                        "long": "description"
+                      },
+                      {
+                        "long": "name"
+                      },
+                      {
+                        "long": "project",
+                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                      },
+                      {
+                        "long": "router",
+                        "help": "Name or ID of the router"
+                      },
+                      {
+                        "long": "vpc",
+                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "delete",
+                    "about": "Delete a route",
+                    "args": [
+                      {
+                        "long": "project",
+                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                      },
+                      {
+                        "long": "route",
+                        "help": "Name or ID of the route"
+                      },
+                      {
+                        "long": "router",
+                        "help": "Name or ID of the router"
+                      },
+                      {
+                        "long": "vpc",
+                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "list",
+                    "about": "List routes\n\nList the routes associated with a router in a particular VPC.",
+                    "args": [
+                      {
+                        "long": "limit",
+                        "help": "Maximum number of items returned by a single call"
+                      },
+                      {
+                        "long": "project",
+                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                      },
+                      {
+                        "long": "router",
+                        "help": "Name or ID of the router"
+                      },
+                      {
+                        "long": "sort-by"
+                      },
+                      {
+                        "long": "vpc",
+                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "update",
+                    "about": "Update a route",
+                    "args": [
+                      {
+                        "long": "description"
+                      },
+                      {
+                        "long": "name"
+                      },
+                      {
+                        "long": "project",
+                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                      },
+                      {
+                        "long": "route",
+                        "help": "Name or ID of the route"
+                      },
+                      {
+                        "long": "router",
+                        "help": "Name or ID of the router"
+                      },
+                      {
+                        "long": "vpc",
+                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "view",
+                    "about": "Fetch a route",
+                    "args": [
+                      {
+                        "long": "project",
+                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                      },
+                      {
+                        "long": "route",
+                        "help": "Name or ID of the route"
+                      },
+                      {
+                        "long": "router",
+                        "help": "Name or ID of the router"
+                      },
+                      {
+                        "long": "vpc",
+                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "update",
+                "about": "Update a router",
+                "args": [
+                  {
+                    "long": "description"
+                  },
+                  {
+                    "long": "name"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "router",
+                    "help": "Name or ID of the router"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "Get a router",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "router",
+                    "help": "Name or ID of the router"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "subnet",
+            "subcommands": [
+              {
+                "name": "create",
+                "about": "Create a subnet",
+                "args": [
+                  {
+                    "long": "description"
+                  },
+                  {
+                    "long": "ipv4-block",
+                    "help": "The IPv4 address range for this subnet.\n\nIt must be allocated from an RFC 1918 private address range, and must not overlap with any other existing subnet in the VPC."
+                  },
+                  {
+                    "long": "ipv6-block",
+                    "help": "The IPv6 address range for this subnet.\n\nIt must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC."
+                  },
+                  {
+                    "long": "name"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "delete",
+                "about": "Delete a subnet",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "subnet",
+                    "help": "Name or ID of the subnet"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "about": "Fetch a subnet",
+                "args": [
+                  {
+                    "long": "limit",
+                    "help": "Maximum number of items returned by a single call"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "sort-by"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "nic",
+                "subcommands": [
+                  {
+                    "name": "list",
+                    "about": "List network interfaces",
+                    "args": [
+                      {
+                        "long": "limit",
+                        "help": "Maximum number of items returned by a single call"
+                      },
+                      {
+                        "long": "project",
+                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                      },
+                      {
+                        "long": "sort-by"
+                      },
+                      {
+                        "long": "subnet",
+                        "help": "Name or ID of the subnet"
+                      },
+                      {
+                        "long": "vpc",
+                        "help": "Name or ID of the VPC"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "update",
+                "about": "Update a subnet",
+                "args": [
+                  {
+                    "long": "description"
+                  },
+                  {
+                    "long": "name"
+                  },
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "subnet",
+                    "help": "Name or ID of the subnet"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              },
+              {
+                "name": "view",
+                "about": "Fetch a subnet",
+                "args": [
+                  {
+                    "long": "project",
+                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                  },
+                  {
+                    "long": "subnet",
+                    "help": "Name or ID of the subnet"
+                  },
+                  {
+                    "long": "vpc",
+                    "help": "Name or ID of the VPC"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "update",
+            "about": "Update a VPC",
+            "args": [
+              {
+                "long": "description"
+              },
+              {
+                "long": "dns-name"
+              },
+              {
+                "long": "name"
+              },
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "vpc",
+                "help": "Name or ID of the VPC"
+              }
+            ]
+          },
+          {
+            "name": "view",
+            "about": "Fetch a VPC",
+            "args": [
+              {
+                "long": "project",
+                "help": "Name or ID of the project"
+              },
+              {
+                "long": "vpc",
+                "help": "Name or ID of the VPC"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.0",
   "name": "oxide",
+  "version": "0.1.0",
   "subcommands": [
     {
       "name": "api",

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1,2031 +1,2029 @@
 {
   "version": "0.1.0",
-  "commands": {
-    "name": "oxide",
-    "subcommands": [
-      {
-        "name": "api",
-        "about": "Makes an authenticated HTTP request to the Oxide API and prints the response.",
-        "long_about": "Makes an authenticated HTTP request to the Oxide API and prints the response.\n\nThe endpoint argument should be a path of a Oxide API endpoint.\n\nThe default HTTP request method is \"GET\" normally and \"POST\" if any\nparameters were added. Override the method with `--method`.\n\nPass one or more `-f/--raw-field` values in \"key=value\" format to add\nstatic string parameters to the request payload. To add non-string or\notherwise dynamic values, see `--field` below. Note that adding request\nparameters will automatically switch the request method to POST. To send\nthe parameters as a GET query string instead, use `--method GET`.\n\nThe `-F/--field` flag has magic type conversion based on the format of the\nvalue:\n\n- literal values \"true\", \"false\", \"null\", and integer/float numbers get\n  converted to appropriate JSON types;\n- if the value starts with \"@\", the rest of the value is interpreted as a\n  filename to read the value from. Pass \"-\" to read from standard input.\n\nRaw request body may be passed from the outside via a file specified by\n`--input`. Pass \"-\" to read from standard input. In this mode, parameters\nspecified via `--field` flags are serialized into URL query parameters.\n\nIn `--paginate` mode, all pages of results will sequentially be requested\nuntil there are no more pages of results.",
-        "args": [
-          {
-            "long": "field",
-            "short": "F",
-            "help": "Add a typed parameter in key=value format"
-          },
-          {
-            "long": "header",
-            "short": "H",
-            "help": "Add a HTTP request header in `key:value` format"
-          },
-          {
-            "long": "include",
-            "short": "i",
-            "help": "Include HTTP response headers in the output"
-          },
-          {
-            "long": "input",
-            "help": "The file to use as body for the HTTP request (use \"-\" to read from standard input)"
-          },
-          {
-            "long": "method",
-            "short": "X",
-            "help": "The HTTP method for the request"
-          },
-          {
-            "long": "paginate",
-            "help": "Make additional HTTP requests to fetch all pages of results"
-          },
-          {
-            "long": "raw-field",
-            "short": "f",
-            "help": "Add a string parameter in key=value format"
-          }
-        ]
-      },
-      {
-        "name": "auth",
-        "about": "Login, logout, and get the status of your authentication.",
-        "long_about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
-        "subcommands": [
-          {
-            "name": "login",
-            "about": "Authenticate with an Oxide host.",
-            "long_about": "Authenticate with an Oxide host.\n\nAlternatively, pass in a token on standard input by using `--with-token`.\n\n    # start interactive setup\n    $ oxide auth login\n\n    # authenticate against a specific Oxide instance by reading the token\n    # from a file\n    $ oxide auth login --with-token --host oxide.internal < mytoken.txt\n\n    # authenticate with a specific Oxide instance\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide instance (not recommended)\n    $ oxide auth login --host http://oxide.internal",
-            "args": [
-              {
-                "long": "browser",
-                "help": "Override the default browser when opening the authentication URL"
-              },
-              {
-                "long": "host",
-                "short": "H",
-                "help": "The host of the Oxide instance to authenticate with. This assumes http; specify an `http://` prefix if needed"
-              },
-              {
-                "long": "no-browser",
-                "help": "Print the authentication URL rather than opening a browser window"
-              },
-              {
-                "long": "with-token",
-                "help": "Read token from standard input"
-              }
-            ]
-          },
-          {
-            "name": "logout",
-            "about": "Removes saved authentication information.",
-            "long_about": "Removes saved authentication information.\n\nThis command does not invalidate any tokens from the hosts.",
-            "args": [
-              {
-                "long": "all",
-                "short": "a",
-                "help": "If set, all known hosts and authentication information will be deleted"
-              },
-              {
-                "long": "force",
-                "short": "f",
-                "help": "Skip confirmation prompt"
-              },
-              {
-                "long": "host",
-                "short": "H",
-                "help": "Remove authentication information for a single host"
-              }
-            ]
-          },
-          {
-            "name": "status",
-            "about": "Verifies and displays information about your authentication state.",
-            "long_about": "Verifies and displays information about your authentication state.\n\nThis command validates the authentication state for each Oxide environment\nin the current configuration. These hosts may be from your hosts.toml file\nand/or $OXIDE_HOST environment variable.",
-            "args": [
-              {
-                "long": "host",
-                "short": "H",
-                "help": "Specific hostname to validate"
-              },
-              {
-                "long": "show-token",
-                "short": "t",
-                "help": "Display the auth token"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "certificate",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "service",
-                "help": "The service using this certificate"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
-            "args": [
-              {
-                "long": "certificate"
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a certificate\n\nReturns the details of a specific certificate",
-            "args": [
-              {
-                "long": "certificate"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "current-user",
-        "subcommands": [
-          {
-            "name": "groups",
-            "about": "Fetch the silo groups the current user belongs to",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "ssh-key",
-            "subcommands": [
-              {
-                "name": "create",
-                "about": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
-                "args": [
-                  {
-                    "long": "description"
-                  },
-                  {
-                    "long": "name"
-                  },
-                  {
-                    "long": "public-key",
-                    "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
-                  }
-                ]
-              },
-              {
-                "name": "delete",
-                "about": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
-                "args": [
-                  {
-                    "long": "ssh-key",
-                    "help": "Name or ID of the SSH key"
-                  }
-                ]
-              },
-              {
-                "name": "list",
-                "about": "List SSH public keys\n\nLists SSH public keys for the currently authenticated user.",
-                "args": [
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "sort-by"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
-                "args": [
-                  {
-                    "long": "ssh-key",
-                    "help": "Name or ID of the SSH key"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch the user associated with the current session"
-          }
-        ]
-      },
-      {
-        "name": "disk",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create a disk",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "size",
-                "help": "total size of the Disk in bytes"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete a disk",
-            "args": [
-              {
-                "long": "disk",
-                "help": "Name or ID of the disk"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "import"
-          },
-          {
-            "name": "list",
-            "about": "List disks",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "metrics",
-            "subcommands": [
-              {
-                "name": "list",
-                "about": "Fetch disk metrics",
-                "args": [
-                  {
-                    "long": "disk"
-                  },
-                  {
-                    "long": "end-time",
-                    "help": "An exclusive end time of metrics."
-                  },
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "metric"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project"
-                  },
-                  {
-                    "long": "start-time",
-                    "help": "An inclusive start time of metrics."
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a disk",
-            "args": [
-              {
-                "long": "disk",
-                "help": "Name or ID of the disk"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "docs",
-        "about": "Generate CLI docs in JSON format"
-      },
-      {
-        "name": "group",
-        "subcommands": [
-          {
-            "name": "list",
-            "about": "List groups",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "image",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create an image\n\nCreate a new image in a project.",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "os",
-                "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "version",
-                "help": "The version of the operating system (e.g. 18.04, 20.04, etc.)"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
-            "args": [
-              {
-                "long": "image",
-                "help": "Name or ID of the image"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
-            "args": [
-              {
-                "long": "include-silo-images",
-                "help": "Flag used to indicate if silo scoped images should be included when listing project images. Only valid when `project` is provided."
-              },
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "promote",
-            "about": "Promote a project image to be visible to all projects in the silo",
-            "args": [
-              {
-                "long": "image",
-                "help": "Name or ID of the image"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch an image\n\nFetch the details for a specific image in a project.",
-            "args": [
-              {
-                "long": "image",
-                "help": "Name or ID of the image"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "instance",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create an instance",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "hostname"
-              },
-              {
-                "long": "memory"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "ncpus"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "start",
-                "help": "Should this instance be started upon creation; true by default."
-              },
-              {
-                "long": "user-data",
-                "help": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data."
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete an instance",
-            "args": [
-              {
-                "long": "instance",
-                "help": "Name or ID of the instance"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "disk",
-            "subcommands": [
-              {
-                "name": "attach",
-                "about": "Attach a disk to an instance",
-                "args": [
-                  {
-                    "long": "disk",
-                    "help": "Name or ID of the disk"
-                  },
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project"
-                  }
-                ]
-              },
-              {
-                "name": "detach",
-                "about": "Detach a disk from an instance",
-                "args": [
-                  {
-                    "long": "disk",
-                    "help": "Name or ID of the disk"
-                  },
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project"
-                  }
-                ]
-              },
-              {
-                "name": "list",
-                "about": "List an instance's disks",
-                "args": [
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project"
-                  },
-                  {
-                    "long": "sort-by"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "external-ip",
-            "subcommands": [
-              {
-                "name": "list",
-                "about": "List external IP addresses",
-                "args": [
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List instances",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "nic",
-            "subcommands": [
-              {
-                "name": "create",
-                "about": "Create a network interface",
-                "args": [
-                  {
-                    "long": "description"
-                  },
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "ip",
-                    "help": "The IP address for the interface. One will be auto-assigned if not provided."
-                  },
-                  {
-                    "long": "name"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                  },
-                  {
-                    "long": "subnet-name",
-                    "help": "The VPC Subnet in which to create the interface."
-                  },
-                  {
-                    "long": "vpc-name",
-                    "help": "The VPC in which to create the interface."
-                  }
-                ]
-              },
-              {
-                "name": "delete",
-                "about": "Delete a network interface\n\nNote that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
-                "args": [
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "interface",
-                    "help": "Name or ID of the network interface"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                  }
-                ]
-              },
-              {
-                "name": "list",
-                "about": "List network interfaces",
-                "args": [
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                  },
-                  {
-                    "long": "sort-by"
-                  }
-                ]
-              },
-              {
-                "name": "update",
-                "about": "Update a network interface",
-                "args": [
-                  {
-                    "long": "description"
-                  },
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "interface",
-                    "help": "Name or ID of the network interface"
-                  },
-                  {
-                    "long": "name"
-                  },
-                  {
-                    "long": "primary",
-                    "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "Fetch a network interface",
-                "args": [
-                  {
-                    "long": "instance",
-                    "help": "Name or ID of the instance"
-                  },
-                  {
-                    "long": "interface",
-                    "help": "Name or ID of the network interface"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "reboot",
-            "about": "Reboot an instance",
-            "args": [
-              {
-                "long": "instance",
-                "help": "Name or ID of the instance"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "start",
-            "about": "Boot an instance",
-            "args": [
-              {
-                "long": "instance",
-                "help": "Name or ID of the instance"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "stop",
-            "about": "Stop an instance",
-            "args": [
-              {
-                "long": "instance",
-                "help": "Name or ID of the instance"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch an instance",
-            "args": [
-              {
-                "long": "instance",
-                "help": "Name or ID of the instance"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "ip-pool",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create an IP pool",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "name"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete an IP Pool",
-            "args": [
-              {
-                "long": "pool",
-                "help": "Name or ID of the IP pool"
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List IP pools",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "range",
-            "subcommands": [
-              {
-                "name": "add",
-                "about": "Add a range to an IP pool",
-                "args": [
-                  {
-                    "long": "first"
-                  },
-                  {
-                    "long": "last"
-                  },
-                  {
-                    "long": "pool",
-                    "help": "Name or ID of the IP pool"
-                  }
-                ]
-              },
-              {
-                "name": "list",
-                "about": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
-                "args": [
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "pool",
-                    "help": "Name or ID of the IP pool"
-                  }
-                ]
-              },
-              {
-                "name": "remove",
-                "about": "Remove a range from an IP pool",
-                "args": [
-                  {
-                    "long": "pool",
-                    "help": "Name or ID of the IP pool"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "service",
-            "subcommands": [
-              {
-                "name": "range",
-                "subcommands": [
-                  {
-                    "name": "add",
-                    "about": "Add a range to an IP pool used for Oxide services."
-                  },
-                  {
-                    "name": "list",
-                    "about": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
-                    "args": [
-                      {
-                        "long": "limit",
-                        "help": "Maximum number of items returned by a single call"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "remove",
-                "about": "Remove a range from an IP pool used for Oxide services."
-              },
-              {
-                "name": "view",
-                "about": "Fetch the IP pool used for Oxide services."
-              }
-            ]
-          },
-          {
-            "name": "update",
-            "about": "Update an IP Pool",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "pool",
-                "help": "Name or ID of the IP pool"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch an IP pool",
-            "args": [
-              {
-                "long": "pool",
-                "help": "Name or ID of the IP pool"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "physical-disk",
-        "subcommands": [
-          {
-            "name": "list",
-            "about": "List physical disks",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "policy",
-        "subcommands": [
-          {
-            "name": "update",
-            "about": "Update the current silo's IAM policy"
-          },
-          {
-            "name": "view",
-            "about": "Fetch the current silo's IAM policy"
-          }
-        ]
-      },
-      {
-        "name": "project",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create a project",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "name"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete a project",
-            "args": [
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List projects",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "policy",
-            "subcommands": [
-              {
-                "name": "update",
-                "about": "Update a project's IAM policy",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "Fetch a project's IAM policy",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "update",
-            "about": "Update a project",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a project",
-            "args": [
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "rack",
-        "subcommands": [
-          {
-            "name": "list",
-            "about": "List racks",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a rack",
-            "args": [
-              {
-                "long": "rack-id",
-                "help": "The rack's unique ID."
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "saga",
-        "subcommands": [
-          {
-            "name": "list",
-            "about": "List sagas",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a saga",
-            "args": [
-              {
-                "long": "saga-id"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "silo",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create a silo",
-            "args": [
-              {
-                "long": "admin-group-name",
-                "help": "If set, this group will be created during Silo creation and granted the \"Silo Admin\" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.\n\nNote that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information."
-              },
-              {
-                "long": "description"
-              },
-              {
-                "long": "discoverable"
-              },
-              {
-                "long": "identity-mode"
-              },
-              {
-                "long": "name"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete a silo\n\nDelete a silo by name.",
-            "args": [
-              {
-                "long": "silo",
-                "help": "Name or ID of the silo"
-              }
-            ]
-          },
-          {
-            "name": "idp",
-            "subcommands": [
-              {
-                "name": "list",
-                "about": "List a silo's IDPs_name",
-                "args": [
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "silo",
-                    "help": "Name or ID of the silo"
-                  },
-                  {
-                    "long": "sort-by"
-                  }
-                ]
-              },
-              {
-                "name": "local",
-                "subcommands": [
-                  {
-                    "name": "user",
-                    "subcommands": [
-                      {
-                        "name": "create",
-                        "about": "Create a user\n\nUsers can only be created in Silos with `provision_type` == `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user first logs in using an external Identity Provider.",
-                        "args": [
-                          {
-                            "long": "external-id",
-                            "help": "username used to log in"
-                          },
-                          {
-                            "long": "silo",
-                            "help": "Name or ID of the silo"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "delete",
-                        "about": "Delete a user",
-                        "args": [
-                          {
-                            "long": "silo",
-                            "help": "Name or ID of the silo"
-                          },
-                          {
-                            "long": "user-id",
-                            "help": "The user's internal id"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "set-password",
-                        "about": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
-                        "args": [
-                          {
-                            "long": "silo",
-                            "help": "Name or ID of the silo"
-                          },
-                          {
-                            "long": "user-id",
-                            "help": "The user's internal id"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "saml",
-                "subcommands": [
-                  {
-                    "name": "create",
-                    "about": "Create a SAML IDP",
-                    "args": [
-                      {
-                        "long": "acs-url",
-                        "help": "service provider endpoint where the response will be sent"
-                      },
-                      {
-                        "long": "description"
-                      },
-                      {
-                        "long": "group-attribute-name",
-                        "help": "If set, SAML attributes with this name will be considered to denote a user's group membership, where the attribute value(s) should be a comma-separated list of group names."
-                      },
-                      {
-                        "long": "idp-entity-id",
-                        "help": "idp's entity id"
-                      },
-                      {
-                        "long": "name"
-                      },
-                      {
-                        "long": "silo",
-                        "help": "Name or ID of the silo"
-                      },
-                      {
-                        "long": "slo-url",
-                        "help": "service provider endpoint where the idp should send log out requests"
-                      },
-                      {
-                        "long": "sp-client-id",
-                        "help": "sp's client id"
-                      },
-                      {
-                        "long": "technical-contact-email",
-                        "help": "customer's technical contact for saml configuration"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "view",
-                    "about": "Fetch a SAML IDP",
-                    "args": [
-                      {
-                        "long": "provider",
-                        "help": "Name or ID of the SAML identity provider"
-                      },
-                      {
-                        "long": "silo",
-                        "help": "Name or ID of the silo"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List silos\n\nLists silos that are discoverable based on the current permissions.",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "policy",
-            "subcommands": [
-              {
-                "name": "update",
-                "about": "Update a silo's IAM policy",
-                "args": [
-                  {
-                    "long": "silo",
-                    "help": "Name or ID of the silo"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "Fetch a silo's IAM policy",
-                "args": [
-                  {
-                    "long": "silo",
-                    "help": "Name or ID of the silo"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "user",
-            "subcommands": [
-              {
-                "name": "list",
-                "about": "List users in a silo",
-                "args": [
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "silo",
-                    "help": "Name or ID of the silo"
-                  },
-                  {
-                    "long": "sort-by"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "Fetch a user",
-                "args": [
-                  {
-                    "long": "silo",
-                    "help": "Name or ID of the silo"
-                  },
-                  {
-                    "long": "user-id",
-                    "help": "The user's internal id"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a silo\n\nFetch a silo by name.",
-            "args": [
-              {
-                "long": "silo",
-                "help": "Name or ID of the silo"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "sled",
-        "subcommands": [
-          {
-            "name": "disk-led",
-            "about": "List physical disks attached to sleds",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sled-id",
-                "help": "The sled's unique ID."
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List sleds",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a sled",
-            "args": [
-              {
-                "long": "sled-id",
-                "help": "The sled's unique ID."
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "snapshot",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "disk",
-                "help": "The name of the disk to be snapshotted"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete a snapshot",
-            "args": [
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "snapshot",
-                "help": "Name or ID of the snapshot"
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List snapshots",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a snapshot",
-            "args": [
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "snapshot",
-                "help": "Name or ID of the snapshot"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "system",
-        "subcommands": [
-          {
-            "name": "policy",
-            "subcommands": [
-              {
-                "name": "update",
-                "about": "Update the top-level IAM policy"
-              },
-              {
-                "name": "view",
-                "about": "Fetch the top-level IAM policy"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "user",
-        "subcommands": [
-          {
-            "name": "list",
-            "about": "List users",
-            "args": [
-              {
-                "long": "group"
-              },
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "version",
-        "about": "Prints version information about the CLI."
-      },
-      {
-        "name": "vpc",
-        "subcommands": [
-          {
-            "name": "create",
-            "about": "Create a VPC",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "dns-name"
-              },
-              {
-                "long": "ipv6-prefix",
-                "help": "The IPv6 prefix for this VPC.\n\nAll IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix."
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              }
-            ]
-          },
-          {
-            "name": "delete",
-            "about": "Delete a VPC",
-            "args": [
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "vpc",
-                "help": "Name or ID of the VPC"
-              }
-            ]
-          },
-          {
-            "name": "firewall-rules",
-            "subcommands": [
-              {
-                "name": "update",
-                "about": "Replace firewall rules",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "List firewall rules",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "list",
-            "about": "List VPCs",
-            "args": [
-              {
-                "long": "limit",
-                "help": "Maximum number of items returned by a single call"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "sort-by"
-              }
-            ]
-          },
-          {
-            "name": "router",
-            "subcommands": [
-              {
-                "name": "create",
-                "about": "Create a VPC router",
-                "args": [
-                  {
-                    "long": "description"
-                  },
-                  {
-                    "long": "name"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "delete",
-                "about": "Delete a router",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "router",
-                    "help": "Name or ID of the router"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "list",
-                "about": "List routers",
-                "args": [
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "sort-by"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "route",
-                "subcommands": [
-                  {
-                    "name": "create",
-                    "about": "Create a router",
-                    "args": [
-                      {
-                        "long": "description"
-                      },
-                      {
-                        "long": "name"
-                      },
-                      {
-                        "long": "project",
-                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                      },
-                      {
-                        "long": "router",
-                        "help": "Name or ID of the router"
-                      },
-                      {
-                        "long": "vpc",
-                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "delete",
-                    "about": "Delete a route",
-                    "args": [
-                      {
-                        "long": "project",
-                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                      },
-                      {
-                        "long": "route",
-                        "help": "Name or ID of the route"
-                      },
-                      {
-                        "long": "router",
-                        "help": "Name or ID of the router"
-                      },
-                      {
-                        "long": "vpc",
-                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "list",
-                    "about": "List routes\n\nList the routes associated with a router in a particular VPC.",
-                    "args": [
-                      {
-                        "long": "limit",
-                        "help": "Maximum number of items returned by a single call"
-                      },
-                      {
-                        "long": "project",
-                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                      },
-                      {
-                        "long": "router",
-                        "help": "Name or ID of the router"
-                      },
-                      {
-                        "long": "sort-by"
-                      },
-                      {
-                        "long": "vpc",
-                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "update",
-                    "about": "Update a route",
-                    "args": [
-                      {
-                        "long": "description"
-                      },
-                      {
-                        "long": "name"
-                      },
-                      {
-                        "long": "project",
-                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                      },
-                      {
-                        "long": "route",
-                        "help": "Name or ID of the route"
-                      },
-                      {
-                        "long": "router",
-                        "help": "Name or ID of the router"
-                      },
-                      {
-                        "long": "vpc",
-                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "view",
-                    "about": "Fetch a route",
-                    "args": [
-                      {
-                        "long": "project",
-                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                      },
-                      {
-                        "long": "route",
-                        "help": "Name or ID of the route"
-                      },
-                      {
-                        "long": "router",
-                        "help": "Name or ID of the router"
-                      },
-                      {
-                        "long": "vpc",
-                        "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "update",
-                "about": "Update a router",
-                "args": [
-                  {
-                    "long": "description"
-                  },
-                  {
-                    "long": "name"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "router",
-                    "help": "Name or ID of the router"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "Get a router",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "router",
-                    "help": "Name or ID of the router"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "subnet",
-            "subcommands": [
-              {
-                "name": "create",
-                "about": "Create a subnet",
-                "args": [
-                  {
-                    "long": "description"
-                  },
-                  {
-                    "long": "ipv4-block",
-                    "help": "The IPv4 address range for this subnet.\n\nIt must be allocated from an RFC 1918 private address range, and must not overlap with any other existing subnet in the VPC."
-                  },
-                  {
-                    "long": "ipv6-block",
-                    "help": "The IPv6 address range for this subnet.\n\nIt must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC."
-                  },
-                  {
-                    "long": "name"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "delete",
-                "about": "Delete a subnet",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "subnet",
-                    "help": "Name or ID of the subnet"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "list",
-                "about": "Fetch a subnet",
-                "args": [
-                  {
-                    "long": "limit",
-                    "help": "Maximum number of items returned by a single call"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "sort-by"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "nic",
-                "subcommands": [
-                  {
-                    "name": "list",
-                    "about": "List network interfaces",
-                    "args": [
-                      {
-                        "long": "limit",
-                        "help": "Maximum number of items returned by a single call"
-                      },
-                      {
-                        "long": "project",
-                        "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                      },
-                      {
-                        "long": "sort-by"
-                      },
-                      {
-                        "long": "subnet",
-                        "help": "Name or ID of the subnet"
-                      },
-                      {
-                        "long": "vpc",
-                        "help": "Name or ID of the VPC"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "update",
-                "about": "Update a subnet",
-                "args": [
-                  {
-                    "long": "description"
-                  },
-                  {
-                    "long": "name"
-                  },
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "subnet",
-                    "help": "Name or ID of the subnet"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              },
-              {
-                "name": "view",
-                "about": "Fetch a subnet",
-                "args": [
-                  {
-                    "long": "project",
-                    "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
-                  },
-                  {
-                    "long": "subnet",
-                    "help": "Name or ID of the subnet"
-                  },
-                  {
-                    "long": "vpc",
-                    "help": "Name or ID of the VPC"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "update",
-            "about": "Update a VPC",
-            "args": [
-              {
-                "long": "description"
-              },
-              {
-                "long": "dns-name"
-              },
-              {
-                "long": "name"
-              },
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "vpc",
-                "help": "Name or ID of the VPC"
-              }
-            ]
-          },
-          {
-            "name": "view",
-            "about": "Fetch a VPC",
-            "args": [
-              {
-                "long": "project",
-                "help": "Name or ID of the project"
-              },
-              {
-                "long": "vpc",
-                "help": "Name or ID of the VPC"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
+  "name": "oxide",
+  "subcommands": [
+    {
+      "name": "api",
+      "about": "Makes an authenticated HTTP request to the Oxide API and prints the response.",
+      "long_about": "Makes an authenticated HTTP request to the Oxide API and prints the response.\n\nThe endpoint argument should be a path of a Oxide API endpoint.\n\nThe default HTTP request method is \"GET\" normally and \"POST\" if any\nparameters were added. Override the method with `--method`.\n\nPass one or more `-f/--raw-field` values in \"key=value\" format to add\nstatic string parameters to the request payload. To add non-string or\notherwise dynamic values, see `--field` below. Note that adding request\nparameters will automatically switch the request method to POST. To send\nthe parameters as a GET query string instead, use `--method GET`.\n\nThe `-F/--field` flag has magic type conversion based on the format of the\nvalue:\n\n- literal values \"true\", \"false\", \"null\", and integer/float numbers get\n  converted to appropriate JSON types;\n- if the value starts with \"@\", the rest of the value is interpreted as a\n  filename to read the value from. Pass \"-\" to read from standard input.\n\nRaw request body may be passed from the outside via a file specified by\n`--input`. Pass \"-\" to read from standard input. In this mode, parameters\nspecified via `--field` flags are serialized into URL query parameters.\n\nIn `--paginate` mode, all pages of results will sequentially be requested\nuntil there are no more pages of results.",
+      "args": [
+        {
+          "long": "field",
+          "short": "F",
+          "help": "Add a typed parameter in key=value format"
+        },
+        {
+          "long": "header",
+          "short": "H",
+          "help": "Add a HTTP request header in `key:value` format"
+        },
+        {
+          "long": "include",
+          "short": "i",
+          "help": "Include HTTP response headers in the output"
+        },
+        {
+          "long": "input",
+          "help": "The file to use as body for the HTTP request (use \"-\" to read from standard input)"
+        },
+        {
+          "long": "method",
+          "short": "X",
+          "help": "The HTTP method for the request"
+        },
+        {
+          "long": "paginate",
+          "help": "Make additional HTTP requests to fetch all pages of results"
+        },
+        {
+          "long": "raw-field",
+          "short": "f",
+          "help": "Add a string parameter in key=value format"
+        }
+      ]
+    },
+    {
+      "name": "auth",
+      "about": "Login, logout, and get the status of your authentication.",
+      "long_about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
+      "subcommands": [
+        {
+          "name": "login",
+          "about": "Authenticate with an Oxide host.",
+          "long_about": "Authenticate with an Oxide host.\n\nAlternatively, pass in a token on standard input by using `--with-token`.\n\n    # start interactive setup\n    $ oxide auth login\n\n    # authenticate against a specific Oxide instance by reading the token\n    # from a file\n    $ oxide auth login --with-token --host oxide.internal < mytoken.txt\n\n    # authenticate with a specific Oxide instance\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide instance (not recommended)\n    $ oxide auth login --host http://oxide.internal",
+          "args": [
+            {
+              "long": "browser",
+              "help": "Override the default browser when opening the authentication URL"
+            },
+            {
+              "long": "host",
+              "short": "H",
+              "help": "The host of the Oxide instance to authenticate with. This assumes http; specify an `http://` prefix if needed"
+            },
+            {
+              "long": "no-browser",
+              "help": "Print the authentication URL rather than opening a browser window"
+            },
+            {
+              "long": "with-token",
+              "help": "Read token from standard input"
+            }
+          ]
+        },
+        {
+          "name": "logout",
+          "about": "Removes saved authentication information.",
+          "long_about": "Removes saved authentication information.\n\nThis command does not invalidate any tokens from the hosts.",
+          "args": [
+            {
+              "long": "all",
+              "short": "a",
+              "help": "If set, all known hosts and authentication information will be deleted"
+            },
+            {
+              "long": "force",
+              "short": "f",
+              "help": "Skip confirmation prompt"
+            },
+            {
+              "long": "host",
+              "short": "H",
+              "help": "Remove authentication information for a single host"
+            }
+          ]
+        },
+        {
+          "name": "status",
+          "about": "Verifies and displays information about your authentication state.",
+          "long_about": "Verifies and displays information about your authentication state.\n\nThis command validates the authentication state for each Oxide environment\nin the current configuration. These hosts may be from your hosts.toml file\nand/or $OXIDE_HOST environment variable.",
+          "args": [
+            {
+              "long": "host",
+              "short": "H",
+              "help": "Specific hostname to validate"
+            },
+            {
+              "long": "show-token",
+              "short": "t",
+              "help": "Display the auth token"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "certificate",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically used by the Oxide Control plane to serve external connections.",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "service",
+              "help": "The service using this certificate"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete a certificate\n\nPermanently delete a certificate. This operation cannot be undone.",
+          "args": [
+            {
+              "long": "certificate"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List system-wide certificates\n\nReturns a list of all the system-wide certificates. System-wide certificates are returned sorted by creation date, with the most recent certificates appearing first.",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a certificate\n\nReturns the details of a specific certificate",
+          "args": [
+            {
+              "long": "certificate"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "current-user",
+      "subcommands": [
+        {
+          "name": "groups",
+          "about": "Fetch the silo groups the current user belongs to",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "ssh-key",
+          "subcommands": [
+            {
+              "name": "create",
+              "about": "Create an SSH public key\n\nCreate an SSH public key for the currently authenticated user.",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "public-key",
+                  "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "about": "Delete an SSH public key\n\nDelete an SSH public key associated with the currently authenticated user.",
+              "args": [
+                {
+                  "long": "ssh-key",
+                  "help": "Name or ID of the SSH key"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "about": "List SSH public keys\n\nLists SSH public keys for the currently authenticated user.",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently authenticated user.",
+              "args": [
+                {
+                  "long": "ssh-key",
+                  "help": "Name or ID of the SSH key"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch the user associated with the current session"
+        }
+      ]
+    },
+    {
+      "name": "disk",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create a disk",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "size",
+              "help": "total size of the Disk in bytes"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete a disk",
+          "args": [
+            {
+              "long": "disk",
+              "help": "Name or ID of the disk"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "import"
+        },
+        {
+          "name": "list",
+          "about": "List disks",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "metrics",
+          "subcommands": [
+            {
+              "name": "list",
+              "about": "Fetch disk metrics",
+              "args": [
+                {
+                  "long": "disk"
+                },
+                {
+                  "long": "end-time",
+                  "help": "An exclusive end time of metrics."
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "metric"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                },
+                {
+                  "long": "start-time",
+                  "help": "An inclusive start time of metrics."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a disk",
+          "args": [
+            {
+              "long": "disk",
+              "help": "Name or ID of the disk"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "docs",
+      "about": "Generate CLI docs in JSON format"
+    },
+    {
+      "name": "group",
+      "subcommands": [
+        {
+          "name": "list",
+          "about": "List groups",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create an image\n\nCreate a new image in a project.",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "os",
+              "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "version",
+              "help": "The version of the operating system (e.g. 18.04, 20.04, etc.)"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete an image\n\nPermanently delete an image from a project. This operation cannot be undone. Any instances in the project using the image will continue to run, however new instances can not be created with this image.",
+          "args": [
+            {
+              "long": "image",
+              "help": "Name or ID of the image"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List images\n\nList images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
+          "args": [
+            {
+              "long": "include-silo-images",
+              "help": "Flag used to indicate if silo scoped images should be included when listing project images. Only valid when `project` is provided."
+            },
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "promote",
+          "about": "Promote a project image to be visible to all projects in the silo",
+          "args": [
+            {
+              "long": "image",
+              "help": "Name or ID of the image"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch an image\n\nFetch the details for a specific image in a project.",
+          "args": [
+            {
+              "long": "image",
+              "help": "Name or ID of the image"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "instance",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create an instance",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "hostname"
+            },
+            {
+              "long": "memory"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "ncpus"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "start",
+              "help": "Should this instance be started upon creation; true by default."
+            },
+            {
+              "long": "user-data",
+              "help": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data."
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete an instance",
+          "args": [
+            {
+              "long": "instance",
+              "help": "Name or ID of the instance"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "disk",
+          "subcommands": [
+            {
+              "name": "attach",
+              "about": "Attach a disk to an instance",
+              "args": [
+                {
+                  "long": "disk",
+                  "help": "Name or ID of the disk"
+                },
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                }
+              ]
+            },
+            {
+              "name": "detach",
+              "about": "Detach a disk from an instance",
+              "args": [
+                {
+                  "long": "disk",
+                  "help": "Name or ID of the disk"
+                },
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "about": "List an instance's disks",
+              "args": [
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "external-ip",
+          "subcommands": [
+            {
+              "name": "list",
+              "about": "List external IP addresses",
+              "args": [
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List instances",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "nic",
+          "subcommands": [
+            {
+              "name": "create",
+              "about": "Create a network interface",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "ip",
+                  "help": "The IP address for the interface. One will be auto-assigned if not provided."
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                },
+                {
+                  "long": "subnet-name",
+                  "help": "The VPC Subnet in which to create the interface."
+                },
+                {
+                  "long": "vpc-name",
+                  "help": "The VPC in which to create the interface."
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "about": "Delete a network interface\n\nNote that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
+              "args": [
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "interface",
+                  "help": "Name or ID of the network interface"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "about": "List network interfaces",
+              "args": [
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "name": "update",
+              "about": "Update a network interface",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "interface",
+                  "help": "Name or ID of the network interface"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "primary",
+                  "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "Fetch a network interface",
+              "args": [
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "interface",
+                  "help": "Name or ID of the network interface"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "reboot",
+          "about": "Reboot an instance",
+          "args": [
+            {
+              "long": "instance",
+              "help": "Name or ID of the instance"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "start",
+          "about": "Boot an instance",
+          "args": [
+            {
+              "long": "instance",
+              "help": "Name or ID of the instance"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "stop",
+          "about": "Stop an instance",
+          "args": [
+            {
+              "long": "instance",
+              "help": "Name or ID of the instance"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch an instance",
+          "args": [
+            {
+              "long": "instance",
+              "help": "Name or ID of the instance"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ip-pool",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create an IP pool",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete an IP Pool",
+          "args": [
+            {
+              "long": "pool",
+              "help": "Name or ID of the IP pool"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List IP pools",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "range",
+          "subcommands": [
+            {
+              "name": "add",
+              "about": "Add a range to an IP pool",
+              "args": [
+                {
+                  "long": "first"
+                },
+                {
+                  "long": "last"
+                },
+                {
+                  "long": "pool",
+                  "help": "Name or ID of the IP pool"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "about": "List ranges for an IP pool\n\nRanges are ordered by their first address.",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "pool",
+                  "help": "Name or ID of the IP pool"
+                }
+              ]
+            },
+            {
+              "name": "remove",
+              "about": "Remove a range from an IP pool",
+              "args": [
+                {
+                  "long": "pool",
+                  "help": "Name or ID of the IP pool"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "service",
+          "subcommands": [
+            {
+              "name": "range",
+              "subcommands": [
+                {
+                  "name": "add",
+                  "about": "Add a range to an IP pool used for Oxide services."
+                },
+                {
+                  "name": "list",
+                  "about": "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by their first address.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "remove",
+              "about": "Remove a range from an IP pool used for Oxide services."
+            },
+            {
+              "name": "view",
+              "about": "Fetch the IP pool used for Oxide services."
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "about": "Update an IP Pool",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "pool",
+              "help": "Name or ID of the IP pool"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch an IP pool",
+          "args": [
+            {
+              "long": "pool",
+              "help": "Name or ID of the IP pool"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "physical-disk",
+      "subcommands": [
+        {
+          "name": "list",
+          "about": "List physical disks",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "policy",
+      "subcommands": [
+        {
+          "name": "update",
+          "about": "Update the current silo's IAM policy"
+        },
+        {
+          "name": "view",
+          "about": "Fetch the current silo's IAM policy"
+        }
+      ]
+    },
+    {
+      "name": "project",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create a project",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete a project",
+          "args": [
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List projects",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "policy",
+          "subcommands": [
+            {
+              "name": "update",
+              "about": "Update a project's IAM policy",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "Fetch a project's IAM policy",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "about": "Update a project",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a project",
+          "args": [
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "rack",
+      "subcommands": [
+        {
+          "name": "list",
+          "about": "List racks",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a rack",
+          "args": [
+            {
+              "long": "rack-id",
+              "help": "The rack's unique ID."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "saga",
+      "subcommands": [
+        {
+          "name": "list",
+          "about": "List sagas",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a saga",
+          "args": [
+            {
+              "long": "saga-id"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "silo",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create a silo",
+          "args": [
+            {
+              "long": "admin-group-name",
+              "help": "If set, this group will be created during Silo creation and granted the \"Silo Admin\" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.\n\nNote that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information."
+            },
+            {
+              "long": "description"
+            },
+            {
+              "long": "discoverable"
+            },
+            {
+              "long": "identity-mode"
+            },
+            {
+              "long": "name"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete a silo\n\nDelete a silo by name.",
+          "args": [
+            {
+              "long": "silo",
+              "help": "Name or ID of the silo"
+            }
+          ]
+        },
+        {
+          "name": "idp",
+          "subcommands": [
+            {
+              "name": "list",
+              "about": "List a silo's IDPs_name",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "silo",
+                  "help": "Name or ID of the silo"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "name": "local",
+              "subcommands": [
+                {
+                  "name": "user",
+                  "subcommands": [
+                    {
+                      "name": "create",
+                      "about": "Create a user\n\nUsers can only be created in Silos with `provision_type` == `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user first logs in using an external Identity Provider.",
+                      "args": [
+                        {
+                          "long": "external-id",
+                          "help": "username used to log in"
+                        },
+                        {
+                          "long": "silo",
+                          "help": "Name or ID of the silo"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "delete",
+                      "about": "Delete a user",
+                      "args": [
+                        {
+                          "long": "silo",
+                          "help": "Name or ID of the silo"
+                        },
+                        {
+                          "long": "user-id",
+                          "help": "The user's internal id"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "set-password",
+                      "about": "Set or invalidate a user's password\n\nPasswords can only be updated for users in Silos with identity mode `LocalOnly`.",
+                      "args": [
+                        {
+                          "long": "silo",
+                          "help": "Name or ID of the silo"
+                        },
+                        {
+                          "long": "user-id",
+                          "help": "The user's internal id"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "saml",
+              "subcommands": [
+                {
+                  "name": "create",
+                  "about": "Create a SAML IDP",
+                  "args": [
+                    {
+                      "long": "acs-url",
+                      "help": "service provider endpoint where the response will be sent"
+                    },
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "group-attribute-name",
+                      "help": "If set, SAML attributes with this name will be considered to denote a user's group membership, where the attribute value(s) should be a comma-separated list of group names."
+                    },
+                    {
+                      "long": "idp-entity-id",
+                      "help": "idp's entity id"
+                    },
+                    {
+                      "long": "name"
+                    },
+                    {
+                      "long": "silo",
+                      "help": "Name or ID of the silo"
+                    },
+                    {
+                      "long": "slo-url",
+                      "help": "service provider endpoint where the idp should send log out requests"
+                    },
+                    {
+                      "long": "sp-client-id",
+                      "help": "sp's client id"
+                    },
+                    {
+                      "long": "technical-contact-email",
+                      "help": "customer's technical contact for saml configuration"
+                    }
+                  ]
+                },
+                {
+                  "name": "view",
+                  "about": "Fetch a SAML IDP",
+                  "args": [
+                    {
+                      "long": "provider",
+                      "help": "Name or ID of the SAML identity provider"
+                    },
+                    {
+                      "long": "silo",
+                      "help": "Name or ID of the silo"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List silos\n\nLists silos that are discoverable based on the current permissions.",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "policy",
+          "subcommands": [
+            {
+              "name": "update",
+              "about": "Update a silo's IAM policy",
+              "args": [
+                {
+                  "long": "silo",
+                  "help": "Name or ID of the silo"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "Fetch a silo's IAM policy",
+              "args": [
+                {
+                  "long": "silo",
+                  "help": "Name or ID of the silo"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "user",
+          "subcommands": [
+            {
+              "name": "list",
+              "about": "List users in a silo",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "silo",
+                  "help": "Name or ID of the silo"
+                },
+                {
+                  "long": "sort-by"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "Fetch a user",
+              "args": [
+                {
+                  "long": "silo",
+                  "help": "Name or ID of the silo"
+                },
+                {
+                  "long": "user-id",
+                  "help": "The user's internal id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a silo\n\nFetch a silo by name.",
+          "args": [
+            {
+              "long": "silo",
+              "help": "Name or ID of the silo"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "sled",
+      "subcommands": [
+        {
+          "name": "disk-led",
+          "about": "List physical disks attached to sleds",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sled-id",
+              "help": "The sled's unique ID."
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List sleds",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a sled",
+          "args": [
+            {
+              "long": "sled-id",
+              "help": "The sled's unique ID."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "snapshot",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create a snapshot\n\nCreates a point-in-time snapshot from a disk.",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "disk",
+              "help": "The name of the disk to be snapshotted"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete a snapshot",
+          "args": [
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "snapshot",
+              "help": "Name or ID of the snapshot"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List snapshots",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a snapshot",
+          "args": [
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "snapshot",
+              "help": "Name or ID of the snapshot"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "system",
+      "subcommands": [
+        {
+          "name": "policy",
+          "subcommands": [
+            {
+              "name": "update",
+              "about": "Update the top-level IAM policy"
+            },
+            {
+              "name": "view",
+              "about": "Fetch the top-level IAM policy"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "user",
+      "subcommands": [
+        {
+          "name": "list",
+          "about": "List users",
+          "args": [
+            {
+              "long": "group"
+            },
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "version",
+      "about": "Prints version information about the CLI."
+    },
+    {
+      "name": "vpc",
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create a VPC",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "dns-name"
+            },
+            {
+              "long": "ipv6-prefix",
+              "help": "The IPv6 prefix for this VPC.\n\nAll IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix."
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete a VPC",
+          "args": [
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "vpc",
+              "help": "Name or ID of the VPC"
+            }
+          ]
+        },
+        {
+          "name": "firewall-rules",
+          "subcommands": [
+            {
+              "name": "update",
+              "about": "Replace firewall rules",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "List firewall rules",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List VPCs",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "sort-by"
+            }
+          ]
+        },
+        {
+          "name": "router",
+          "subcommands": [
+            {
+              "name": "create",
+              "about": "Create a VPC router",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "about": "Delete a router",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "router",
+                  "help": "Name or ID of the router"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "about": "List routers",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "sort-by"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "route",
+              "subcommands": [
+                {
+                  "name": "create",
+                  "about": "Create a router",
+                  "args": [
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "name"
+                    },
+                    {
+                      "long": "project",
+                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                    },
+                    {
+                      "long": "router",
+                      "help": "Name or ID of the router"
+                    },
+                    {
+                      "long": "vpc",
+                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                    }
+                  ]
+                },
+                {
+                  "name": "delete",
+                  "about": "Delete a route",
+                  "args": [
+                    {
+                      "long": "project",
+                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                    },
+                    {
+                      "long": "route",
+                      "help": "Name or ID of the route"
+                    },
+                    {
+                      "long": "router",
+                      "help": "Name or ID of the router"
+                    },
+                    {
+                      "long": "vpc",
+                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                    }
+                  ]
+                },
+                {
+                  "name": "list",
+                  "about": "List routes\n\nList the routes associated with a router in a particular VPC.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "project",
+                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                    },
+                    {
+                      "long": "router",
+                      "help": "Name or ID of the router"
+                    },
+                    {
+                      "long": "sort-by"
+                    },
+                    {
+                      "long": "vpc",
+                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                    }
+                  ]
+                },
+                {
+                  "name": "update",
+                  "about": "Update a route",
+                  "args": [
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "name"
+                    },
+                    {
+                      "long": "project",
+                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                    },
+                    {
+                      "long": "route",
+                      "help": "Name or ID of the route"
+                    },
+                    {
+                      "long": "router",
+                      "help": "Name or ID of the router"
+                    },
+                    {
+                      "long": "vpc",
+                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                    }
+                  ]
+                },
+                {
+                  "name": "view",
+                  "about": "Fetch a route",
+                  "args": [
+                    {
+                      "long": "project",
+                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                    },
+                    {
+                      "long": "route",
+                      "help": "Name or ID of the route"
+                    },
+                    {
+                      "long": "router",
+                      "help": "Name or ID of the router"
+                    },
+                    {
+                      "long": "vpc",
+                      "help": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "update",
+              "about": "Update a router",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "router",
+                  "help": "Name or ID of the router"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "Get a router",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "router",
+                  "help": "Name or ID of the router"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "subnet",
+          "subcommands": [
+            {
+              "name": "create",
+              "about": "Create a subnet",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "ipv4-block",
+                  "help": "The IPv4 address range for this subnet.\n\nIt must be allocated from an RFC 1918 private address range, and must not overlap with any other existing subnet in the VPC."
+                },
+                {
+                  "long": "ipv6-block",
+                  "help": "The IPv6 address range for this subnet.\n\nIt must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC."
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "about": "Delete a subnet",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "subnet",
+                  "help": "Name or ID of the subnet"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "about": "Fetch a subnet",
+              "args": [
+                {
+                  "long": "limit",
+                  "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "sort-by"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "nic",
+              "subcommands": [
+                {
+                  "name": "list",
+                  "about": "List network interfaces",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "project",
+                      "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                    },
+                    {
+                      "long": "sort-by"
+                    },
+                    {
+                      "long": "subnet",
+                      "help": "Name or ID of the subnet"
+                    },
+                    {
+                      "long": "vpc",
+                      "help": "Name or ID of the VPC"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "update",
+              "about": "Update a subnet",
+              "args": [
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "name"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "subnet",
+                  "help": "Name or ID of the subnet"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "about": "Fetch a subnet",
+              "args": [
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
+                },
+                {
+                  "long": "subnet",
+                  "help": "Name or ID of the subnet"
+                },
+                {
+                  "long": "vpc",
+                  "help": "Name or ID of the VPC"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "about": "Update a VPC",
+          "args": [
+            {
+              "long": "description"
+            },
+            {
+              "long": "dns-name"
+            },
+            {
+              "long": "name"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "vpc",
+              "help": "Name or ID of the VPC"
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "Fetch a VPC",
+          "args": [
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            },
+            {
+              "long": "vpc",
+              "help": "Name or ID of the VPC"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/cli/src/cmd_docs.rs
+++ b/cli/src/cmd_docs.rs
@@ -64,6 +64,8 @@ fn to_json(cmd: &Command) -> JsonDoc {
 #[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct OutputJson {
     version: String,
+
+    #[serde(flatten)]
     commands: JsonDoc,
 }
 

--- a/cli/src/cmd_docs.rs
+++ b/cli/src/cmd_docs.rs
@@ -4,6 +4,7 @@
 
 // Copyright 2023 Oxide Computer Company
 
+use super::cmd_version::built_info;
 use anyhow::Result;
 use clap::{Command, Parser};
 use serde::Serialize;
@@ -30,6 +31,8 @@ pub struct JsonArg {
 pub struct JsonDoc {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     about: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     long_about: Option<String>,
@@ -52,8 +55,17 @@ fn to_json(cmd: &Command) -> JsonDoc {
         })
         .collect::<Vec<_>>();
     args.sort_unstable();
+
+    let name = cmd.get_name().to_string();
+    let version: Option<String> = if name == "oxide" {
+        Some(built_info::PKG_VERSION.to_string())
+    } else {
+        None
+    };
+
     JsonDoc {
-        name: cmd.get_name().to_string(),
+        name,
+        version,
         about: cmd.get_about().map(ToString::to_string),
         long_about: cmd.get_long_about().map(ToString::to_string),
         args,
@@ -61,23 +73,10 @@ fn to_json(cmd: &Command) -> JsonDoc {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, Eq)]
-pub struct OutputJson {
-    version: String,
-
-    #[serde(flatten)]
-    commands: JsonDoc,
-}
-
 impl CmdDocs {
     pub async fn run(&self, app: &Command) -> Result<()> {
-        const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
         let json_doc = to_json(app);
-        let output = OutputJson {
-            version: CLI_VERSION.to_string(),
-            commands: json_doc,
-        };
-        let pretty_json = serde_json::to_string_pretty(&output)?;
+        let pretty_json = serde_json::to_string_pretty(&json_doc)?;
         println!("{}", pretty_json);
         Ok(())
     }

--- a/cli/src/cmd_docs.rs
+++ b/cli/src/cmd_docs.rs
@@ -61,9 +61,21 @@ fn to_json(cmd: &Command) -> JsonDoc {
     }
 }
 
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct OutputJson {
+    version: String,
+    commands: JsonDoc,
+}
+
 impl CmdDocs {
     pub async fn run(&self, app: &Command) -> Result<()> {
-        let pretty_json = serde_json::to_string_pretty(&to_json(app))?;
+        const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+        let json_doc = to_json(app);
+        let output = OutputJson {
+            version: CLI_VERSION.to_string(),
+            commands: json_doc,
+        };
+        let pretty_json = serde_json::to_string_pretty(&output)?;
         println!("{}", pretty_json);
         Ok(())
     }


### PR DESCRIPTION
Adding package version to `cli.json` as per #129.

For parity between the `cli` and `api` specs — and also lets us show the CLI version in the docs.

Are there any consumers of `cli.json` other than the docs site that might be affected by this?