### PR TITLE
Add `oxide instance external-ip attach/detach`

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -599,6 +599,39 @@
       "name": "floating-ip",
       "subcommands": [
         {
+          "name": "attach",
+          "about": "Attach a floating IP to an instance or other resource",
+          "args": [
+            {
+              "long": "floating-ip",
+              "help": "Name or ID of the floating IP"
+            },
+            {
+              "long": "json-body",
+              "help": "Path to a file that contains the full json body."
+            },
+            {
+              "long": "json-body-template",
+              "help": "XXX"
+            },
+            {
+              "long": "kind",
+              "values": [
+                "instance"
+              ],
+              "help": "The type of `parent`'s resource"
+            },
+            {
+              "long": "parent",
+              "help": "Name or ID of the resource that this IP address should be attached to"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
           "name": "create",
           "about": "Create a floating IP",
           "args": [
@@ -636,7 +669,21 @@
           "args": [
             {
               "long": "floating-ip",
-              "help": "Name or ID of the Floating IP"
+              "help": "Name or ID of the floating IP"
+            },
+            {
+              "long": "project",
+              "help": "Name or ID of the project"
+            }
+          ]
+        },
+        {
+          "name": "detach",
+          "about": "Detach a floating IP from an instance or other resource",
+          "args": [
+            {
+              "long": "floating-ip",
+              "help": "Name or ID of the floating IP"
             },
             {
               "long": "project",
@@ -672,7 +719,7 @@
           "args": [
             {
               "long": "floating-ip",
-              "help": "Name or ID of the Floating IP"
+              "help": "Name or ID of the floating IP"
             },
             {
               "long": "project",
@@ -972,6 +1019,46 @@
         {
           "name": "external-ip",
           "subcommands": [
+            {
+              "name": "attach-ephemeral",
+              "about": "Allocate and attach an ephemeral IP to an instance",
+              "args": [
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "json-body",
+                  "help": "Path to a file that contains the full json body."
+                },
+                {
+                  "long": "json-body-template",
+                  "help": "XXX"
+                },
+                {
+                  "long": "pool",
+                  "help": "Name or ID of the IP pool used to allocate an address"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                }
+              ]
+            },
+            {
+              "name": "detach-ephemeral",
+              "about": "Detach and deallocate an ephemeral IP from an instance",
+              "args": [
+                {
+                  "long": "instance",
+                  "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "project",
+                  "help": "Name or ID of the project"
+                }
+              ]
+            },
             {
               "name": "list",
               "about": "List external IP addresses",

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -278,6 +278,8 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::InstanceStart => Some("instance start"),
         CliCommand::InstanceStop => Some("instance stop"),
         CliCommand::InstanceExternalIpList => Some("instance external-ip list"),
+        CliCommand::InstanceEphemeralIpAttach => Some("instance external-ip attach-ephemeral"),
+        CliCommand::InstanceEphemeralIpDetach => Some("instance external-ip detach-ephemeral"),
 
         CliCommand::ProjectList => Some("project list"),
         CliCommand::ProjectCreate => Some("project create"),
@@ -467,6 +469,8 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::FloatingIpList => Some("floating-ip list"),
         CliCommand::FloatingIpCreate => Some("floating-ip create"),
         CliCommand::FloatingIpDelete => Some("floating-ip delete"),
+        CliCommand::FloatingIpAttach => Some("floating-ip attach"),
+        CliCommand::FloatingIpDetach => Some("floating-ip detach"),
 
         CliCommand::Ping => Some("ping"),
 

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -268,7 +268,7 @@ impl RunnableCmd for CmdInstanceFromImage {
                             .expect("valid disk name"),
                         size: self.size.clone(),
                     }])
-                    .external_ips(vec![ExternalIpCreate::Ephemeral { pool_name: None }])
+                    .external_ips(vec![ExternalIpCreate::Ephemeral { pool: None }])
                     .hostname(self.hostname.clone())
                     .memory(self.memory.clone())
                     .ncpus(self.ncpus.clone())

--- a/cli/src/generated_cli.rs
+++ b/cli/src/generated_cli.rs
@@ -34,6 +34,8 @@ impl Cli {
             CliCommand::FloatingIpCreate => Self::cli_floating_ip_create(),
             CliCommand::FloatingIpView => Self::cli_floating_ip_view(),
             CliCommand::FloatingIpDelete => Self::cli_floating_ip_delete(),
+            CliCommand::FloatingIpAttach => Self::cli_floating_ip_attach(),
+            CliCommand::FloatingIpDetach => Self::cli_floating_ip_detach(),
             CliCommand::GroupList => Self::cli_group_list(),
             CliCommand::GroupView => Self::cli_group_view(),
             CliCommand::ImageList => Self::cli_image_list(),
@@ -50,6 +52,8 @@ impl Cli {
             CliCommand::InstanceDiskAttach => Self::cli_instance_disk_attach(),
             CliCommand::InstanceDiskDetach => Self::cli_instance_disk_detach(),
             CliCommand::InstanceExternalIpList => Self::cli_instance_external_ip_list(),
+            CliCommand::InstanceEphemeralIpAttach => Self::cli_instance_ephemeral_ip_attach(),
+            CliCommand::InstanceEphemeralIpDetach => Self::cli_instance_ephemeral_ip_detach(),
             CliCommand::InstanceMigrate => Self::cli_instance_migrate(),
             CliCommand::InstanceReboot => Self::cli_instance_reboot(),
             CliCommand::InstanceSerialConsole => Self::cli_instance_serial_console(),
@@ -860,7 +864,7 @@ impl Cli {
                     .long("floating-ip")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(true)
-                    .help("Name or ID of the Floating IP"),
+                    .help("Name or ID of the floating IP"),
             )
             .arg(
                 clap::Arg::new("project")
@@ -879,7 +883,7 @@ impl Cli {
                     .long("floating-ip")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(true)
-                    .help("Name or ID of the Floating IP"),
+                    .help("Name or ID of the floating IP"),
             )
             .arg(
                 clap::Arg::new("project")
@@ -889,6 +893,77 @@ impl Cli {
                     .help("Name or ID of the project"),
             )
             .about("Delete a floating IP")
+    }
+
+    pub fn cli_floating_ip_attach() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("floating-ip")
+                    .long("floating-ip")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true)
+                    .help("Name or ID of the floating IP"),
+            )
+            .arg(
+                clap::Arg::new("kind")
+                    .long("kind")
+                    .value_parser(clap::builder::TypedValueParser::map(
+                        clap::builder::PossibleValuesParser::new([
+                            types::FloatingIpParentKind::Instance.to_string(),
+                        ]),
+                        |s| types::FloatingIpParentKind::try_from(s).unwrap(),
+                    ))
+                    .required_unless_present("json-body")
+                    .help("The type of `parent`'s resource"),
+            )
+            .arg(
+                clap::Arg::new("parent")
+                    .long("parent")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required_unless_present("json-body")
+                    .help("Name or ID of the resource that this IP address should be attached to"),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false)
+                    .help("Name or ID of the project"),
+            )
+            .arg(
+                clap::Arg::new("json-body")
+                    .long("json-body")
+                    .value_name("JSON-FILE")
+                    .required(false)
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .help("Path to a file that contains the full json body."),
+            )
+            .arg(
+                clap::Arg::new("json-body-template")
+                    .long("json-body-template")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("XXX"),
+            )
+            .about("Attach a floating IP to an instance or other resource")
+    }
+
+    pub fn cli_floating_ip_detach() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("floating-ip")
+                    .long("floating-ip")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true)
+                    .help("Name or ID of the floating IP"),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false)
+                    .help("Name or ID of the project"),
+            )
+            .about("Detach a floating IP from an instance or other resource")
     }
 
     pub fn cli_group_list() -> clap::Command {
@@ -1379,6 +1454,65 @@ impl Cli {
                     .help("Name or ID of the project"),
             )
             .about("List external IP addresses")
+    }
+
+    pub fn cli_instance_ephemeral_ip_attach() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("instance")
+                    .long("instance")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true)
+                    .help("Name or ID of the instance"),
+            )
+            .arg(
+                clap::Arg::new("pool")
+                    .long("pool")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false)
+                    .help("Name or ID of the IP pool used to allocate an address"),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false)
+                    .help("Name or ID of the project"),
+            )
+            .arg(
+                clap::Arg::new("json-body")
+                    .long("json-body")
+                    .value_name("JSON-FILE")
+                    .required(false)
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .help("Path to a file that contains the full json body."),
+            )
+            .arg(
+                clap::Arg::new("json-body-template")
+                    .long("json-body-template")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("XXX"),
+            )
+            .about("Allocate and attach an ephemeral IP to an instance")
+    }
+
+    pub fn cli_instance_ephemeral_ip_detach() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("instance")
+                    .long("instance")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true)
+                    .help("Name or ID of the instance"),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false)
+                    .help("Name or ID of the project"),
+            )
+            .about("Detach and deallocate an ephemeral IP from an instance")
     }
 
     pub fn cli_instance_migrate() -> clap::Command {
@@ -4930,6 +5064,12 @@ impl<T: CliOverride> Cli<T> {
             CliCommand::FloatingIpDelete => {
                 self.execute_floating_ip_delete(matches).await;
             }
+            CliCommand::FloatingIpAttach => {
+                self.execute_floating_ip_attach(matches).await;
+            }
+            CliCommand::FloatingIpDetach => {
+                self.execute_floating_ip_detach(matches).await;
+            }
             CliCommand::GroupList => {
                 self.execute_group_list(matches).await;
             }
@@ -4977,6 +5117,12 @@ impl<T: CliOverride> Cli<T> {
             }
             CliCommand::InstanceExternalIpList => {
                 self.execute_instance_external_ip_list(matches).await;
+            }
+            CliCommand::InstanceEphemeralIpAttach => {
+                self.execute_instance_ephemeral_ip_attach(matches).await;
+            }
+            CliCommand::InstanceEphemeralIpDetach => {
+                self.execute_instance_ephemeral_ip_detach(matches).await;
             }
             CliCommand::InstanceMigrate => {
                 self.execute_instance_migrate(matches).await;
@@ -6011,6 +6157,68 @@ impl<T: CliOverride> Cli<T> {
         }
     }
 
+    pub async fn execute_floating_ip_attach(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.floating_ip_attach();
+        if let Some(value) = matches.get_one::<types::NameOrId>("floating-ip") {
+            request = request.floating_ip(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::FloatingIpParentKind>("kind") {
+            request = request.body_map(|body| body.kind(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("parent") {
+            request = request.body_map(|body| body.parent(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::FloatingIpAttach>(&body_txt).unwrap();
+            request = request.body(body_value);
+        }
+
+        self.over
+            .execute_floating_ip_attach(matches, &mut request)
+            .unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("error\n{:#?}", r)
+            }
+        }
+    }
+
+    pub async fn execute_floating_ip_detach(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.floating_ip_detach();
+        if let Some(value) = matches.get_one::<types::NameOrId>("floating-ip") {
+            request = request.floating_ip(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
+        }
+
+        self.over
+            .execute_floating_ip_detach(matches, &mut request)
+            .unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("error\n{:#?}", r)
+            }
+        }
+    }
+
     pub async fn execute_group_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.group_list();
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
@@ -6479,6 +6687,64 @@ impl<T: CliOverride> Cli<T> {
 
         self.over
             .execute_instance_external_ip_list(matches, &mut request)
+            .unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("error\n{:#?}", r)
+            }
+        }
+    }
+
+    pub async fn execute_instance_ephemeral_ip_attach(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.instance_ephemeral_ip_attach();
+        if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
+            request = request.instance(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("pool") {
+            request = request.body_map(|body| body.pool(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::EphemeralIpCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
+        }
+
+        self.over
+            .execute_instance_ephemeral_ip_attach(matches, &mut request)
+            .unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("error\n{:#?}", r)
+            }
+        }
+    }
+
+    pub async fn execute_instance_ephemeral_ip_detach(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.instance_ephemeral_ip_detach();
+        if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
+            request = request.instance(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
+        }
+
+        self.over
+            .execute_instance_ephemeral_ip_detach(matches, &mut request)
             .unwrap();
         let result = request.send().await;
         match result {
@@ -10271,6 +10537,22 @@ pub trait CliOverride {
         Ok(())
     }
 
+    fn execute_floating_ip_attach(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::FloatingIpAttach,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn execute_floating_ip_detach(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::FloatingIpDetach,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
     fn execute_group_list(
         &self,
         matches: &clap::ArgMatches,
@@ -10395,6 +10677,22 @@ pub trait CliOverride {
         &self,
         matches: &clap::ArgMatches,
         request: &mut builder::InstanceExternalIpList,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn execute_instance_ephemeral_ip_attach(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::InstanceEphemeralIpAttach,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn execute_instance_ephemeral_ip_detach(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::InstanceEphemeralIpDetach,
     ) -> Result<(), String> {
         Ok(())
     }
@@ -11440,6 +11738,8 @@ pub enum CliCommand {
     FloatingIpCreate,
     FloatingIpView,
     FloatingIpDelete,
+    FloatingIpAttach,
+    FloatingIpDetach,
     GroupList,
     GroupView,
     ImageList,
@@ -11456,6 +11756,8 @@ pub enum CliCommand {
     InstanceDiskAttach,
     InstanceDiskDetach,
     InstanceExternalIpList,
+    InstanceEphemeralIpAttach,
+    InstanceEphemeralIpDetach,
     InstanceMigrate,
     InstanceReboot,
     InstanceSerialConsole,
@@ -11609,6 +11911,8 @@ impl CliCommand {
             CliCommand::FloatingIpCreate,
             CliCommand::FloatingIpView,
             CliCommand::FloatingIpDelete,
+            CliCommand::FloatingIpAttach,
+            CliCommand::FloatingIpDetach,
             CliCommand::GroupList,
             CliCommand::GroupView,
             CliCommand::ImageList,
@@ -11625,6 +11929,8 @@ impl CliCommand {
             CliCommand::InstanceDiskAttach,
             CliCommand::InstanceDiskDetach,
             CliCommand::InstanceExternalIpList,
+            CliCommand::InstanceEphemeralIpAttach,
+            CliCommand::InstanceEphemeralIpDetach,
             CliCommand::InstanceMigrate,
             CliCommand::InstanceReboot,
             CliCommand::InstanceSerialConsole,

--- a/oxide.json
+++ b/oxide.json
@@ -930,7 +930,7 @@
           {
             "in": "path",
             "name": "floating_ip",
-            "description": "Name or ID of the Floating IP",
+            "description": "Name or ID of the floating IP",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -974,7 +974,7 @@
           {
             "in": "path",
             "name": "floating_ip",
-            "description": "Name or ID of the Floating IP",
+            "description": "Name or ID of the floating IP",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -992,6 +992,108 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/floating-ips/{floating_ip}/attach": {
+      "post": {
+        "tags": [
+          "floating-ips"
+        ],
+        "summary": "Attach a floating IP to an instance or other resource",
+        "operationId": "floating_ip_attach",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "floating_ip",
+            "description": "Name or ID of the floating IP",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FloatingIpAttach"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FloatingIp"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/floating-ips/{floating_ip}/detach": {
+      "post": {
+        "tags": [
+          "floating-ips"
+        ],
+        "summary": "Detach a floating IP from an instance or other resource",
+        "operationId": "floating_ip_detach",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "floating_ip",
+            "description": "Name or ID of the floating IP",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FloatingIp"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -1816,6 +1918,99 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/instances/{instance}/external-ips/ephemeral": {
+      "post": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Allocate and attach an ephemeral IP to an instance",
+        "operationId": "instance_ephemeral_ip_attach",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance",
+            "description": "Name or ID of the instance",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EphemeralIpCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalIp"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Detach and deallocate an ephemeral IP from an instance",
+        "operationId": "instance_ephemeral_ip_detach",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance",
+            "description": "Name or ID of the instance",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -10937,6 +11132,21 @@
           }
         ]
       },
+      "EphemeralIpCreate": {
+        "description": "Parameters for creating an ephemeral IP address for an instance.",
+        "type": "object",
+        "properties": {
+          "pool": {
+            "nullable": true,
+            "description": "Name or ID of the IP pool used to allocate an address",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NameOrId"
+              }
+            ]
+          }
+        }
+      },
       "Error": {
         "description": "Error information from a response.",
         "type": "object",
@@ -10957,33 +11167,105 @@
         ]
       },
       "ExternalIp": {
-        "type": "object",
-        "properties": {
-          "ip": {
-            "type": "string",
-            "format": "ip"
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "ip": {
+                "type": "string",
+                "format": "ip"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "ephemeral"
+                ]
+              }
+            },
+            "required": [
+              "ip",
+              "kind"
+            ]
           },
-          "kind": {
-            "$ref": "#/components/schemas/IpKind"
+          {
+            "description": "A Floating IP is a well-known IP address which can be attached and detached from instances.",
+            "type": "object",
+            "properties": {
+              "description": {
+                "description": "human-readable free-form text about a resource",
+                "type": "string"
+              },
+              "id": {
+                "description": "unique, immutable, system-controlled identifier for each resource",
+                "type": "string",
+                "format": "uuid"
+              },
+              "instance_id": {
+                "nullable": true,
+                "description": "The ID of the instance that this Floating IP is attached to, if it is presently in use.",
+                "type": "string",
+                "format": "uuid"
+              },
+              "ip": {
+                "description": "The IP address held by this resource.",
+                "type": "string",
+                "format": "ip"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "floating"
+                ]
+              },
+              "name": {
+                "description": "unique, mutable, user-controlled identifier for each resource",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Name"
+                  }
+                ]
+              },
+              "project_id": {
+                "description": "The project this resource exists within.",
+                "type": "string",
+                "format": "uuid"
+              },
+              "time_created": {
+                "description": "timestamp when this resource was created",
+                "type": "string",
+                "format": "date-time"
+              },
+              "time_modified": {
+                "description": "timestamp when this resource was last modified",
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "description",
+              "id",
+              "ip",
+              "kind",
+              "name",
+              "project_id",
+              "time_created",
+              "time_modified"
+            ]
           }
-        },
-        "required": [
-          "ip",
-          "kind"
         ]
       },
       "ExternalIpCreate": {
         "description": "Parameters for creating an external IP address for instances.",
         "oneOf": [
           {
-            "description": "An IP address providing both inbound and outbound access. The address is automatically-assigned from the provided IP Pool, or all available pools if not specified.",
+            "description": "An IP address providing both inbound and outbound access. The address is automatically-assigned from the provided IP Pool, or the current silo's default pool if not specified.",
             "type": "object",
             "properties": {
-              "pool_name": {
+              "pool": {
                 "nullable": true,
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/Name"
+                    "$ref": "#/components/schemas/NameOrId"
                   }
                 ]
               },
@@ -10999,11 +11281,11 @@
             ]
           },
           {
-            "description": "An IP address providing both inbound and outbound access. The address is an existing Floating IP object assigned to the current project.\n\nThe floating IP must not be in use by another instance or service.",
+            "description": "An IP address providing both inbound and outbound access. The address is an existing floating IP object assigned to the current project.\n\nThe floating IP must not be in use by another instance or service.",
             "type": "object",
             "properties": {
-              "floating_ip_name": {
-                "$ref": "#/components/schemas/Name"
+              "floating_ip": {
+                "$ref": "#/components/schemas/NameOrId"
               },
               "type": {
                 "type": "string",
@@ -11013,7 +11295,7 @@
               }
             },
             "required": [
-              "floating_ip_name",
+              "floating_ip",
               "type"
             ]
           }
@@ -11158,6 +11440,32 @@
           "time_modified"
         ]
       },
+      "FloatingIpAttach": {
+        "description": "Parameters for attaching a floating IP address to another resource",
+        "type": "object",
+        "properties": {
+          "kind": {
+            "description": "The type of `parent`'s resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FloatingIpParentKind"
+              }
+            ]
+          },
+          "parent": {
+            "description": "Name or ID of the resource that this IP address should be attached to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NameOrId"
+              }
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "parent"
+        ]
+      },
       "FloatingIpCreate": {
         "description": "Parameters for creating a new floating IP address for instances.",
         "type": "object",
@@ -11187,6 +11495,13 @@
         "required": [
           "description",
           "name"
+        ]
+      },
+      "FloatingIpParentKind": {
+        "description": "The type of resource that a floating IP is attached to",
+        "type": "string",
+        "enum": [
+          "instance"
         ]
       },
       "FloatingIpResultsPage": {
@@ -12411,14 +12726,6 @@
               "destroyed"
             ]
           }
-        ]
-      },
-      "IpKind": {
-        "description": "The kind of an external IP address for an instance",
-        "type": "string",
-        "enum": [
-          "ephemeral",
-          "floating"
         ]
       },
       "IpNet": {

--- a/sdk-httpmock/src/generated_httpmock.rs
+++ b/sdk-httpmock/src/generated_httpmock.rs
@@ -1616,6 +1616,164 @@ pub mod operations {
         }
     }
 
+    pub struct FloatingIpAttachWhen(httpmock::When);
+    impl FloatingIpAttachWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(regex::Regex::new("^/v1/floating-ips/[^/]*/attach$").unwrap()),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn floating_ip(self, value: &types::NameOrId) -> Self {
+            let re = regex::Regex::new(&format!("^/v1/floating-ips/{}/attach$", value.to_string()))
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+
+        pub fn project<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a types::NameOrId>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("project", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "project"))
+                        .is_none()
+                }))
+            }
+        }
+
+        pub fn body(self, value: &types::FloatingIpAttach) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+
+    pub struct FloatingIpAttachThen(httpmock::Then);
+    impl FloatingIpAttachThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn accepted(self, value: &types::FloatingIp) -> Self {
+            Self(
+                self.0
+                    .status(202u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
+    pub struct FloatingIpDetachWhen(httpmock::When);
+    impl FloatingIpDetachWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(regex::Regex::new("^/v1/floating-ips/[^/]*/detach$").unwrap()),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn floating_ip(self, value: &types::NameOrId) -> Self {
+            let re = regex::Regex::new(&format!("^/v1/floating-ips/{}/detach$", value.to_string()))
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+
+        pub fn project<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a types::NameOrId>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("project", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "project"))
+                        .is_none()
+                }))
+            }
+        }
+    }
+
+    pub struct FloatingIpDetachThen(httpmock::Then);
+    impl FloatingIpDetachThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn accepted(self, value: &types::FloatingIp) -> Self {
+            Self(
+                self.0
+                    .status(202u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
     pub struct GroupListWhen(httpmock::When);
     impl GroupListWhen {
         pub fn new(inner: httpmock::When) -> Self {
@@ -2941,6 +3099,161 @@ pub mod operations {
                     .header("content-type", "application/json")
                     .json_body_obj(value),
             )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
+    pub struct InstanceEphemeralIpAttachWhen(httpmock::When);
+    impl InstanceEphemeralIpAttachWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(inner.method(httpmock::Method::POST).path_matches(
+                regex::Regex::new("^/v1/instances/[^/]*/external-ips/ephemeral$").unwrap(),
+            ))
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn instance(self, value: &types::NameOrId) -> Self {
+            let re = regex::Regex::new(&format!(
+                "^/v1/instances/{}/external-ips/ephemeral$",
+                value.to_string()
+            ))
+            .unwrap();
+            Self(self.0.path_matches(re))
+        }
+
+        pub fn project<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a types::NameOrId>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("project", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "project"))
+                        .is_none()
+                }))
+            }
+        }
+
+        pub fn body(self, value: &types::EphemeralIpCreate) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+
+    pub struct InstanceEphemeralIpAttachThen(httpmock::Then);
+    impl InstanceEphemeralIpAttachThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn accepted(self, value: &types::ExternalIp) -> Self {
+            Self(
+                self.0
+                    .status(202u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
+    pub struct InstanceEphemeralIpDetachWhen(httpmock::When);
+    impl InstanceEphemeralIpDetachWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(inner.method(httpmock::Method::DELETE).path_matches(
+                regex::Regex::new("^/v1/instances/[^/]*/external-ips/ephemeral$").unwrap(),
+            ))
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn instance(self, value: &types::NameOrId) -> Self {
+            let re = regex::Regex::new(&format!(
+                "^/v1/instances/{}/external-ips/ephemeral$",
+                value.to_string()
+            ))
+            .unwrap();
+            Self(self.0.path_matches(re))
+        }
+
+        pub fn project<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a types::NameOrId>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("project", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "project"))
+                        .is_none()
+                }))
+            }
+        }
+    }
+
+    pub struct InstanceEphemeralIpDetachThen(httpmock::Then);
+    impl InstanceEphemeralIpDetachThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn no_content(self) -> Self {
+            Self(self.0.status(204u16))
         }
 
         pub fn client_error(self, status: u16, value: &types::Error) -> Self {
@@ -13066,6 +13379,12 @@ pub trait MockServerExt {
     fn floating_ip_delete<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::FloatingIpDeleteWhen, operations::FloatingIpDeleteThen);
+    fn floating_ip_attach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::FloatingIpAttachWhen, operations::FloatingIpAttachThen);
+    fn floating_ip_detach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::FloatingIpDetachWhen, operations::FloatingIpDetachThen);
     fn group_list<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::GroupListWhen, operations::GroupListThen);
@@ -13114,6 +13433,18 @@ pub trait MockServerExt {
     fn instance_external_ip_list<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::InstanceExternalIpListWhen, operations::InstanceExternalIpListThen);
+    fn instance_ephemeral_ip_attach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::InstanceEphemeralIpAttachWhen,
+            operations::InstanceEphemeralIpAttachThen,
+        );
+    fn instance_ephemeral_ip_detach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::InstanceEphemeralIpDetachWhen,
+            operations::InstanceEphemeralIpDetachThen,
+        );
     fn instance_migrate<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::InstanceMigrateWhen, operations::InstanceMigrateThen);
@@ -13846,6 +14177,30 @@ impl MockServerExt for httpmock::MockServer {
         })
     }
 
+    fn floating_ip_attach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::FloatingIpAttachWhen, operations::FloatingIpAttachThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::FloatingIpAttachWhen::new(when),
+                operations::FloatingIpAttachThen::new(then),
+            )
+        })
+    }
+
+    fn floating_ip_detach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::FloatingIpDetachWhen, operations::FloatingIpDetachThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::FloatingIpDetachWhen::new(when),
+                operations::FloatingIpDetachThen::new(then),
+            )
+        })
+    }
+
     fn group_list<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::GroupListWhen, operations::GroupListThen),
@@ -14034,6 +14389,36 @@ impl MockServerExt for httpmock::MockServer {
             config_fn(
                 operations::InstanceExternalIpListWhen::new(when),
                 operations::InstanceExternalIpListThen::new(then),
+            )
+        })
+    }
+
+    fn instance_ephemeral_ip_attach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::InstanceEphemeralIpAttachWhen,
+            operations::InstanceEphemeralIpAttachThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::InstanceEphemeralIpAttachWhen::new(when),
+                operations::InstanceEphemeralIpAttachThen::new(then),
+            )
+        })
+    }
+
+    fn instance_ephemeral_ip_detach<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::InstanceEphemeralIpDetachWhen,
+            operations::InstanceEphemeralIpDetachThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::InstanceEphemeralIpDetachWhen::new(when),
+                operations::InstanceEphemeralIpDetachThen::new(then),
             )
         })
     }

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -5763,6 +5763,48 @@ pub mod types {
         }
     }
 
+    /// Parameters for creating an ephemeral IP address for an instance.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Parameters for creating an ephemeral IP address for an
+    /// instance.",
+    ///  "type": "object",
+    ///  "properties": {
+    ///    "pool": {
+    ///      "description": "Name or ID of the IP pool used to allocate an
+    /// address",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/NameOrId"
+    ///        }
+    ///      ]
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, Serialize, schemars :: JsonSchema)]
+    pub struct EphemeralIpCreate {
+        /// Name or ID of the IP pool used to allocate an address
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub pool: Option<NameOrId>,
+    }
+
+    impl From<&EphemeralIpCreate> for EphemeralIpCreate {
+        fn from(value: &EphemeralIpCreate) -> Self {
+            value.clone()
+        }
+    }
+
+    impl EphemeralIpCreate {
+        pub fn builder() -> builder::EphemeralIpCreate {
+            Default::default()
+        }
+    }
+
     /// Error information from a response.
     ///
     /// <details><summary>JSON schema</summary>
@@ -5815,38 +5857,137 @@ pub mod types {
     ///
     /// ```json
     /// {
-    ///  "type": "object",
-    ///  "required": [
-    ///    "ip",
-    ///    "kind"
-    ///  ],
-    ///  "properties": {
-    ///    "ip": {
-    ///      "type": "string",
-    ///      "format": "ip"
+    ///  "oneOf": [
+    ///    {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "ip",
+    ///        "kind"
+    ///      ],
+    ///      "properties": {
+    ///        "ip": {
+    ///          "type": "string",
+    ///          "format": "ip"
+    ///        },
+    ///        "kind": {
+    ///          "type": "string",
+    ///          "enum": [
+    ///            "ephemeral"
+    ///          ]
+    ///        }
+    ///      }
     ///    },
-    ///    "kind": {
-    ///      "$ref": "#/components/schemas/IpKind"
+    ///    {
+    ///      "description": "A Floating IP is a well-known IP address which can
+    /// be attached and detached from instances.",
+    ///      "type": "object",
+    ///      "required": [
+    ///        "description",
+    ///        "id",
+    ///        "ip",
+    ///        "kind",
+    ///        "name",
+    ///        "project_id",
+    ///        "time_created",
+    ///        "time_modified"
+    ///      ],
+    ///      "properties": {
+    ///        "description": {
+    ///          "description": "human-readable free-form text about a
+    /// resource",
+    ///          "type": "string"
+    ///        },
+    ///        "id": {
+    ///          "description": "unique, immutable, system-controlled identifier
+    /// for each resource",
+    ///          "type": "string",
+    ///          "format": "uuid"
+    ///        },
+    ///        "instance_id": {
+    ///          "description": "The ID of the instance that this Floating IP is
+    /// attached to, if it is presently in use.",
+    ///          "type": [
+    ///            "string",
+    ///            "null"
+    ///          ],
+    ///          "format": "uuid"
+    ///        },
+    ///        "ip": {
+    ///          "description": "The IP address held by this resource.",
+    ///          "type": "string",
+    ///          "format": "ip"
+    ///        },
+    ///        "kind": {
+    ///          "type": "string",
+    ///          "enum": [
+    ///            "floating"
+    ///          ]
+    ///        },
+    ///        "name": {
+    ///          "description": "unique, mutable, user-controlled identifier for
+    /// each resource",
+    ///          "allOf": [
+    ///            {
+    ///              "$ref": "#/components/schemas/Name"
+    ///            }
+    ///          ]
+    ///        },
+    ///        "project_id": {
+    ///          "description": "The project this resource exists within.",
+    ///          "type": "string",
+    ///          "format": "uuid"
+    ///        },
+    ///        "time_created": {
+    ///          "description": "timestamp when this resource was created",
+    ///          "type": "string",
+    ///          "format": "date-time"
+    ///        },
+    ///        "time_modified": {
+    ///          "description": "timestamp when this resource was last
+    /// modified",
+    ///          "type": "string",
+    ///          "format": "date-time"
+    ///        }
+    ///      }
     ///    }
-    ///  }
+    ///  ]
     /// }
     /// ```
     /// </details>
     #[derive(Clone, Debug, Deserialize, Serialize, schemars :: JsonSchema)]
-    pub struct ExternalIp {
-        pub ip: std::net::IpAddr,
-        pub kind: IpKind,
+    #[serde(tag = "kind")]
+    pub enum ExternalIp {
+        #[serde(rename = "ephemeral")]
+        Ephemeral { ip: std::net::IpAddr },
+        /// A Floating IP is a well-known IP address which can be attached and
+        /// detached from instances.
+        #[serde(rename = "floating")]
+        Floating {
+            /// human-readable free-form text about a resource
+            description: String,
+            /// unique, immutable, system-controlled identifier for each
+            /// resource
+            id: uuid::Uuid,
+            /// The ID of the instance that this Floating IP is attached to, if
+            /// it is presently in use.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            instance_id: Option<uuid::Uuid>,
+            /// The IP address held by this resource.
+            ip: std::net::IpAddr,
+            /// unique, mutable, user-controlled identifier for each resource
+            name: Name,
+            /// The project this resource exists within.
+            project_id: uuid::Uuid,
+            /// timestamp when this resource was created
+            time_created: chrono::DateTime<chrono::offset::Utc>,
+            /// timestamp when this resource was last modified
+            time_modified: chrono::DateTime<chrono::offset::Utc>,
+        },
     }
 
     impl From<&ExternalIp> for ExternalIp {
         fn from(value: &ExternalIp) -> Self {
             value.clone()
-        }
-    }
-
-    impl ExternalIp {
-        pub fn builder() -> builder::ExternalIp {
-            Default::default()
         }
     }
 
@@ -5862,16 +6003,16 @@ pub mod types {
     ///    {
     ///      "description": "An IP address providing both inbound and outbound
     /// access. The address is automatically-assigned from the provided IP Pool,
-    /// or all available pools if not specified.",
+    /// or the current silo's default pool if not specified.",
     ///      "type": "object",
     ///      "required": [
     ///        "type"
     ///      ],
     ///      "properties": {
-    ///        "pool_name": {
+    ///        "pool": {
     ///          "allOf": [
     ///            {
-    ///              "$ref": "#/components/schemas/Name"
+    ///              "$ref": "#/components/schemas/NameOrId"
     ///            }
     ///          ]
     ///        },
@@ -5885,17 +6026,17 @@ pub mod types {
     ///    },
     ///    {
     ///      "description": "An IP address providing both inbound and outbound
-    /// access. The address is an existing Floating IP object assigned to the
+    /// access. The address is an existing floating IP object assigned to the
     /// current project.\n\nThe floating IP must not be in use by another
     /// instance or service.",
     ///      "type": "object",
     ///      "required": [
-    ///        "floating_ip_name",
+    ///        "floating_ip",
     ///        "type"
     ///      ],
     ///      "properties": {
-    ///        "floating_ip_name": {
-    ///          "$ref": "#/components/schemas/Name"
+    ///        "floating_ip": {
+    ///          "$ref": "#/components/schemas/NameOrId"
     ///        },
     ///        "type": {
     ///          "type": "string",
@@ -5913,20 +6054,20 @@ pub mod types {
     #[serde(tag = "type")]
     pub enum ExternalIpCreate {
         /// An IP address providing both inbound and outbound access. The
-        /// address is automatically-assigned from the provided IP Pool, or all
-        /// available pools if not specified.
+        /// address is automatically-assigned from the provided IP Pool, or the
+        /// current silo's default pool if not specified.
         #[serde(rename = "ephemeral")]
         Ephemeral {
             #[serde(default, skip_serializing_if = "Option::is_none")]
-            pool_name: Option<Name>,
+            pool: Option<NameOrId>,
         },
         /// An IP address providing both inbound and outbound access. The
-        /// address is an existing Floating IP object assigned to the current
+        /// address is an existing floating IP object assigned to the current
         /// project.
         ///
         /// The floating IP must not be in use by another instance or service.
         #[serde(rename = "floating")]
-        Floating { floating_ip_name: Name },
+        Floating { floating_ip: NameOrId },
     }
 
     impl From<&ExternalIpCreate> for ExternalIpCreate {
@@ -6329,6 +6470,62 @@ pub mod types {
         }
     }
 
+    /// Parameters for attaching a floating IP address to another resource
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Parameters for attaching a floating IP address to
+    /// another resource",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "kind",
+    ///    "parent"
+    ///  ],
+    ///  "properties": {
+    ///    "kind": {
+    ///      "description": "The type of `parent`'s resource",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/FloatingIpParentKind"
+    ///        }
+    ///      ]
+    ///    },
+    ///    "parent": {
+    ///      "description": "Name or ID of the resource that this IP address
+    /// should be attached to",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/NameOrId"
+    ///        }
+    ///      ]
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, Serialize, schemars :: JsonSchema)]
+    pub struct FloatingIpAttach {
+        /// The type of `parent`'s resource
+        pub kind: FloatingIpParentKind,
+        /// Name or ID of the resource that this IP address should be attached
+        /// to
+        pub parent: NameOrId,
+    }
+
+    impl From<&FloatingIpAttach> for FloatingIpAttach {
+        fn from(value: &FloatingIpAttach) -> Self {
+            value.clone()
+        }
+    }
+
+    impl FloatingIpAttach {
+        pub fn builder() -> builder::FloatingIpAttach {
+            Default::default()
+        }
+    }
+
     /// Parameters for creating a new floating IP address for instances.
     ///
     /// <details><summary>JSON schema</summary>
@@ -6398,6 +6595,84 @@ pub mod types {
     impl FloatingIpCreate {
         pub fn builder() -> builder::FloatingIpCreate {
             Default::default()
+        }
+    }
+
+    /// The type of resource that a floating IP is attached to
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "The type of resource that a floating IP is attached
+    /// to",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "instance"
+    ///  ]
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        Deserialize,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Serialize,
+        schemars :: JsonSchema,
+    )]
+    pub enum FloatingIpParentKind {
+        #[serde(rename = "instance")]
+        Instance,
+    }
+
+    impl From<&FloatingIpParentKind> for FloatingIpParentKind {
+        fn from(value: &FloatingIpParentKind) -> Self {
+            value.clone()
+        }
+    }
+
+    impl ToString for FloatingIpParentKind {
+        fn to_string(&self) -> String {
+            match *self {
+                Self::Instance => "instance".to_string(),
+            }
+        }
+    }
+
+    impl std::str::FromStr for FloatingIpParentKind {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
+            match value {
+                "instance" => Ok(Self::Instance),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+
+    impl std::convert::TryFrom<&str> for FloatingIpParentKind {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl std::convert::TryFrom<&String> for FloatingIpParentKind {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl std::convert::TryFrom<String> for FloatingIpParentKind {
+        type Error = self::error::ConversionError;
+        fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
+            value.parse()
         }
     }
 
@@ -9259,88 +9534,6 @@ pub mod types {
     }
 
     impl std::convert::TryFrom<String> for InstanceState {
-        type Error = self::error::ConversionError;
-        fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-
-    /// The kind of an external IP address for an instance
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "The kind of an external IP address for an instance",
-    ///  "type": "string",
-    ///  "enum": [
-    ///    "ephemeral",
-    ///    "floating"
-    ///  ]
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        Deserialize,
-        Eq,
-        Hash,
-        Ord,
-        PartialEq,
-        PartialOrd,
-        Serialize,
-        schemars :: JsonSchema,
-    )]
-    pub enum IpKind {
-        #[serde(rename = "ephemeral")]
-        Ephemeral,
-        #[serde(rename = "floating")]
-        Floating,
-    }
-
-    impl From<&IpKind> for IpKind {
-        fn from(value: &IpKind) -> Self {
-            value.clone()
-        }
-    }
-
-    impl ToString for IpKind {
-        fn to_string(&self) -> String {
-            match *self {
-                Self::Ephemeral => "ephemeral".to_string(),
-                Self::Floating => "floating".to_string(),
-            }
-        }
-    }
-
-    impl std::str::FromStr for IpKind {
-        type Err = self::error::ConversionError;
-        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
-            match value {
-                "ephemeral" => Ok(Self::Ephemeral),
-                "floating" => Ok(Self::Floating),
-                _ => Err("invalid value".into()),
-            }
-        }
-    }
-
-    impl std::convert::TryFrom<&str> for IpKind {
-        type Error = self::error::ConversionError;
-        fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-
-    impl std::convert::TryFrom<&String> for IpKind {
-        type Error = self::error::ConversionError;
-        fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-
-    impl std::convert::TryFrom<String> for IpKind {
         type Error = self::error::ConversionError;
         fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
             value.parse()
@@ -23055,6 +23248,47 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
+        pub struct EphemeralIpCreate {
+            pool: Result<Option<super::NameOrId>, String>,
+        }
+
+        impl Default for EphemeralIpCreate {
+            fn default() -> Self {
+                Self {
+                    pool: Ok(Default::default()),
+                }
+            }
+        }
+
+        impl EphemeralIpCreate {
+            pub fn pool<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<super::NameOrId>>,
+                T::Error: std::fmt::Display,
+            {
+                self.pool = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for pool: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<EphemeralIpCreate> for super::EphemeralIpCreate {
+            type Error = super::error::ConversionError;
+            fn try_from(value: EphemeralIpCreate) -> Result<Self, super::error::ConversionError> {
+                Ok(Self { pool: value.pool? })
+            }
+        }
+
+        impl From<super::EphemeralIpCreate> for EphemeralIpCreate {
+            fn from(value: super::EphemeralIpCreate) -> Self {
+                Self {
+                    pool: Ok(value.pool),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
         pub struct Error {
             error_code: Result<Option<String>, String>,
             message: Result<String, String>,
@@ -23121,63 +23355,6 @@ pub mod types {
                     error_code: Ok(value.error_code),
                     message: Ok(value.message),
                     request_id: Ok(value.request_id),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct ExternalIp {
-            ip: Result<std::net::IpAddr, String>,
-            kind: Result<super::IpKind, String>,
-        }
-
-        impl Default for ExternalIp {
-            fn default() -> Self {
-                Self {
-                    ip: Err("no value supplied for ip".to_string()),
-                    kind: Err("no value supplied for kind".to_string()),
-                }
-            }
-        }
-
-        impl ExternalIp {
-            pub fn ip<T>(mut self, value: T) -> Self
-            where
-                T: std::convert::TryInto<std::net::IpAddr>,
-                T::Error: std::fmt::Display,
-            {
-                self.ip = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip: {}", e));
-                self
-            }
-            pub fn kind<T>(mut self, value: T) -> Self
-            where
-                T: std::convert::TryInto<super::IpKind>,
-                T::Error: std::fmt::Display,
-            {
-                self.kind = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
-                self
-            }
-        }
-
-        impl std::convert::TryFrom<ExternalIp> for super::ExternalIp {
-            type Error = super::error::ConversionError;
-            fn try_from(value: ExternalIp) -> Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    ip: value.ip?,
-                    kind: value.kind?,
-                })
-            }
-        }
-
-        impl From<super::ExternalIp> for ExternalIp {
-            fn from(value: super::ExternalIp) -> Self {
-                Self {
-                    ip: Ok(value.ip),
-                    kind: Ok(value.kind),
                 }
             }
         }
@@ -23540,6 +23717,63 @@ pub mod types {
                     project_id: Ok(value.project_id),
                     time_created: Ok(value.time_created),
                     time_modified: Ok(value.time_modified),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct FloatingIpAttach {
+            kind: Result<super::FloatingIpParentKind, String>,
+            parent: Result<super::NameOrId, String>,
+        }
+
+        impl Default for FloatingIpAttach {
+            fn default() -> Self {
+                Self {
+                    kind: Err("no value supplied for kind".to_string()),
+                    parent: Err("no value supplied for parent".to_string()),
+                }
+            }
+        }
+
+        impl FloatingIpAttach {
+            pub fn kind<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::FloatingIpParentKind>,
+                T::Error: std::fmt::Display,
+            {
+                self.kind = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                self
+            }
+            pub fn parent<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::NameOrId>,
+                T::Error: std::fmt::Display,
+            {
+                self.parent = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for parent: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<FloatingIpAttach> for super::FloatingIpAttach {
+            type Error = super::error::ConversionError;
+            fn try_from(value: FloatingIpAttach) -> Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    kind: value.kind?,
+                    parent: value.parent?,
+                })
+            }
+        }
+
+        impl From<super::FloatingIpAttach> for FloatingIpAttach {
+            fn from(value: super::FloatingIpAttach) -> Self {
+                Self {
+                    kind: Ok(value.kind),
+                    parent: Ok(value.parent),
                 }
             }
         }
@@ -34751,7 +34985,7 @@ pub trait ClientFloatingIpsExt {
     /// Sends a `GET` request to `/v1/floating-ips/{floating_ip}`
     ///
     /// Arguments:
-    /// - `floating_ip`: Name or ID of the Floating IP
+    /// - `floating_ip`: Name or ID of the floating IP
     /// - `project`: Name or ID of the project
     /// ```ignore
     /// let response = client.floating_ip_view()
@@ -34766,7 +35000,7 @@ pub trait ClientFloatingIpsExt {
     /// Sends a `DELETE` request to `/v1/floating-ips/{floating_ip}`
     ///
     /// Arguments:
-    /// - `floating_ip`: Name or ID of the Floating IP
+    /// - `floating_ip`: Name or ID of the floating IP
     /// - `project`: Name or ID of the project
     /// ```ignore
     /// let response = client.floating_ip_delete()
@@ -34776,6 +35010,38 @@ pub trait ClientFloatingIpsExt {
     ///    .await;
     /// ```
     fn floating_ip_delete(&self) -> builder::FloatingIpDelete;
+    /// Attach a floating IP to an instance or other resource
+    ///
+    /// Sends a `POST` request to `/v1/floating-ips/{floating_ip}/attach`
+    ///
+    /// Arguments:
+    /// - `floating_ip`: Name or ID of the floating IP
+    /// - `project`: Name or ID of the project
+    /// - `body`
+    /// ```ignore
+    /// let response = client.floating_ip_attach()
+    ///    .floating_ip(floating_ip)
+    ///    .project(project)
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn floating_ip_attach(&self) -> builder::FloatingIpAttach;
+    /// Detach a floating IP from an instance or other resource
+    ///
+    /// Sends a `POST` request to `/v1/floating-ips/{floating_ip}/detach`
+    ///
+    /// Arguments:
+    /// - `floating_ip`: Name or ID of the floating IP
+    /// - `project`: Name or ID of the project
+    /// ```ignore
+    /// let response = client.floating_ip_detach()
+    ///    .floating_ip(floating_ip)
+    ///    .project(project)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn floating_ip_detach(&self) -> builder::FloatingIpDetach;
 }
 
 impl ClientFloatingIpsExt for Client {
@@ -34793,6 +35059,14 @@ impl ClientFloatingIpsExt for Client {
 
     fn floating_ip_delete(&self) -> builder::FloatingIpDelete {
         builder::FloatingIpDelete::new(self)
+    }
+
+    fn floating_ip_attach(&self) -> builder::FloatingIpAttach {
+        builder::FloatingIpAttach::new(self)
+    }
+
+    fn floating_ip_detach(&self) -> builder::FloatingIpDetach {
+        builder::FloatingIpDetach::new(self)
     }
 }
 
@@ -35154,6 +35428,40 @@ pub trait ClientInstancesExt {
     ///    .await;
     /// ```
     fn instance_external_ip_list(&self) -> builder::InstanceExternalIpList;
+    /// Allocate and attach an ephemeral IP to an instance
+    ///
+    /// Sends a `POST` request to
+    /// `/v1/instances/{instance}/external-ips/ephemeral`
+    ///
+    /// Arguments:
+    /// - `instance`: Name or ID of the instance
+    /// - `project`: Name or ID of the project
+    /// - `body`
+    /// ```ignore
+    /// let response = client.instance_ephemeral_ip_attach()
+    ///    .instance(instance)
+    ///    .project(project)
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn instance_ephemeral_ip_attach(&self) -> builder::InstanceEphemeralIpAttach;
+    /// Detach and deallocate an ephemeral IP from an instance
+    ///
+    /// Sends a `DELETE` request to
+    /// `/v1/instances/{instance}/external-ips/ephemeral`
+    ///
+    /// Arguments:
+    /// - `instance`: Name or ID of the instance
+    /// - `project`: Name or ID of the project
+    /// ```ignore
+    /// let response = client.instance_ephemeral_ip_detach()
+    ///    .instance(instance)
+    ///    .project(project)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn instance_ephemeral_ip_detach(&self) -> builder::InstanceEphemeralIpDetach;
     /// Migrate an instance
     ///
     /// Sends a `POST` request to `/v1/instances/{instance}/migrate`
@@ -35402,6 +35710,14 @@ impl ClientInstancesExt for Client {
 
     fn instance_external_ip_list(&self) -> builder::InstanceExternalIpList {
         builder::InstanceExternalIpList::new(self)
+    }
+
+    fn instance_ephemeral_ip_attach(&self) -> builder::InstanceEphemeralIpAttach {
+        builder::InstanceEphemeralIpAttach::new(self)
+    }
+
+    fn instance_ephemeral_ip_detach(&self) -> builder::InstanceEphemeralIpDetach {
+        builder::InstanceEphemeralIpDetach::new(self)
     }
 
     fn instance_migrate(&self) -> builder::InstanceMigrate {
@@ -40083,6 +40399,199 @@ pub mod builder {
         }
     }
 
+    /// Builder for [`ClientFloatingIpsExt::floating_ip_attach`]
+    ///
+    /// [`ClientFloatingIpsExt::floating_ip_attach`]: super::ClientFloatingIpsExt::floating_ip_attach
+    #[derive(Debug, Clone)]
+    pub struct FloatingIpAttach<'a> {
+        client: &'a super::Client,
+        floating_ip: Result<types::NameOrId, String>,
+        project: Result<Option<types::NameOrId>, String>,
+        body: Result<types::builder::FloatingIpAttach, String>,
+    }
+
+    impl<'a> FloatingIpAttach<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                floating_ip: Err("floating_ip was not initialized".to_string()),
+                project: Ok(None),
+                body: Ok(types::builder::FloatingIpAttach::default()),
+            }
+        }
+
+        pub fn floating_ip<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.floating_ip = value
+                .try_into()
+                .map_err(|_| "conversion to `NameOrId` for floating_ip failed".to_string());
+            self
+        }
+
+        pub fn project<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.project = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `NameOrId` for project failed".to_string());
+            self
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::FloatingIpAttach>,
+            <V as std::convert::TryInto<types::FloatingIpAttach>>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| format!("conversion to `FloatingIpAttach` for body failed: {}", s));
+            self
+        }
+
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::FloatingIpAttach,
+            ) -> types::builder::FloatingIpAttach,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+
+        /// Sends a `POST` request to `/v1/floating-ips/{floating_ip}/attach`
+        pub async fn send(self) -> Result<ResponseValue<types::FloatingIp>, Error<types::Error>> {
+            let Self {
+                client,
+                floating_ip,
+                project,
+                body,
+            } = self;
+            let floating_ip = floating_ip.map_err(Error::InvalidRequest)?;
+            let project = project.map_err(Error::InvalidRequest)?;
+            let body = body
+                .and_then(|v| types::FloatingIpAttach::try_from(v).map_err(|e| e.to_string()))
+                .map_err(Error::InvalidRequest)?;
+            let url = format!(
+                "{}/v1/floating-ips/{}/attach",
+                client.baseurl,
+                encode_path(&floating_ip.to_string()),
+            );
+            let mut query = Vec::with_capacity(1usize);
+            if let Some(v) = &project {
+                query.push(("project", v.to_string()));
+            }
+            let request = client
+                .client
+                .post(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .query(&query)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    /// Builder for [`ClientFloatingIpsExt::floating_ip_detach`]
+    ///
+    /// [`ClientFloatingIpsExt::floating_ip_detach`]: super::ClientFloatingIpsExt::floating_ip_detach
+    #[derive(Debug, Clone)]
+    pub struct FloatingIpDetach<'a> {
+        client: &'a super::Client,
+        floating_ip: Result<types::NameOrId, String>,
+        project: Result<Option<types::NameOrId>, String>,
+    }
+
+    impl<'a> FloatingIpDetach<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                floating_ip: Err("floating_ip was not initialized".to_string()),
+                project: Ok(None),
+            }
+        }
+
+        pub fn floating_ip<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.floating_ip = value
+                .try_into()
+                .map_err(|_| "conversion to `NameOrId` for floating_ip failed".to_string());
+            self
+        }
+
+        pub fn project<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.project = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `NameOrId` for project failed".to_string());
+            self
+        }
+
+        /// Sends a `POST` request to `/v1/floating-ips/{floating_ip}/detach`
+        pub async fn send(self) -> Result<ResponseValue<types::FloatingIp>, Error<types::Error>> {
+            let Self {
+                client,
+                floating_ip,
+                project,
+            } = self;
+            let floating_ip = floating_ip.map_err(Error::InvalidRequest)?;
+            let project = project.map_err(Error::InvalidRequest)?;
+            let url = format!(
+                "{}/v1/floating-ips/{}/detach",
+                client.baseurl,
+                encode_path(&floating_ip.to_string()),
+            );
+            let mut query = Vec::with_capacity(1usize);
+            if let Some(v) = &project {
+                query.push(("project", v.to_string()));
+            }
+            let request = client
+                .client
+                .post(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&query)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
     /// Builder for [`ClientSilosExt::group_list`]
     ///
     /// [`ClientSilosExt::group_list`]: super::ClientSilosExt::group_list
@@ -41804,6 +42313,201 @@ pub mod builder {
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    /// Builder for [`ClientInstancesExt::instance_ephemeral_ip_attach`]
+    ///
+    /// [`ClientInstancesExt::instance_ephemeral_ip_attach`]: super::ClientInstancesExt::instance_ephemeral_ip_attach
+    #[derive(Debug, Clone)]
+    pub struct InstanceEphemeralIpAttach<'a> {
+        client: &'a super::Client,
+        instance: Result<types::NameOrId, String>,
+        project: Result<Option<types::NameOrId>, String>,
+        body: Result<types::builder::EphemeralIpCreate, String>,
+    }
+
+    impl<'a> InstanceEphemeralIpAttach<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                instance: Err("instance was not initialized".to_string()),
+                project: Ok(None),
+                body: Ok(types::builder::EphemeralIpCreate::default()),
+            }
+        }
+
+        pub fn instance<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.instance = value
+                .try_into()
+                .map_err(|_| "conversion to `NameOrId` for instance failed".to_string());
+            self
+        }
+
+        pub fn project<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.project = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `NameOrId` for project failed".to_string());
+            self
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::EphemeralIpCreate>,
+            <V as std::convert::TryInto<types::EphemeralIpCreate>>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| format!("conversion to `EphemeralIpCreate` for body failed: {}", s));
+            self
+        }
+
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::EphemeralIpCreate,
+            ) -> types::builder::EphemeralIpCreate,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+
+        /// Sends a `POST` request to
+        /// `/v1/instances/{instance}/external-ips/ephemeral`
+        pub async fn send(self) -> Result<ResponseValue<types::ExternalIp>, Error<types::Error>> {
+            let Self {
+                client,
+                instance,
+                project,
+                body,
+            } = self;
+            let instance = instance.map_err(Error::InvalidRequest)?;
+            let project = project.map_err(Error::InvalidRequest)?;
+            let body = body
+                .and_then(|v| types::EphemeralIpCreate::try_from(v).map_err(|e| e.to_string()))
+                .map_err(Error::InvalidRequest)?;
+            let url = format!(
+                "{}/v1/instances/{}/external-ips/ephemeral",
+                client.baseurl,
+                encode_path(&instance.to_string()),
+            );
+            let mut query = Vec::with_capacity(1usize);
+            if let Some(v) = &project {
+                query.push(("project", v.to_string()));
+            }
+            let request = client
+                .client
+                .post(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .query(&query)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    /// Builder for [`ClientInstancesExt::instance_ephemeral_ip_detach`]
+    ///
+    /// [`ClientInstancesExt::instance_ephemeral_ip_detach`]: super::ClientInstancesExt::instance_ephemeral_ip_detach
+    #[derive(Debug, Clone)]
+    pub struct InstanceEphemeralIpDetach<'a> {
+        client: &'a super::Client,
+        instance: Result<types::NameOrId, String>,
+        project: Result<Option<types::NameOrId>, String>,
+    }
+
+    impl<'a> InstanceEphemeralIpDetach<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                instance: Err("instance was not initialized".to_string()),
+                project: Ok(None),
+            }
+        }
+
+        pub fn instance<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.instance = value
+                .try_into()
+                .map_err(|_| "conversion to `NameOrId` for instance failed".to_string());
+            self
+        }
+
+        pub fn project<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.project = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `NameOrId` for project failed".to_string());
+            self
+        }
+
+        /// Sends a `DELETE` request to
+        /// `/v1/instances/{instance}/external-ips/ephemeral`
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
+            let Self {
+                client,
+                instance,
+                project,
+            } = self;
+            let instance = instance.map_err(Error::InvalidRequest)?;
+            let project = project.map_err(Error::InvalidRequest)?;
+            let url = format!(
+                "{}/v1/instances/{}/external-ips/ephemeral",
+                client.baseurl,
+                encode_path(&instance.to_string()),
+            );
+            let mut query = Vec::with_capacity(1usize);
+            if let Some(v) = &project {
+                query.push(("project", v.to_string()));
+            }
+            let request = client
+                .client
+                .delete(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&query)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),


### PR DESCRIPTION
Relies on oxidecomputer/omicron#4694. This adds the autogenerated commands:
- `oxide floating-ip attach --floating-ip <floating-ip> --kind <kind> --parent <parent>`
- `oxide floating-ip detach --floating-ip <floating-ip>`
- `oxide instance external-ip attach-ephemeral --instance <instance>`
- `oxide instance external-ip detach-ephemeral --instance <instance>`