### PR TITLE
update ubuntu build to 22.04 at least for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         - os: macos-11
           dist-args: --artifacts=local --target=aarch64-apple-darwin --target=x86_64-apple-darwin
           install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.7/cargo-dist-installer.sh | sh
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           dist-args: --artifacts=local --target=x86_64-unknown-linux-gnu
           install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.7/cargo-dist-installer.sh | sh
         - os: windows-2019

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "oxide"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "oxide-api"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "base64 0.21.2",
  "chrono",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "oxide-httpmock"
-version = "0.1.0"
+version = "0.2.0-beta.2"
 dependencies = [
  "chrono",
  "httpmock",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oxide"
 description = "CLI for the Oxide rack"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/oxidecomputer/oxide.rs"

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1,6 +1,6 @@
 {
   "name": "oxide",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "args": [
     {
       "long": "cacert",

--- a/sdk-httpmock/Cargo.toml
+++ b/sdk-httpmock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oxide-httpmock"
 description = "httpmock for the Oxide rack API"
-version = "0.1.0"
+version = "0.2.0-beta.2"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/oxidecomputer/oxide.rs"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oxide-api"
 description = "SDK for the Oxide rack"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/oxidecomputer/oxide.rs"


### PR DESCRIPTION
Related to #295, but for a more durable fix we may want to use the openssl crates's vendored feature flag: https://docs.rs/openssl/latest/openssl/#vendored