### PR TITLE
Print full error chain on failure

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,7 +59,7 @@ async fn main() {
         .await
         .unwrap();
     if let Err(e) = result {
-        eprintln!("{e}");
+        eprintln!("{e:?}");
         std::process::exit(1)
     }
 }


### PR DESCRIPTION
`anyhow::Error`'s debug formatting will print the entire error chain, as opposed to its default display format which only prints the topmost error.

An example failure prior to this PR:

```
bash$ cargo run -- auth login --host https://172.20.27.3/
Request failed
```

and after:

```
bash$ cargo run -- auth login --host https://172.20.27.3/
Request failed

Caused by:
    0: error sending request for url (https://172.20.27.3/device/auth): error trying to connect: error:14094419:SSL routines:ssl3_read_bytes:tlsv1 alert access denied:ssl/record/rec_layer_s3.c:1562:SSL alert number 49
    1: error trying to connect: error:14094419:SSL routines:ssl3_read_bytes:tlsv1 alert access denied:ssl/record/rec_layer_s3.c:1562:SSL alert number 49
    2: error:14094419:SSL routines:ssl3_read_bytes:tlsv1 alert access denied:ssl/record/rec_layer_s3.c:1562:SSL alert number 49
    3: error:14094419:SSL routines:ssl3_read_bytes:tlsv1 alert access denied:ssl/record/rec_layer_s3.c:1562:SSL alert number 49
```

(Perhaps not the _most_ illuminating error chain in this case, but I think it's still worth it?)