### PR TITLE
have the SDK depend on a published version of progenitor-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
- "progenitor-client",
+ "progenitor-client 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "regress",
  "reqwest",
@@ -2193,10 +2193,25 @@ name = "progenitor"
 version = "0.5.0"
 source = "git+https://github.com/oxidecomputer/progenitor#4625065afd3c4334ce967be4ba3986d348e1dd9f"
 dependencies = [
- "progenitor-client",
+ "progenitor-client 0.5.0 (git+https://github.com/oxidecomputer/progenitor)",
  "progenitor-impl",
  "progenitor-macro",
  "serde_json",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24dd3cac4cd81ac77f90e5a8dcb8c9311c7500c6ce8c65c98ce61a5894672e9"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
- "progenitor-client",
+ "progenitor-client 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "regress",
  "reqwest",
@@ -2193,10 +2193,25 @@ name = "progenitor"
 version = "0.5.0"
 source = "git+https://github.com/oxidecomputer/progenitor#067a5a4a62c2b7e11793b1061fd79c618f0c8b0d"
 dependencies = [
- "progenitor-client",
+ "progenitor-client 0.5.0 (git+https://github.com/oxidecomputer/progenitor)",
  "progenitor-impl",
  "progenitor-macro",
  "serde_json",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24dd3cac4cd81ac77f90e5a8dcb8c9311c7500c6ce8c65c98ce61a5894672e9"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ oxide-httpmock = { path = "sdk-httpmock", version = "0.2.0" }
 predicates = "3.0.4"
 pretty_assertions = "1.4.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor-client = "0.5.0"
 rand = "0.8.5"
 rcgen = "0.10.0"
 regex = "1.10.2"


### PR DESCRIPTION
... so that we can publish the crate.

It would be a bit more robust to either generate the content of `progenitor_client.rs` or to use the published version of `progenitor` as well, but progenitor-client moves slowly enough that this isn't likely to be an issue while progenitor itself is still being updated to support the CLI and SDK.