### PR TITLE
Only support "most-recent" context bytes in serial stream.

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1116,11 +1116,6 @@
               "about": "Connect to an instance's serial console interactively.",
               "args": [
                 {
-                  "long": "byte-offset",
-                  "short": "b",
-                  "help": "The offset since boot (or if negative, the current end of the buffered data) from which to retrieve output history"
-                },
-                {
                   "long": "escape-prefix-length",
                   "help": "The number of bytes from the beginning of the escape string to pass to the VM before beginning to buffer inputs until a mismatch. Defaults to 0, such that input matching the escape string does not get sent to the VM at all until a non-matching character is typed. For example, to mimic the escape sequence for exiting SSH (\"\\n~.\"), you may pass `-e '^M~.' --escape-prefix-length=1` such that newline gets sent to the VM immediately while still continuing to match the rest of the sequence"
                 },
@@ -1133,6 +1128,11 @@
                   "long": "instance",
                   "short": "i",
                   "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "most-recent",
+                  "short": "m",
+                  "help": "The number of bytes from the most recent output to retrieve as context before connecting to the interactive session directly"
                 },
                 {
                   "long": "project",

--- a/cli/tests/test_instance.rs
+++ b/cli/tests/test_instance.rs
@@ -132,7 +132,7 @@ fn test_instance_serial_console() {
         .arg("miniwheats")
         .arg("--project")
         .arg("influences")
-        .arg("--byte-offset=-3")
+        .arg("--most-recent=3")
         .assert()
         .failure()
         .stdout(pred);


### PR DESCRIPTION
Removal of an API footgun, as use of the `from_start` query parameter really only makes sense for the `serial history` query command, not the continuous websocket connection.

Eventually over an instance's lifespan, it makes less sense for a client connecting to try asking for bytes starting from the beginning of time, as we don't buffer everything forever and this eventually becomes impossible to satisfy.

(explanation in this comment https://github.com/oxidecomputer/propolis/issues/409#issuecomment-1552351154 - a bug encountered while investigating what is likely an unrelated issue)