### PR TITLE
from-image: disk_size -> size to match API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.65+curl-8.2.1"
+version = "0.4.68+curl-8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961ba061c9ef2fe34bbd12b807152d96f0badd2bebe7b90ce6c8c8b7572a0986"
+checksum = "b4a0d18d88360e374b16b2273c832b5e57258ffc1d4aa4f96b108e0738d5752f"
 dependencies = [
  "cc",
  "libc",
@@ -667,7 +667,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -910,10 +910,6 @@
               "help": "Description of the instance to create"
             },
             {
-              "long": "disk-size",
-              "help": "Boot disk size e.g. 512G. Suffix can be k,m,g,t"
-            },
-            {
               "long": "hostname",
               "help": "Hostname of the instance to create"
             },
@@ -936,6 +932,10 @@
             {
               "long": "project",
               "help": "Project for image and instance"
+            },
+            {
+              "long": "size",
+              "help": "Boot disk size e.g. 512G. Suffix can be k,m,g,t"
             },
             {
               "long": "start",

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -233,7 +233,7 @@ pub struct CmdInstanceFromImage {
 
     /// Boot disk size e.g. 512G. Suffix can be k,m,g,t
     #[clap(long)]
-    disk_size: ByteCount,
+    size: ByteCount,
 
     /// Start the instance immediately
     #[clap(long)]
@@ -266,7 +266,7 @@ impl RunnableCmd for CmdInstanceFromImage {
                         name: format!("{}-disk", *self.name)
                             .parse()
                             .expect("valid disk name"),
-                        size: self.disk_size.clone(),
+                        size: self.size.clone(),
                     }])
                     .external_ips(vec![ExternalIpCreate::Ephemeral { pool_name: None }])
                     .hostname(self.hostname.clone())


### PR DESCRIPTION
Matching the API names means errors correspond to user provided parameters.

- improves #389