### PR TITLE
support --resolve for name resolution and --cacert to specify a ca cert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,7 +1894,6 @@ dependencies = [
  "futures",
  "http",
  "httpmock",
- "hyper",
  "indicatif",
  "log",
  "oauth2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+]
+
+[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +293,17 @@ name = "atomic-waker"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -386,6 +419,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-lock"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,7 +471,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -537,6 +579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -742,6 +794,60 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dropshot"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46371d019d9f68266b236f22d7d25bb81e52cc012ad948ec0342990b1ea449e3"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.21.2",
+ "bytes",
+ "camino",
+ "chrono",
+ "dropshot_endpoint",
+ "futures",
+ "hostname",
+ "http",
+ "hyper",
+ "indexmap",
+ "openapiv3",
+ "paste",
+ "percent-encoding",
+ "proc-macro2",
+ "rustls 0.20.8",
+ "rustls-pemfile",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1",
+ "slog",
+ "slog-async",
+ "slog-bunyan",
+ "slog-json",
+ "slog-term",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "toml 0.5.11",
+ "uuid",
+ "version_check",
+]
+
+[[package]]
+name = "dropshot_endpoint"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe7bfbce8f473f4683ca5241c6153dc19bb186863a5f59f6eb7a58ca67dfe6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream 0.1.7",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -1098,6 +1204,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -1117,6 +1232,17 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
  "winapi",
 ]
 
@@ -1190,9 +1316,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1220,9 +1346,9 @@ checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.1",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -1546,6 +1672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1747,11 +1888,13 @@ dependencies = [
  "clap",
  "dialoguer",
  "dirs",
+ "dropshot",
  "env_logger",
  "expectorate",
  "futures",
  "http",
  "httpmock",
+ "hyper",
  "indicatif",
  "log",
  "oauth2",
@@ -1761,6 +1904,7 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "rand",
+ "rcgen",
  "reqwest",
  "schemars",
  "serde",
@@ -1838,10 +1982,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2067,7 +2226,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_tokenstream",
+ "serde_tokenstream 0.2.0",
  "serde_yaml",
  "syn 2.0.11",
 ]
@@ -2109,6 +2268,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.22",
+ "yasna",
 ]
 
 [[package]]
@@ -2204,14 +2375,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -2277,6 +2448,18 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.3.1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -2510,6 +2693,17 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
+dependencies = [
+ "proc-macro2",
+ "serde",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "serde_tokenstream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a00ffd23fd882d096f09fcaae2a9de8329a328628e86027e049ee051dc1621f"
@@ -2639,6 +2833,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-async"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "766c59b252e62a34651412870ff55d8c4e6d04df19b43eecb2703e417b097ffe"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-bunyan"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440fd32d0423c31e4f98d76c0b62ebdb847f905aa07357197e9b41ac620af97d"
+dependencies = [
+ "hostname",
+ "slog",
+ "slog-json",
+ "time 0.3.22",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
+dependencies = [
+ "serde",
+ "serde_json",
+ "slog",
+ "time 0.3.22",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+dependencies = [
+ "atty",
+ "slog",
+ "term",
+ "thread_local",
+ "time 0.3.22",
+]
+
+[[package]]
 name = "sluice"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2969,12 @@ checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
@@ -2807,6 +3062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +3080,35 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -2883,11 +3177,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.8",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls",
+ "rustls 0.21.1",
  "tokio",
 ]
 
@@ -3089,7 +3394,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_tokenstream",
+ "serde_tokenstream 0.2.0",
  "syn 2.0.11",
  "typify-impl",
 ]
@@ -3575,6 +3880,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time 0.3.22",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4.26", features = ["serde"] }
 clap = { version = "4.3", features = ["derive", "string", "env"] }
 dialoguer = "0.10.4"
 dirs = "4.0.0"
+dropshot = "0.9.0"
 env_logger = "0.10.0"
 # TODO need a new expectorate release after we're happy with it
 #expectorate = { version = "1.0.8", features = ["predicates"] }
@@ -36,6 +37,7 @@ pretty_assertions = "1.3.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
 rand = "0.8.5"
+rcgen = "0.10.0"
 regex = "1.8.4"
 regress = "0.6.0"
 reqwest = "0.11.18"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,6 +20,8 @@ dirs = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+# TODO remove
+hyper = "0.14.26"
 indicatif = { workspace = true }
 log = { workspace = true }
 oauth2 = { workspace = true }
@@ -41,11 +43,13 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+dropshot = { workspace = true }
 expectorate = { workspace = true }
 httpmock = { workspace = true }
 oxide-httpmock = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }
+rcgen = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 serial_test = { workspace = true }
 tempfile = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,8 +20,6 @@ dirs = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
-# TODO remove
-hyper = "0.14.26"
 indicatif = { workspace = true }
 log = { workspace = true }
 oauth2 = { workspace = true }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -3,10 +3,20 @@
   "version": "0.1.0",
   "args": [
     {
-      "long": "config-dir"
+      "long": "cacert",
+      "help": "Specify a trusted CA cert"
     },
     {
-      "long": "debug"
+      "long": "config-dir",
+      "help": "Directory to use for configuration"
+    },
+    {
+      "long": "debug",
+      "help": "Enable debug output"
+    },
+    {
+      "long": "resolve",
+      "help": "Modify name resolution"
     }
   ],
   "subcommands": [

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -12,9 +12,13 @@ use serde::{Deserialize, Serialize};
 use toml_edit::{Item, Table};
 use uuid::Uuid;
 
+use crate::cli_builder::ResolveValue;
+
 pub struct Config {
     pub client_id: Uuid,
     pub hosts: Hosts,
+    pub resolve: Option<ResolveValue>,
+    pub cert: Option<reqwest::Certificate>,
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]
@@ -63,6 +67,8 @@ impl Config {
         Self {
             client_id: Default::default(),
             hosts,
+            resolve: None,
+            cert: None,
         }
     }
 
@@ -101,5 +107,15 @@ impl Config {
         std::fs::write(hosts_path, hosts.to_string())?;
 
         Ok(())
+    }
+
+    pub fn with_resolve(mut self, resolve: ResolveValue) -> Self {
+        self.resolve = Some(resolve);
+        self
+    }
+
+    pub fn with_cert(mut self, cert: reqwest::Certificate) -> Self {
+        self.cert = Some(cert);
+        self
     }
 }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -57,25 +57,6 @@ fn get_client(config: &Config) -> Result<Option<Client>> {
     };
 
     Ok(Some(make_client(&host, token, config)))
-
-    // // TODO use make_client()
-    // let auth = format!("Bearer {}", token);
-    // let mut auth_value = reqwest::header::HeaderValue::from_str(&auth)?;
-    // auth_value.set_sensitive(true);
-
-    // let dur = std::time::Duration::from_secs(15);
-    // let rclient = reqwest::Client::builder()
-    //     .connect_timeout(dur)
-    //     .timeout(dur)
-    //     .default_headers(
-    //         [(http::header::AUTHORIZATION, auth_value)]
-    //             .into_iter()
-    //             .collect(),
-    //     )
-    //     .build()
-    //     .unwrap();
-    // let client = oxide_api::Client::new_with_client(&host, rclient);
-    // Ok(Some(client))
 }
 
 pub fn make_client(host: &str, token: String, config: &Config) -> Client {

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -4,10 +4,14 @@
 
 // Copyright 2023 Oxide Computer Company
 
-use anyhow::{anyhow, Result};
-use oxide_api::Client;
+use std::{net::SocketAddr, time::Duration};
 
-use crate::config::Config;
+use anyhow::{anyhow, Result};
+use http::{HeaderMap, HeaderValue};
+use oxide_api::Client;
+use reqwest::ClientBuilder;
+
+use crate::{cli_builder::ResolveValue, config::Config};
 
 pub struct Context {
     client: Option<Client>,
@@ -52,22 +56,46 @@ fn get_client(config: &Config) -> Result<Option<Client>> {
         }
     };
 
-    // TODO use make_client()
-    let auth = format!("Bearer {}", token);
-    let mut auth_value = reqwest::header::HeaderValue::from_str(&auth)?;
-    auth_value.set_sensitive(true);
+    Ok(Some(make_client(&host, token, config)))
 
-    let dur = std::time::Duration::from_secs(15);
-    let rclient = reqwest::Client::builder()
-        .connect_timeout(dur)
-        .timeout(dur)
-        .default_headers(
-            [(http::header::AUTHORIZATION, auth_value)]
-                .into_iter()
-                .collect(),
-        )
-        .build()
-        .unwrap();
-    let client = oxide_api::Client::new_with_client(&host, rclient);
-    Ok(Some(client))
+    // // TODO use make_client()
+    // let auth = format!("Bearer {}", token);
+    // let mut auth_value = reqwest::header::HeaderValue::from_str(&auth)?;
+    // auth_value.set_sensitive(true);
+
+    // let dur = std::time::Duration::from_secs(15);
+    // let rclient = reqwest::Client::builder()
+    //     .connect_timeout(dur)
+    //     .timeout(dur)
+    //     .default_headers(
+    //         [(http::header::AUTHORIZATION, auth_value)]
+    //             .into_iter()
+    //             .collect(),
+    //     )
+    //     .build()
+    //     .unwrap();
+    // let client = oxide_api::Client::new_with_client(&host, rclient);
+    // Ok(Some(client))
+}
+
+pub fn make_client(host: &str, token: String, config: &Config) -> Client {
+    let mut bearer = HeaderValue::from_str(format!("Bearer {}", token).as_str()).unwrap();
+    bearer.set_sensitive(true);
+    let mut headers = HeaderMap::new();
+    headers.insert(http::header::AUTHORIZATION, bearer);
+
+    let mut client_builder = ClientBuilder::new()
+        .connect_timeout(Duration::from_secs(15))
+        .default_headers(headers);
+
+    if let Some(ResolveValue { host, port, addr }) = &config.resolve {
+        client_builder = client_builder.resolve(host, SocketAddr::new(*addr, *port));
+    }
+    if let Some(cert) = &config.cert {
+        client_builder = client_builder.add_root_certificate(cert.clone());
+    }
+
+    let rclient = client_builder.build().unwrap();
+
+    Client::new_with_client(host, rclient)
 }

--- a/cli/tests/test_resolve_cert.rs
+++ b/cli/tests/test_resolve_cert.rs
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! This test involves starting a dropshot server in order to validate
+//! TLS certificates. This mechanism should not be copied! Instead use httpmock
+//! or--better--generated mocks from the local sdk-httpmock crate.
+
+use assert_cmd::Command;
+use dropshot::{
+    endpoint, ApiDescription, ConfigDropshot, ConfigLogging, ConfigLoggingLevel, ConfigTls,
+    HttpError, HttpResponseUpdatedNoContent, HttpServerStarter, RequestContext,
+};
+
+#[endpoint {
+    method = GET,
+    path = "/aok"
+}]
+async fn aok(_: RequestContext<()>) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+#[tokio::test]
+async fn test_resolve_and_cacert() {
+    const HOSTNAME: &str = "fake.cloud.oxide.computer";
+    let cert = rcgen::generate_simple_self_signed(vec![HOSTNAME.to_string()]).unwrap();
+
+    let mut api = ApiDescription::new();
+    api.register(aok).unwrap();
+
+    let tempdir = tempfile::tempdir().unwrap();
+
+    let log = ConfigLogging::StderrTerminal {
+        level: ConfigLoggingLevel::Critical,
+    }
+    .to_logger("test")
+    .unwrap();
+
+    let cert_path = tempdir.path().join("cert.pem");
+    std::fs::write(cert_path.clone(), cert.serialize_pem().unwrap()).unwrap();
+
+    let key_path = tempdir.path().join("key.pem");
+    std::fs::write(key_path.clone(), cert.serialize_private_key_pem()).unwrap();
+
+    let server = HttpServerStarter::new(
+        &ConfigDropshot {
+            bind_address: "127.0.0.1:0".parse().unwrap(),
+            request_body_max_bytes: 1024,
+            tls: Some(ConfigTls::AsFile {
+                cert_file: cert_path.clone(),
+                key_file: key_path,
+            }),
+        },
+        api,
+        (),
+        &log,
+    )
+    .map_err(|error| format!("failed to start server: {}", error))
+    .unwrap()
+    .start();
+
+    let addr = server.local_addr();
+
+    // This is non-async, blocking code so we need to shove it into its own
+    // task. We're just looking for the command to succeed.
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("oxide")
+            .unwrap()
+            .env(
+                "OXIDE_HOST",
+                format!("https://{}:{}", HOSTNAME, addr.port()),
+            )
+            .env("OXIDE_TOKEN", "fake-token")
+            .arg("--resolve")
+            .arg(format!("{}:{}:{}", HOSTNAME, addr.port(), addr.ip()))
+            .arg("--cacert")
+            .arg(cert_path)
+            .arg("api")
+            .arg("/aok")
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    server.close().await.unwrap();
+}


### PR DESCRIPTION
Fixes #193 

This adds two top-level options `--resolve` and `--cacert` both modeled after curl's eponymous options.

Note that --resolve takes a tuple of HOSTNAME:PORT:IPADDR and the PORT is actually ignored. I thought it was better to match curl approximately, but it might be better to just have HOSTNAME:IPADDR.