### PR TITLE
Merge strategy for integration workflow

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -49,7 +49,7 @@ jobs:
             git checkout main -- sdk-httpmock/src/generated_httpmock.rs
 
             # Commit the merge
-            git commit -m 'Merge branch 'main' into integration and reset generated code'
+            git commit -m "Merge branch 'main' into integration and reset generated code"
           fi
 
           # Ensure there are no outstanding conflicts

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -35,17 +35,22 @@ jobs:
       # branch
       - name: Merge main
         run: |
+          MERGE_STATUS=0
           git checkout integration
-          git merge main || echo 'Found conflicts. Attempt to use changes from main'
+          git merge main || MERGE_STATUS=$? && echo 'Found conflicts. Attempt to use changes from main'
 
-          # Reset generated files
-          git checkout main -- cli/docs/cli.json
-          git checkout main -- cli/src/generated_cli.rs
-          git checkout main -- sdk/src/generated_sdk.rs
-          git checkout main -- sdk-httpmock/src/generated_httpmock.rs
+          # If there was a merge conflict attempt to reset the generated files and commit them back
+          if [ $MERGE_STATUS -eq 1 ]
+          then
+            # Reset generated files
+            git checkout main -- cli/docs/cli.json
+            git checkout main -- cli/src/generated_cli.rs
+            git checkout main -- sdk/src/generated_sdk.rs
+            git checkout main -- sdk-httpmock/src/generated_httpmock.rs
 
-          # Commit the merge
-          git commit -m 'Merge main'
+            # Commit the merge
+            git commit -m 'Merge branch 'main' into integration and reset generated code'
+          fi
 
           # Ensure there are no outstanding conflicts
           STATUS=$(git status --porcelain=v1 2>/dev/null | wc -l)

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,33 +23,36 @@ jobs:
       group: integration
       cancel-in-progress: true
     runs-on: ubuntu-22.04
+    env:
+      INT_BRANCH: integration
+      TARGET_BRANCH: main
     steps:
 
-      # Checkout both the main and integration branches
+      # Checkout both the target and integration branches
       - uses: actions/checkout@v3.5.0
         with:
           token: ${{ inputs.reflector_access_token }}
           fetch-depth: 0
 
-      # Attempt to merge main in to integration. Discarding any generated code on the integration
-      # branch
-      - name: Merge main
+      # Attempt to merge target branch in to integration branch. Discarding any generated code on
+      # the integration branch
+      - name: Merge target
         run: |
           MERGE_STATUS=0
-          git checkout integration
-          git merge main || MERGE_STATUS=$? && echo 'Found conflicts. Attempt to use changes from main'
+          git checkout $INT_BRANCH
+          git merge $TARGET_BRANCH || MERGE_STATUS=$? && echo 'Found conflicts. Attempt to use changes from $TARGET_BRANCH'
 
           # If there was a merge conflict attempt to reset the generated files and commit them back
           if [ $MERGE_STATUS -eq 1 ]
           then
             # Reset generated files
-            git checkout main -- cli/docs/cli.json
-            git checkout main -- cli/src/generated_cli.rs
-            git checkout main -- sdk/src/generated_sdk.rs
-            git checkout main -- sdk-httpmock/src/generated_httpmock.rs
+            git checkout $TARGET_BRANCH -- cli/docs/cli.json
+            git checkout $TARGET_BRANCH -- cli/src/generated_cli.rs
+            git checkout $TARGET_BRANCH -- sdk/src/generated_sdk.rs
+            git checkout $TARGET_BRANCH -- sdk-httpmock/src/generated_httpmock.rs
 
             # Commit the merge
-            git commit -m "Merge branch 'main' into integration and reset generated code"
+            git commit -m "Merge branch '$TARGET_BRANCH' into $INT_BRANCH and reset generated code"
           fi
 
           # Ensure there are no outstanding conflicts
@@ -132,37 +135,34 @@ jobs:
 
           git add .
           git commit -m "Rebuilt with latest dependency updates" || echo "Nothing to commit"
-          git push origin integration
+          git push origin $INT_BRANCH
         id: committed
 
       - name: Update pull request
         env:
           GH_TOKEN: ${{ inputs.reflector_access_token }}
         run: |
-          mainToIntegration="$(git rev-list --count main..integration)"
-          integrationToMain="$(git rev-list --count integration..main)"
+          # Compare the integration branch with the target branch
+          TARGET_TO_INT="$(git rev-list --count $TARGET_BRANCH..$INT_BRANCH)"
+          INT_TO_TARGET="$(git rev-list --count $INT_BRANCH..$TARGET_BRANCH)"
 
-          prUrl=$(gh search prs --head integration --base main --state open --repo $GITHUB_REPOSITORY --json url --jq .[].url)
+          # Check for an existing pull request from the integration branch to the target branch
+          eval $(gh pr view $INT_BRANCH --repo $GITHUB_REPOSITORY --json url,number,state | jq -r 'to_entries[] | "\(.key | ascii_upcase)=\(.value)"')
+          HASPR=0
+          [ "$NUMBER" != "" ] && [ "$BASEREFNAME" == "$TARGET_BRANCH" ] || HASPR=$?
 
-          # Sleep to help prevent GitHub cli from tripping over itself
-          sleep 2
-
-          prNumber=$(gh search prs --head integration --base main --state open --repo $GITHUB_REPOSITORY --json number --jq .[].number)
-
-          sleep 2
-
-          if [ "$mainToIntegration" -eq 0 -a "$integrationToMain" -eq 0 ]
+          if [ "$TARGET_TO_INT" -eq 0 -a "$INT_TO_TARGET" -eq 0 ]
           then
-            echo "Main is up to date with integration. No pull request needed"
+            echo "$TARGET_BRANCH is up to date with $INT_BRANCH. No pull request needed"
 
-            if [ "$prNumber" != "" ]
+            if [ "$HASPR" -eq 0 -a "$NUMBER" != "" ]
             then
               echo "Closing existing PR"
-              gh pr close $prNumber
+              gh pr close $NUMBER
             fi
-          elif [ "$mainToIntegration" -gt 0 ]
+          elif [ "$TARGET_TO_INT" -gt 0 ]
           then
-            echo "Main is behind integration ($mainToIntegration)"
+            echo "$TARGET_BRANCH is behind $INT_BRANCH ($TARGET_TO_INT)"
 
             title=""
             echo "" > body
@@ -207,14 +207,14 @@ jobs:
 
             title="Bump${title}"
 
-            if [ -z "$prNumber" ]
+            if [ -z "$NUMBER" -o "$STATE" != "OPEN" ]
             then
-              gh pr create -B main -H integration --title "$title" --body-file body
+              gh pr create -B $TARGET_BRANCH -H $INT_BRANCH --title "$title" --body-file body
             else
-              echo "PR already exists: ($prNumber) $prUrl . Updating..."
-              gh pr edit "$prNumber" --title "$title" --body-file body
+              echo "PR already exists: ($NUMBER) $URL . Updating..."
+              gh pr edit "$NUMBER" --title "$title" --body-file body
             fi
           else
-            echo "Integration is behind main ($integrationToMain). This is likely an error"
+            echo "$INT_BRANCH is behind $TARGET_BRANCH ($INT_TO_TARGET). This is likely an error"
             exit 1
           fi

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -24,10 +24,41 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     steps:
+
+      # Checkout both the main and integration branches
       - uses: actions/checkout@v3.5.0
         with:
           token: ${{ inputs.reflector_access_token }}
-          ref: main
+          fetch-depth: 0
+
+      # Attempt to merge main in to integration. Discarding any generated code on the integration
+      # branch
+      - name: Merge main
+        run: |
+          git checkout integration
+          git merge main || echo 'Found conflicts. Attempt to use changes from main'
+
+          # Reset generated files
+          git checkout main -- cli/docs/cli.json
+          git checkout main -- cli/src/generated_cli.rs
+          git checkout main -- sdk/src/generated_sdk.rs
+          git checkout main -- sdk-httpmock/src/generated_httpmock.rs
+
+          # Commit the merge
+          git commit -m 'Merge main'
+
+          # Ensure there are no outstanding conflicts
+          STATUS=$(git status --porcelain=v1 2>/dev/null | wc -l)
+          if [ $STATUS -eq 0 ]
+          then
+            exit 0
+          else
+            echo 'Found additional conflicts from merge attempt that need to be manually resolved'
+            git status
+            exit 1
+          fi
+
+      # Configure Rust tools
       - name: Install nightly rustfmt
         uses: actions-rs/toolchain@v1
         with:
@@ -96,18 +127,13 @@ jobs:
 
           git add .
           git commit -m "Rebuilt with latest dependency updates" || echo "Nothing to commit"
-          git push origin main:integration --force
-          # Reset back to the original main
-          git reset --hard origin/main
+          git push origin integration
         id: committed
 
       - name: Update pull request
         env:
           GH_TOKEN: ${{ inputs.reflector_access_token }}
         run: |
-          git checkout integration
-          git pull origin integration
-
           mainToIntegration="$(git rev-list --count main..integration)"
           integrationToMain="$(git rev-list --count integration..main)"
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -39,12 +39,14 @@ jobs:
       - name: Merge target
         run: |
           MERGE_STATUS=0
-          git checkout $INT_BRANCH
-          git merge $TARGET_BRANCH || MERGE_STATUS=$? && echo 'Found conflicts. Attempt to use changes from $TARGET_BRANCH'
+          git checkout $INT_BRANCH 2>/dev/null || git checkout -b $INT_BRANCH
+          git merge $TARGET_BRANCH || MERGE_STATUS=$?
 
           # If there was a merge conflict attempt to reset the generated files and commit them back
           if [ $MERGE_STATUS -eq 1 ]
           then
+            echo "Found conflicts. Attempt to use changes from $TARGET_BRANCH"
+
             # Reset generated files
             git checkout $TARGET_BRANCH -- cli/docs/cli.json
             git checkout $TARGET_BRANCH -- cli/src/generated_cli.rs
@@ -119,23 +121,23 @@ jobs:
           git config --local user.name "oxide-reflector-bot[bot]"
           git config --local user.email "${{ inputs.reflector_user_id }}+oxide-reflector-bot[bot]@users.noreply.github.com"
 
-          # Detect specific changes that will be committed back
-
-          # Check if the spec file has been updated
-          git diff --quiet oxide.json || specUpdate=$?
-          echo "spec=${specUpdate}" >> $GITHUB_OUTPUT
-
-          # Check if the generated docs spec file has been updated
-          git diff --quiet cli/docs/cli.json || docsUpdate=$?
-          echo "docs=${docsUpdate}" >> $GITHUB_OUTPUT
-
-          # Check if anything in the lock file has updated
-          git diff --quiet Cargo.lock || depsUpdate=$?
-          echo "deps=${depsUpdate}" >> $GITHUB_OUTPUT
-
           git add .
           git commit -m "Rebuilt with latest dependency updates" || echo "Nothing to commit"
           git push origin $INT_BRANCH
+
+          # Detect changes to report back
+
+          # Check if the spec file has been updated
+          git diff $TARGET_BRANCH...$INT_BRANCH --quiet oxide.json || specUpdate=$?
+          echo "spec=${specUpdate}" >> $GITHUB_OUTPUT
+
+          # Check if the generated docs spec file has been updated
+          git diff $TARGET_BRANCH...$INT_BRANCH --quiet cli/docs/cli.json || docsUpdate=$?
+          echo "docs=${docsUpdate}" >> $GITHUB_OUTPUT
+
+          # Check if anything in the lock file has updated
+          git diff $TARGET_BRANCH...$INT_BRANCH --quiet Cargo.lock || depsUpdate=$?
+          echo "deps=${depsUpdate}" >> $GITHUB_OUTPUT
         id: committed
 
       - name: Update pull request


### PR DESCRIPTION
Changes the way the `integration` branch gets updated. Previously this workflow would take the latest from `main`, apply schema and Cargo updates, and then force push those changes to `integration`. This change instead now merges `main` into `integration` (and specifically uses the generated code from `main` in the case of conflicts) as the first step. Updates are then applied over top of the merged branch.

There is a chance for this action to fail if there are conflicts in non-generated files and those would need to be manually resolved.