### PR TITLE
New issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Let us know about unexpected behaviour when using the CLI or Oxide Rust SDK
+body:
+  - type: checkboxes
+    id: preliminary
+    attributes:
+      label: Preliminary checks
+      description: Please verify the following.
+      options:
+        - label: I am using the latest version, or the latest version that corresponds to my Oxide installation.
+        - label: There is no open issue that reports the same problem.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: source
+    attributes:
+      label: Source of issue
+      description: Is this a problem with the CLI or SDK?
+      options:
+        - label: CLI
+        - label: SDK
+        - label: Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What was the expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is the current behaviour and what actions did you take to get there
+      description: Please provide as much background as you can.
+    validations:
+      required: true
+
+  - type: input
+    id: oxide-version
+    attributes:
+      label: CLI or SDK version
+      description: The version of the component that is exhibiting the problem.
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: What operating system are you using.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else you would like to add?

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Let us know about unexpected behaviour when using the CLI or Oxide Rust SDK
+description: Report unexpected behaviour when using the Oxide CLI or Rust SDK
 body:
   - type: checkboxes
     id: preliminary

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -52,7 +52,7 @@ body:
     id: os
     attributes:
       label: Operating system
-      description: What operating system are you using.
+      description: Under what operating system are you using the CLI or SDK?
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,16 +1,12 @@
 name: Bug report
 description: Report unexpected behaviour when using the Oxide CLI or Rust SDK
 body:
-  - type: checkboxes
-    id: preliminary
+  - type: markdown
     attributes:
-      label: Preliminary checks
-      description: Please verify the following.
-      options:
-        - label: I am using the latest version, or the latest version that corresponds to my Oxide installation.
-        - label: There is no open issue that reports the same problem.
-    validations:
-      required: true
+      value: |
+        Thanks for taking the time to fill out this bug report. Please verify the following:
+        - Check that the version of the CLI or SDK matches that of the Oxide installation.
+        - See if there's already an issue filed for the behavior you're experiencing--there may already be a fix or work-around.
 
   - type: checkboxes
     id: component
@@ -44,7 +40,9 @@ body:
     id: oxide-version
     attributes:
       label: CLI or SDK version
-      description: The version of the component that is exhibiting the problem.
+      description: |
+        The version of the component that is exhibiting the problem. For the CLI, copy
+        the output of `oxide version`. For the SDK, copy the crate version or git commit hash.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -13,13 +13,14 @@ body:
       required: true
 
   - type: checkboxes
-    id: source
+    id: component
     attributes:
-      label: Source of issue
-      description: Is this a problem with the CLI or SDK?
+      label: Component
+      description: Is this a problem with the CLI or SDK (including their documentation)?
       options:
         - label: CLI
         - label: SDK
+        - label: Something else
         - label: Not sure
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -6,10 +6,12 @@ body:
     id: component
     attributes:
       label: Target component
-      description: Which component is this feature request for?
+      description: Is this a feature request for the CLI or SDK (including their documentation)?
       options:
         - label: CLI
         - label: SDK
+        - label: Something else
+        - label: Not sure
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Let us know about something you'd like to see as part of the CLI or Oxide Rust SDK
+labels: ["feature"]
+body:
+  - type: checkboxes
+    id: component
+    attributes:
+      label: Target component
+      description: Which component is this feature request for?
+      options:
+        - label: CLI
+        - label: SDK
+    validations:
+      required: true
+
+  - type: textarea
+    id: overview
+    attributes:
+      label: Overview
+      description: What is it that you would like to be able to do with this feature?
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation details
+      description: Optionally provide an idea of how you'd like this feature to be implemented.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else you would like to add?


### PR DESCRIPTION
Closes: https://github.com/oxidecomputer/oxide.rs/issues/172

Adds templates for bug reports and feature requests similar to those in the oxide.go repo

https://github.com/oxidecomputer/oxide.go/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml

https://github.com/oxidecomputer/oxide.go/issues/new?assignees=&labels=feature&projects=&template=feature_request.yaml