### PR TITLE
Add instance from-image command

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -898,6 +898,48 @@
           ]
         },
         {
+          "name": "from-image",
+          "about": "Launch an instance from a disk image.",
+          "args": [
+            {
+              "long": "cpus",
+              "help": "Number of CPUs"
+            },
+            {
+              "long": "description",
+              "help": "Description of the instance to create"
+            },
+            {
+              "long": "disk-size",
+              "help": "Boot disk size e.g. 512G. Suffix can be k,m,g,t"
+            },
+            {
+              "long": "hostname",
+              "help": "Hostname of the instance to create"
+            },
+            {
+              "long": "image",
+              "help": "Image name"
+            },
+            {
+              "long": "memory",
+              "help": "Ammount of memory e.g 32M. Suffix can be k,m,g,t"
+            },
+            {
+              "long": "name",
+              "help": "Name of the instance to create"
+            },
+            {
+              "long": "project",
+              "help": "Project to create the instance in"
+            },
+            {
+              "long": "start",
+              "help": "Start the instance immediately"
+            }
+          ]
+        },
+        {
           "name": "list",
           "about": "List instances",
           "args": [

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -689,10 +689,9 @@ mod tests {
         ));
 
         // Nonsense scheme
-        assert!(matches!(
-            parse_host("ftp://localhost").map(|host| host.to_string()),
-            Err(_)
-        ));
+        assert!(parse_host("ftp://localhost")
+            .map(|host| host.to_string())
+            .is_err());
 
         // Strip out any extraneous pieces we don't need
         assert!(matches!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,7 +20,7 @@ mod cmd_api;
 mod cmd_auth;
 mod cmd_disk;
 mod cmd_docs;
-mod cmd_instance_serial;
+mod cmd_instance;
 
 mod cmd_version;
 mod config;
@@ -43,7 +43,8 @@ pub fn make_cli() -> NewCli<'static> {
         .add_custom::<cmd_docs::CmdDocs>("docs")
         .add_custom::<cmd_version::CmdVersion>("version")
         .add_custom::<cmd_disk::CmdDiskImport>("disk import")
-        .add_custom::<cmd_instance_serial::CmdInstanceSerial>("instance serial")
+        .add_custom::<cmd_instance::CmdInstanceSerial>("instance serial")
+        .add_custom::<cmd_instance::CmdInstanceFromImage>("instance from-image")
 }
 
 #[tokio::main]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -163,10 +163,10 @@ fn format_code(code: String) -> String {
 
     // Add newlines after end-braces at <= two levels of indentation. Rustfmt's
     // `blank_lines_lower_bound` is broken.
-    let regex = regex::Regex::new(r#"(})(\n\s{0,8}[^} ])"#).unwrap();
+    let regex = regex::Regex::new(r"(})(\n\s{0,8}[^} ])").unwrap();
     let contents = regex.replace_all(&contents, "$1\n$2");
 
-    let regex = regex::Regex::new(r#"(\n\s*///)(\S)"#).unwrap();
+    let regex = regex::Regex::new(r"(\n\s*///)(\S)").unwrap();
     regex.replace_all(&contents, "$1 $2").to_string()
 }
 


### PR DESCRIPTION
I'm starting to use a rack for regular dev. The best I could come up with for creating a new instance from an image is this little puddle of sadness.

```bash
#!/bin/bash

NAME=${NAME:-omicron-dev}
CPUS=${CPUS:-32}
MEM=${MEM:-128}
PROJ=${PROJ:-rydev}
START=${START:-true}
IMAGE=${IMAGE:-jammy}
STORAGE=${STORAGE:-512}

# to GB
let mem=$MEM*1024*1024*1024
image_id=`./oxide image view --project $PROJ --image $IMAGE | grep ' id:' | awk '{print $2}' | sed 's/,//g'`

let stor=$STORAGE*1024*1024*1024

cat << EOF > instance.json
{
  "name": "$NAME",
  "description": "$NAME instance",
  "hostname": "$NAME",
  "memory": $mem,
  "ncpus": $CPUS,
  "disks": [
    {
      "type": "create",
      "name": "$NAME-$IMAGE",
      "description": "$NAME-$IMAGE disk",
      "disk_source": {
          "type": "image",
          "image_id": "$image_id"
      },
      "size": $stor
    }
  ],
  "external_ips": [{"type": "ephemeral"}],
  "start": $START
}
EOF

# https://docs.oxide.computer/guides/managing-instances#_query_or_delete_existing_instances

./oxide instance create \
    --project $PROJ \
    --json-body instance.json
```

So I wrote a custom CLI command that significantly streamlines this common use case.

```bash
./oxide instance from-image \
    --image jammy \
    --name omicron-dev \
    --project rydev \
    --description "omicron-dev instance" \
    --hostname omicron-dev \
    --memory 128g \
    --cpus 32 \
    --disk-size 512g \
    --start
```