### PR TITLE
Fix pull_request workflows not running on bot commits

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Update pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ inputs.reflector_access_token }}
         run: |
           git checkout integration
           git pull origin integration


### PR DESCRIPTION
* Update GitHub CLI authentication to use the Reflector supplied access token instead of the default GitHub Actions supplied token

Events triggered by the GitHub Actions bot do not trigger workflows. Despite commits being made by Reflector bot, the pull request was being created / updated by the GitHub Actions bot resulting in the `pull_request` event being attributed to the GitHub Actions bot. This change moves all attribution to the Reflector bot