### PR TITLE
Don't require compiling openssl to use the SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = "0.8.5"
 rcgen = "0.10.0"
 regex = "1.10.2"
 regress = "0.7.1"
-reqwest = { version = "0.11.23", features = ["native-tls-vendored"] }
+reqwest = "0.11.23"
 rustfmt-wrapper = "0.2.1"
 schemars = { version = "0.8.16", features = ["chrono", "uuid1"] }
 serde = { version = "1.0.193", features = ["derive"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,7 +34,7 @@ oauth2 = { workspace = true }
 open = { workspace = true }
 oxide = { workspace = true }
 predicates = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["native-tls-vendored"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Currently, projects depending on the oxide SDK cannot choose for themselves whether to use native TLS or rustls. They also cannot choose whether to use the system's OpenSSL or use the vendored TLS. This is because the `native-tls-vendored` feature is specified on reqwest at the project-level.

This feature is wanted by the cli, which ships binaries bundling openssl in it. So let's move it so the cli crate turns it on, while the library crate has no opinion.