### PR TITLE
Reset the lock file prior to updates

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -56,6 +56,9 @@ jobs:
             git checkout $TARGET_BRANCH -- sdk/src/generated_sdk.rs
             git checkout $TARGET_BRANCH -- sdk-httpmock/src/generated_httpmock.rs
 
+            # Always reset the Cargo.lock. It will be updated later
+            git checkout $TARGET_BRANCH -- Cargo.lock
+
             # Commit the merge
             git commit -m "Merge branch '$TARGET_BRANCH' into $INT_BRANCH and reset generated code"
           fi


### PR DESCRIPTION
If the Cargo.lock file changes on `main` it is very easy to get unhandled conflicts with the lock file on `integration`. Since we update the lock file during the `cargo update` step, it is safe to simply use the lock file from `main` during the initial merge.