### PR TITLE
Add bidirectional forwarding detection (BFD) to CLI

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -2827,6 +2827,79 @@
               ]
             },
             {
+              "name": "bfd",
+              "subcommands": [
+                {
+                  "name": "disable",
+                  "about": "Disable a BFD session.",
+                  "args": [
+                    {
+                      "long": "json-body",
+                      "help": "Path to a file that contains the full json body."
+                    },
+                    {
+                      "long": "json-body-template",
+                      "help": "XXX"
+                    },
+                    {
+                      "long": "remote",
+                      "help": "Address of the remote peer to disable a BFD session for."
+                    },
+                    {
+                      "long": "switch",
+                      "help": "The switch to enable this session on. Must be `switch0` or `switch1`."
+                    }
+                  ]
+                },
+                {
+                  "name": "enable",
+                  "about": "Enable a BFD session.",
+                  "args": [
+                    {
+                      "long": "detection-threshold",
+                      "help": "The negotiated Control packet transmission interval, multiplied by this variable, will be the Detection Time for this session (as seen by the remote system)"
+                    },
+                    {
+                      "long": "json-body",
+                      "help": "Path to a file that contains the full json body."
+                    },
+                    {
+                      "long": "json-body-template",
+                      "help": "XXX"
+                    },
+                    {
+                      "long": "local",
+                      "help": "Address the Oxide switch will listen on for BFD traffic. If `None` then the unspecified address (0.0.0.0 or ::) is used."
+                    },
+                    {
+                      "long": "mode",
+                      "values": [
+                        "single_hop",
+                        "multi_hop"
+                      ],
+                      "help": "Select either single-hop (RFC 5881) or multi-hop (RFC 5883)"
+                    },
+                    {
+                      "long": "remote",
+                      "help": "Address of the remote peer to establish a BFD session with."
+                    },
+                    {
+                      "long": "required-rx",
+                      "help": "The minimum interval, in microseconds, between received BFD Control packets that this system requires"
+                    },
+                    {
+                      "long": "switch",
+                      "help": "The switch to enable this session on. Must be `switch0` or `switch1`."
+                    }
+                  ]
+                },
+                {
+                  "name": "status",
+                  "about": "Get BFD status."
+                }
+              ]
+            },
+            {
               "name": "bgp-announce-set",
               "subcommands": [
                 {

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -409,6 +409,10 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
             Some("system networking bgp-imported-routes-ipv4 get")
         }
 
+        CliCommand::NetworkingBfdStatus => Some("system networking bfd status"),
+        CliCommand::NetworkingBfdEnable => Some("system networking bfd enable"),
+        CliCommand::NetworkingBfdDisable => Some("system networking bfd disable"),
+
         CliCommand::NetworkingBgpStatus => Some("system networking bgp-status get"),
 
         // Subcommand: disk
@@ -488,7 +492,8 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         | CliCommand::SiloMetric
         | CliCommand::SystemMetric
         | CliCommand::UserBuiltinList
-        | CliCommand::UserBuiltinView => None,
+        | CliCommand::UserBuiltinView
+        | CliCommand::InstanceSshPublicKeyList => None,
     }
 }
 

--- a/cli/src/generated_cli.rs
+++ b/cli/src/generated_cli.rs
@@ -58,6 +58,7 @@ impl Cli {
             CliCommand::InstanceReboot => Self::cli_instance_reboot(),
             CliCommand::InstanceSerialConsole => Self::cli_instance_serial_console(),
             CliCommand::InstanceSerialConsoleStream => Self::cli_instance_serial_console_stream(),
+            CliCommand::InstanceSshPublicKeyList => Self::cli_instance_ssh_public_key_list(),
             CliCommand::InstanceStart => Self::cli_instance_start(),
             CliCommand::InstanceStop => Self::cli_instance_stop(),
             CliCommand::ProjectIpPoolList => Self::cli_project_ip_pool_list(),
@@ -144,6 +145,9 @@ impl Cli {
             CliCommand::NetworkingAddressLotBlockList => {
                 Self::cli_networking_address_lot_block_list()
             }
+            CliCommand::NetworkingBfdDisable => Self::cli_networking_bfd_disable(),
+            CliCommand::NetworkingBfdEnable => Self::cli_networking_bfd_enable(),
+            CliCommand::NetworkingBfdStatus => Self::cli_networking_bfd_status(),
             CliCommand::NetworkingBgpConfigList => Self::cli_networking_bgp_config_list(),
             CliCommand::NetworkingBgpConfigCreate => Self::cli_networking_bgp_config_create(),
             CliCommand::NetworkingBgpConfigDelete => Self::cli_networking_bgp_config_delete(),
@@ -1661,6 +1665,52 @@ impl Cli {
                     ),
             )
             .about("Stream an instance's serial console")
+    }
+
+    pub fn cli_instance_ssh_public_key_list() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("instance")
+                    .long("instance")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true)
+                    .help("Name or ID of the instance"),
+            )
+            .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false)
+                    .help("Name or ID of the project"),
+            )
+            .arg(
+                clap::Arg::new("sort-by")
+                    .long("sort-by")
+                    .value_parser(clap::builder::TypedValueParser::map(
+                        clap::builder::PossibleValuesParser::new([
+                            types::NameOrIdSortMode::NameAscending.to_string(),
+                            types::NameOrIdSortMode::NameDescending.to_string(),
+                            types::NameOrIdSortMode::IdAscending.to_string(),
+                        ]),
+                        |s| types::NameOrIdSortMode::try_from(s).unwrap(),
+                    ))
+                    .required(false),
+            )
+            .about(
+                "List the SSH public keys added to the instance via cloud-init during instance \
+                 creation",
+            )
+            .long_about(
+                "Note that this list is a snapshot in time and will not reflect updates made \
+                 after the instance is created.",
+            )
     }
 
     pub fn cli_instance_start() -> clap::Command {
@@ -3666,6 +3716,120 @@ impl Cli {
             .about("List the blocks in an address lot")
     }
 
+    pub fn cli_networking_bfd_disable() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("remote")
+                    .long("remote")
+                    .value_parser(clap::value_parser!(std::net::IpAddr))
+                    .required_unless_present("json-body")
+                    .help("Address of the remote peer to disable a BFD session for."),
+            )
+            .arg(
+                clap::Arg::new("switch")
+                    .long("switch")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required_unless_present("json-body")
+                    .help("The switch to enable this session on. Must be `switch0` or `switch1`."),
+            )
+            .arg(
+                clap::Arg::new("json-body")
+                    .long("json-body")
+                    .value_name("JSON-FILE")
+                    .required(false)
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .help("Path to a file that contains the full json body."),
+            )
+            .arg(
+                clap::Arg::new("json-body-template")
+                    .long("json-body-template")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("XXX"),
+            )
+            .about("Disable a BFD session.")
+    }
+
+    pub fn cli_networking_bfd_enable() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("detection-threshold")
+                    .long("detection-threshold")
+                    .value_parser(clap::value_parser!(u8))
+                    .required_unless_present("json-body")
+                    .help(
+                        "The negotiated Control packet transmission interval, multiplied by this \
+                         variable, will be the Detection Time for this session (as seen by the \
+                         remote system)",
+                    ),
+            )
+            .arg(
+                clap::Arg::new("local")
+                    .long("local")
+                    .value_parser(clap::value_parser!(std::net::IpAddr))
+                    .required(false)
+                    .help(
+                        "Address the Oxide switch will listen on for BFD traffic. If `None` then \
+                         the unspecified address (0.0.0.0 or ::) is used.",
+                    ),
+            )
+            .arg(
+                clap::Arg::new("mode")
+                    .long("mode")
+                    .value_parser(clap::builder::TypedValueParser::map(
+                        clap::builder::PossibleValuesParser::new([
+                            types::BfdMode::SingleHop.to_string(),
+                            types::BfdMode::MultiHop.to_string(),
+                        ]),
+                        |s| types::BfdMode::try_from(s).unwrap(),
+                    ))
+                    .required_unless_present("json-body")
+                    .help("Select either single-hop (RFC 5881) or multi-hop (RFC 5883)"),
+            )
+            .arg(
+                clap::Arg::new("remote")
+                    .long("remote")
+                    .value_parser(clap::value_parser!(std::net::IpAddr))
+                    .required_unless_present("json-body")
+                    .help("Address of the remote peer to establish a BFD session with."),
+            )
+            .arg(
+                clap::Arg::new("required-rx")
+                    .long("required-rx")
+                    .value_parser(clap::value_parser!(u64))
+                    .required_unless_present("json-body")
+                    .help(
+                        "The minimum interval, in microseconds, between received BFD Control \
+                         packets that this system requires",
+                    ),
+            )
+            .arg(
+                clap::Arg::new("switch")
+                    .long("switch")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required_unless_present("json-body")
+                    .help("The switch to enable this session on. Must be `switch0` or `switch1`."),
+            )
+            .arg(
+                clap::Arg::new("json-body")
+                    .long("json-body")
+                    .value_name("JSON-FILE")
+                    .required(false)
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .help("Path to a file that contains the full json body."),
+            )
+            .arg(
+                clap::Arg::new("json-body-template")
+                    .long("json-body-template")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("XXX"),
+            )
+            .about("Enable a BFD session.")
+    }
+
+    pub fn cli_networking_bfd_status() -> clap::Command {
+        clap::Command::new("").about("Get BFD status.")
+    }
+
     pub fn cli_networking_bgp_config_list() -> clap::Command {
         clap::Command::new("")
             .arg(
@@ -5169,6 +5333,9 @@ impl<T: CliOverride> Cli<T> {
             CliCommand::InstanceSerialConsoleStream => {
                 self.execute_instance_serial_console_stream(matches).await;
             }
+            CliCommand::InstanceSshPublicKeyList => {
+                self.execute_instance_ssh_public_key_list(matches).await;
+            }
             CliCommand::InstanceStart => {
                 self.execute_instance_start(matches).await;
             }
@@ -5396,6 +5563,15 @@ impl<T: CliOverride> Cli<T> {
             CliCommand::NetworkingAddressLotBlockList => {
                 self.execute_networking_address_lot_block_list(matches)
                     .await;
+            }
+            CliCommand::NetworkingBfdDisable => {
+                self.execute_networking_bfd_disable(matches).await;
+            }
+            CliCommand::NetworkingBfdEnable => {
+                self.execute_networking_bfd_enable(matches).await;
+            }
+            CliCommand::NetworkingBfdStatus => {
+                self.execute_networking_bfd_status(matches).await;
             }
             CliCommand::NetworkingBgpConfigList => {
                 self.execute_networking_bgp_config_list(matches).await;
@@ -6911,6 +7087,44 @@ impl<T: CliOverride> Cli<T> {
             }
             Err(r) => {
                 todo!()
+            }
+        }
+    }
+
+    pub async fn execute_instance_ssh_public_key_list(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.instance_ssh_public_key_list();
+        if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
+            request = request.instance(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrIdSortMode>("sort-by") {
+            request = request.sort_by(value.clone());
+        }
+
+        self.over
+            .execute_instance_ssh_public_key_list(matches, &mut request)
+            .unwrap();
+        let mut stream = request.stream();
+        loop {
+            match futures::TryStreamExt::try_next(&mut stream).await {
+                Err(r) => {
+                    println!("error\n{:#?}", r);
+                    break;
+                }
+                Ok(None) => {
+                    break;
+                }
+                Ok(Some(value)) => {
+                    println!("{:#?}", value);
+                }
             }
         }
     }
@@ -9023,6 +9237,98 @@ impl<T: CliOverride> Cli<T> {
         }
     }
 
+    pub async fn execute_networking_bfd_disable(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.networking_bfd_disable();
+        if let Some(value) = matches.get_one::<std::net::IpAddr>("remote") {
+            request = request.body_map(|body| body.remote(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("switch") {
+            request = request.body_map(|body| body.switch(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::BfdSessionDisable>(&body_txt).unwrap();
+            request = request.body(body_value);
+        }
+
+        self.over
+            .execute_networking_bfd_disable(matches, &mut request)
+            .unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("error\n{:#?}", r)
+            }
+        }
+    }
+
+    pub async fn execute_networking_bfd_enable(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.networking_bfd_enable();
+        if let Some(value) = matches.get_one::<u8>("detection-threshold") {
+            request = request.body_map(|body| body.detection_threshold(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::net::IpAddr>("local") {
+            request = request.body_map(|body| body.local(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::BfdMode>("mode") {
+            request = request.body_map(|body| body.mode(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::net::IpAddr>("remote") {
+            request = request.body_map(|body| body.remote(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<u64>("required-rx") {
+            request = request.body_map(|body| body.required_rx(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("switch") {
+            request = request.body_map(|body| body.switch(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::BfdSessionEnable>(&body_txt).unwrap();
+            request = request.body(body_value);
+        }
+
+        self.over
+            .execute_networking_bfd_enable(matches, &mut request)
+            .unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("error\n{:#?}", r)
+            }
+        }
+    }
+
+    pub async fn execute_networking_bfd_status(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.networking_bfd_status();
+        self.over
+            .execute_networking_bfd_status(matches, &mut request)
+            .unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("error\n{:#?}", r)
+            }
+        }
+    }
+
     pub async fn execute_networking_bgp_config_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.networking_bgp_config_list();
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
@@ -10799,6 +11105,14 @@ pub trait CliOverride {
         Ok(())
     }
 
+    fn execute_instance_ssh_public_key_list(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::InstanceSshPublicKeyList,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
     fn execute_instance_start(
         &self,
         matches: &clap::ArgMatches,
@@ -11391,6 +11705,30 @@ pub trait CliOverride {
         Ok(())
     }
 
+    fn execute_networking_bfd_disable(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::NetworkingBfdDisable,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn execute_networking_bfd_enable(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::NetworkingBfdEnable,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn execute_networking_bfd_status(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::NetworkingBfdStatus,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
     fn execute_networking_bgp_config_list(
         &self,
         matches: &clap::ArgMatches,
@@ -11840,6 +12178,7 @@ pub enum CliCommand {
     InstanceReboot,
     InstanceSerialConsole,
     InstanceSerialConsoleStream,
+    InstanceSshPublicKeyList,
     InstanceStart,
     InstanceStop,
     ProjectIpPoolList,
@@ -11914,6 +12253,9 @@ pub enum CliCommand {
     NetworkingAddressLotCreate,
     NetworkingAddressLotDelete,
     NetworkingAddressLotBlockList,
+    NetworkingBfdDisable,
+    NetworkingBfdEnable,
+    NetworkingBfdStatus,
     NetworkingBgpConfigList,
     NetworkingBgpConfigCreate,
     NetworkingBgpConfigDelete,
@@ -12014,6 +12356,7 @@ impl CliCommand {
             CliCommand::InstanceReboot,
             CliCommand::InstanceSerialConsole,
             CliCommand::InstanceSerialConsoleStream,
+            CliCommand::InstanceSshPublicKeyList,
             CliCommand::InstanceStart,
             CliCommand::InstanceStop,
             CliCommand::ProjectIpPoolList,
@@ -12088,6 +12431,9 @@ impl CliCommand {
             CliCommand::NetworkingAddressLotCreate,
             CliCommand::NetworkingAddressLotDelete,
             CliCommand::NetworkingAddressLotBlockList,
+            CliCommand::NetworkingBfdDisable,
+            CliCommand::NetworkingBfdEnable,
+            CliCommand::NetworkingBfdStatus,
             CliCommand::NetworkingBgpConfigList,
             CliCommand::NetworkingBgpConfigCreate,
             CliCommand::NetworkingBgpConfigDelete,

--- a/oxide.json
+++ b/oxide.json
@@ -2252,6 +2252,83 @@
         "x-dropshot-websocket": {}
       }
     },
+    "/v1/instances/{instance}/ssh-public-keys": {
+      "get": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "List the SSH public keys added to the instance via cloud-init during instance creation",
+        "description": "Note that this list is a snapshot in time and will not reflect updates made after the instance is created.",
+        "operationId": "instance_ssh_public_key_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance",
+            "description": "Name or ID of the instance",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrIdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SshKeyResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": {
+          "required": []
+        }
+      }
+    },
     "/v1/instances/{instance}/start": {
       "post": {
         "tags": [
@@ -5827,6 +5904,97 @@
         }
       }
     },
+    "/v1/system/networking/bfd-disable": {
+      "post": {
+        "tags": [
+          "system/networking"
+        ],
+        "summary": "Disable a BFD session.",
+        "operationId": "networking_bfd_disable",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BfdSessionDisable"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/system/networking/bfd-enable": {
+      "post": {
+        "tags": [
+          "system/networking"
+        ],
+        "summary": "Enable a BFD session.",
+        "operationId": "networking_bfd_enable",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BfdSessionEnable"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/system/networking/bfd-status": {
+      "get": {
+        "tags": [
+          "system/networking"
+        ],
+        "summary": "Get BFD status.",
+        "operationId": "networking_bfd_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_BfdStatus",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BfdStatus"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/system/networking/bgp": {
       "get": {
         "tags": [
@@ -8486,6 +8654,161 @@
           "part",
           "revision",
           "serial"
+        ]
+      },
+      "BfdMode": {
+        "type": "string",
+        "enum": [
+          "single_hop",
+          "multi_hop"
+        ]
+      },
+      "BfdSessionDisable": {
+        "description": "Information needed to disable a BFD session",
+        "type": "object",
+        "properties": {
+          "remote": {
+            "description": "Address of the remote peer to disable a BFD session for.",
+            "type": "string",
+            "format": "ip"
+          },
+          "switch": {
+            "description": "The switch to enable this session on. Must be `switch0` or `switch1`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        },
+        "required": [
+          "remote",
+          "switch"
+        ]
+      },
+      "BfdSessionEnable": {
+        "description": "Information about a bidirectional forwarding detection (BFD) session.",
+        "type": "object",
+        "properties": {
+          "detection_threshold": {
+            "description": "The negotiated Control packet transmission interval, multiplied by this variable, will be the Detection Time for this session (as seen by the remote system)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "local": {
+            "nullable": true,
+            "description": "Address the Oxide switch will listen on for BFD traffic. If `None` then the unspecified address (0.0.0.0 or ::) is used.",
+            "type": "string",
+            "format": "ip"
+          },
+          "mode": {
+            "description": "Select either single-hop (RFC 5881) or multi-hop (RFC 5883)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BfdMode"
+              }
+            ]
+          },
+          "remote": {
+            "description": "Address of the remote peer to establish a BFD session with.",
+            "type": "string",
+            "format": "ip"
+          },
+          "required_rx": {
+            "description": "The minimum interval, in microseconds, between received BFD Control packets that this system requires",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "switch": {
+            "description": "The switch to enable this session on. Must be `switch0` or `switch1`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        },
+        "required": [
+          "detection_threshold",
+          "mode",
+          "remote",
+          "required_rx",
+          "switch"
+        ]
+      },
+      "BfdState": {
+        "oneOf": [
+          {
+            "description": "A stable down state. Non-responsive to incoming messages.",
+            "type": "string",
+            "enum": [
+              "admin_down"
+            ]
+          },
+          {
+            "description": "The initial state.",
+            "type": "string",
+            "enum": [
+              "down"
+            ]
+          },
+          {
+            "description": "The peer has detected a remote peer in the down state.",
+            "type": "string",
+            "enum": [
+              "init"
+            ]
+          },
+          {
+            "description": "The peer has detected a remote peer in the up or init state while in the init state.",
+            "type": "string",
+            "enum": [
+              "up"
+            ]
+          }
+        ]
+      },
+      "BfdStatus": {
+        "type": "object",
+        "properties": {
+          "detection_threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "local": {
+            "nullable": true,
+            "type": "string",
+            "format": "ip"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/BfdMode"
+          },
+          "peer": {
+            "type": "string",
+            "format": "ip"
+          },
+          "required_rx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "state": {
+            "$ref": "#/components/schemas/BfdState"
+          },
+          "switch": {
+            "$ref": "#/components/schemas/Name"
+          }
+        },
+        "required": [
+          "detection_threshold",
+          "mode",
+          "peer",
+          "required_rx",
+          "state",
+          "switch"
         ]
       },
       "BgpAnnounceSet": {
@@ -12352,6 +12675,14 @@
                 "$ref": "#/components/schemas/InstanceNetworkInterfaceAttachment"
               }
             ]
+          },
+          "ssh_public_keys": {
+            "nullable": true,
+            "description": "An allowlist of SSH public keys to be transferred to the instance via cloud-init during instance creation.\n\nIf not provided, all SSH public keys from the user's profile will be sent. If an empty list is provided, no public keys will be transmitted to the instance.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
           },
           "start": {
             "description": "Should this instance be started upon creation; true by default.",

--- a/sdk-httpmock/src/generated_httpmock.rs
+++ b/sdk-httpmock/src/generated_httpmock.rs
@@ -3636,6 +3636,134 @@ pub mod operations {
         }
     }
 
+    pub struct InstanceSshPublicKeyListWhen(httpmock::When);
+    impl InstanceSshPublicKeyListWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner.method(httpmock::Method::GET).path_matches(
+                    regex::Regex::new("^/v1/instances/[^/]*/ssh-public-keys$").unwrap(),
+                ),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn instance(self, value: &types::NameOrId) -> Self {
+            let re = regex::Regex::new(&format!(
+                "^/v1/instances/{}/ssh-public-keys$",
+                value.to_string()
+            ))
+            .unwrap();
+            Self(self.0.path_matches(re))
+        }
+
+        pub fn limit<T>(self, value: T) -> Self
+        where
+            T: Into<Option<std::num::NonZeroU32>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("limit", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "limit"))
+                        .is_none()
+                }))
+            }
+        }
+
+        pub fn page_token<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a str>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page_token", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "page_token"))
+                        .is_none()
+                }))
+            }
+        }
+
+        pub fn project<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a types::NameOrId>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("project", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "project"))
+                        .is_none()
+                }))
+            }
+        }
+
+        pub fn sort_by<T>(self, value: T) -> Self
+        where
+            T: Into<Option<types::NameOrIdSortMode>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("sort_by", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "sort_by"))
+                        .is_none()
+                }))
+            }
+        }
+    }
+
+    pub struct InstanceSshPublicKeyListThen(httpmock::Then);
+    impl InstanceSshPublicKeyListThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn ok(self, value: &types::SshKeyResultsPage) -> Self {
+            Self(
+                self.0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
     pub struct InstanceStartWhen(httpmock::When);
     impl InstanceStartWhen {
         pub fn new(inner: httpmock::When) -> Self {
@@ -9462,6 +9590,169 @@ pub mod operations {
         }
     }
 
+    pub struct NetworkingBfdDisableWhen(httpmock::When);
+    impl NetworkingBfdDisableWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner.method(httpmock::Method::POST).path_matches(
+                    regex::Regex::new("^/v1/system/networking/bfd-disable$").unwrap(),
+                ),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn body(self, value: &types::BfdSessionDisable) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+
+    pub struct NetworkingBfdDisableThen(httpmock::Then);
+    impl NetworkingBfdDisableThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn no_content(self) -> Self {
+            Self(self.0.status(204u16))
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
+    pub struct NetworkingBfdEnableWhen(httpmock::When);
+    impl NetworkingBfdEnableWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(regex::Regex::new("^/v1/system/networking/bfd-enable$").unwrap()),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn body(self, value: &types::BfdSessionEnable) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+
+    pub struct NetworkingBfdEnableThen(httpmock::Then);
+    impl NetworkingBfdEnableThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn no_content(self) -> Self {
+            Self(self.0.status(204u16))
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
+    pub struct NetworkingBfdStatusWhen(httpmock::When);
+    impl NetworkingBfdStatusWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(regex::Regex::new("^/v1/system/networking/bfd-status$").unwrap()),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+    }
+
+    pub struct NetworkingBfdStatusThen(httpmock::Then);
+    impl NetworkingBfdStatusThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn ok(self, value: &Vec<types::BfdStatus>) -> Self {
+            Self(
+                self.0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
     pub struct NetworkingBgpConfigListWhen(httpmock::When);
     impl NetworkingBgpConfigListWhen {
         pub fn new(inner: httpmock::When) -> Self {
@@ -13572,6 +13863,12 @@ pub trait MockServerExt {
             operations::InstanceSerialConsoleStreamWhen,
             operations::InstanceSerialConsoleStreamThen,
         );
+    fn instance_ssh_public_key_list<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::InstanceSshPublicKeyListWhen,
+            operations::InstanceSshPublicKeyListThen,
+        );
     fn instance_start<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::InstanceStartWhen, operations::InstanceStartThen);
@@ -13842,6 +14139,15 @@ pub trait MockServerExt {
             operations::NetworkingAddressLotBlockListWhen,
             operations::NetworkingAddressLotBlockListThen,
         );
+    fn networking_bfd_disable<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBfdDisableWhen, operations::NetworkingBfdDisableThen);
+    fn networking_bfd_enable<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBfdEnableWhen, operations::NetworkingBfdEnableThen);
+    fn networking_bfd_status<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBfdStatusWhen, operations::NetworkingBfdStatusThen);
     fn networking_bgp_config_list<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::NetworkingBgpConfigListWhen, operations::NetworkingBgpConfigListThen);
@@ -14585,6 +14891,21 @@ impl MockServerExt for httpmock::MockServer {
             config_fn(
                 operations::InstanceSerialConsoleStreamWhen::new(when),
                 operations::InstanceSerialConsoleStreamThen::new(then),
+            )
+        })
+    }
+
+    fn instance_ssh_public_key_list<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::InstanceSshPublicKeyListWhen,
+            operations::InstanceSshPublicKeyListThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::InstanceSshPublicKeyListWhen::new(when),
+                operations::InstanceSshPublicKeyListThen::new(then),
             )
         })
     }
@@ -15521,6 +15842,42 @@ impl MockServerExt for httpmock::MockServer {
             config_fn(
                 operations::NetworkingAddressLotBlockListWhen::new(when),
                 operations::NetworkingAddressLotBlockListThen::new(then),
+            )
+        })
+    }
+
+    fn networking_bfd_disable<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBfdDisableWhen, operations::NetworkingBfdDisableThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::NetworkingBfdDisableWhen::new(when),
+                operations::NetworkingBfdDisableThen::new(then),
+            )
+        })
+    }
+
+    fn networking_bfd_enable<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBfdEnableWhen, operations::NetworkingBfdEnableThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::NetworkingBfdEnableWhen::new(when),
+                operations::NetworkingBfdEnableThen::new(then),
+            )
+        })
+    }
+
+    fn networking_bfd_status<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBfdStatusWhen, operations::NetworkingBfdStatusThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::NetworkingBfdStatusWhen::new(when),
+                operations::NetworkingBfdStatusThen::new(then),
             )
         })
     }

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -696,6 +696,440 @@ pub mod types {
         }
     }
 
+    /// BfdMode
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "single_hop",
+    ///    "multi_hop"
+    ///  ]
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        Deserialize,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Serialize,
+        schemars :: JsonSchema,
+    )]
+    pub enum BfdMode {
+        #[serde(rename = "single_hop")]
+        SingleHop,
+        #[serde(rename = "multi_hop")]
+        MultiHop,
+    }
+
+    impl From<&BfdMode> for BfdMode {
+        fn from(value: &BfdMode) -> Self {
+            value.clone()
+        }
+    }
+
+    impl ToString for BfdMode {
+        fn to_string(&self) -> String {
+            match *self {
+                Self::SingleHop => "single_hop".to_string(),
+                Self::MultiHop => "multi_hop".to_string(),
+            }
+        }
+    }
+
+    impl std::str::FromStr for BfdMode {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
+            match value {
+                "single_hop" => Ok(Self::SingleHop),
+                "multi_hop" => Ok(Self::MultiHop),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+
+    impl std::convert::TryFrom<&str> for BfdMode {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl std::convert::TryFrom<&String> for BfdMode {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl std::convert::TryFrom<String> for BfdMode {
+        type Error = self::error::ConversionError;
+        fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    /// Information needed to disable a BFD session
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Information needed to disable a BFD session",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "remote",
+    ///    "switch"
+    ///  ],
+    ///  "properties": {
+    ///    "remote": {
+    ///      "description": "Address of the remote peer to disable a BFD session
+    /// for.",
+    ///      "type": "string",
+    ///      "format": "ip"
+    ///    },
+    ///    "switch": {
+    ///      "description": "The switch to enable this session on. Must be
+    /// `switch0` or `switch1`.",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/Name"
+    ///        }
+    ///      ]
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, Serialize, schemars :: JsonSchema)]
+    pub struct BfdSessionDisable {
+        /// Address of the remote peer to disable a BFD session for.
+        pub remote: std::net::IpAddr,
+        /// The switch to enable this session on. Must be `switch0` or
+        /// `switch1`.
+        pub switch: Name,
+    }
+
+    impl From<&BfdSessionDisable> for BfdSessionDisable {
+        fn from(value: &BfdSessionDisable) -> Self {
+            value.clone()
+        }
+    }
+
+    impl BfdSessionDisable {
+        pub fn builder() -> builder::BfdSessionDisable {
+            Default::default()
+        }
+    }
+
+    /// Information about a bidirectional forwarding detection (BFD) session.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Information about a bidirectional forwarding detection
+    /// (BFD) session.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "detection_threshold",
+    ///    "mode",
+    ///    "remote",
+    ///    "required_rx",
+    ///    "switch"
+    ///  ],
+    ///  "properties": {
+    ///    "detection_threshold": {
+    ///      "description": "The negotiated Control packet transmission
+    /// interval, multiplied by this variable, will be the Detection Time for
+    /// this session (as seen by the remote system)",
+    ///      "type": "integer",
+    ///      "format": "uint8",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "local": {
+    ///      "description": "Address the Oxide switch will listen on for BFD
+    /// traffic. If `None` then the unspecified address (0.0.0.0 or ::) is
+    /// used.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ],
+    ///      "format": "ip"
+    ///    },
+    ///    "mode": {
+    ///      "description": "Select either single-hop (RFC 5881) or multi-hop
+    /// (RFC 5883)",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/BfdMode"
+    ///        }
+    ///      ]
+    ///    },
+    ///    "remote": {
+    ///      "description": "Address of the remote peer to establish a BFD
+    /// session with.",
+    ///      "type": "string",
+    ///      "format": "ip"
+    ///    },
+    ///    "required_rx": {
+    ///      "description": "The minimum interval, in microseconds, between
+    /// received BFD Control packets that this system requires",
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "switch": {
+    ///      "description": "The switch to enable this session on. Must be
+    /// `switch0` or `switch1`.",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/Name"
+    ///        }
+    ///      ]
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, Serialize, schemars :: JsonSchema)]
+    pub struct BfdSessionEnable {
+        /// The negotiated Control packet transmission interval, multiplied by
+        /// this variable, will be the Detection Time for this session (as seen
+        /// by the remote system)
+        pub detection_threshold: u8,
+        /// Address the Oxide switch will listen on for BFD traffic. If `None`
+        /// then the unspecified address (0.0.0.0 or ::) is used.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub local: Option<std::net::IpAddr>,
+        /// Select either single-hop (RFC 5881) or multi-hop (RFC 5883)
+        pub mode: BfdMode,
+        /// Address of the remote peer to establish a BFD session with.
+        pub remote: std::net::IpAddr,
+        /// The minimum interval, in microseconds, between received BFD Control
+        /// packets that this system requires
+        pub required_rx: u64,
+        /// The switch to enable this session on. Must be `switch0` or
+        /// `switch1`.
+        pub switch: Name,
+    }
+
+    impl From<&BfdSessionEnable> for BfdSessionEnable {
+        fn from(value: &BfdSessionEnable) -> Self {
+            value.clone()
+        }
+    }
+
+    impl BfdSessionEnable {
+        pub fn builder() -> builder::BfdSessionEnable {
+            Default::default()
+        }
+    }
+
+    /// BfdState
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "oneOf": [
+    ///    {
+    ///      "description": "A stable down state. Non-responsive to incoming
+    /// messages.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "admin_down"
+    ///      ]
+    ///    },
+    ///    {
+    ///      "description": "The initial state.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "down"
+    ///      ]
+    ///    },
+    ///    {
+    ///      "description": "The peer has detected a remote peer in the down
+    /// state.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "init"
+    ///      ]
+    ///    },
+    ///    {
+    ///      "description": "The peer has detected a remote peer in the up or
+    /// init state while in the init state.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "up"
+    ///      ]
+    ///    }
+    ///  ]
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        Deserialize,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Serialize,
+        schemars :: JsonSchema,
+    )]
+    pub enum BfdState {
+        /// A stable down state. Non-responsive to incoming messages.
+        #[serde(rename = "admin_down")]
+        AdminDown,
+        /// The initial state.
+        #[serde(rename = "down")]
+        Down,
+        /// The peer has detected a remote peer in the down state.
+        #[serde(rename = "init")]
+        Init,
+        /// The peer has detected a remote peer in the up or init state while in
+        /// the init state.
+        #[serde(rename = "up")]
+        Up,
+    }
+
+    impl From<&BfdState> for BfdState {
+        fn from(value: &BfdState) -> Self {
+            value.clone()
+        }
+    }
+
+    impl ToString for BfdState {
+        fn to_string(&self) -> String {
+            match *self {
+                Self::AdminDown => "admin_down".to_string(),
+                Self::Down => "down".to_string(),
+                Self::Init => "init".to_string(),
+                Self::Up => "up".to_string(),
+            }
+        }
+    }
+
+    impl std::str::FromStr for BfdState {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
+            match value {
+                "admin_down" => Ok(Self::AdminDown),
+                "down" => Ok(Self::Down),
+                "init" => Ok(Self::Init),
+                "up" => Ok(Self::Up),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+
+    impl std::convert::TryFrom<&str> for BfdState {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl std::convert::TryFrom<&String> for BfdState {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl std::convert::TryFrom<String> for BfdState {
+        type Error = self::error::ConversionError;
+        fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    /// BfdStatus
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "type": "object",
+    ///  "required": [
+    ///    "detection_threshold",
+    ///    "mode",
+    ///    "peer",
+    ///    "required_rx",
+    ///    "state",
+    ///    "switch"
+    ///  ],
+    ///  "properties": {
+    ///    "detection_threshold": {
+    ///      "type": "integer",
+    ///      "format": "uint8",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "local": {
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ],
+    ///      "format": "ip"
+    ///    },
+    ///    "mode": {
+    ///      "$ref": "#/components/schemas/BfdMode"
+    ///    },
+    ///    "peer": {
+    ///      "type": "string",
+    ///      "format": "ip"
+    ///    },
+    ///    "required_rx": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "state": {
+    ///      "$ref": "#/components/schemas/BfdState"
+    ///    },
+    ///    "switch": {
+    ///      "$ref": "#/components/schemas/Name"
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, Serialize, schemars :: JsonSchema)]
+    pub struct BfdStatus {
+        pub detection_threshold: u8,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub local: Option<std::net::IpAddr>,
+        pub mode: BfdMode,
+        pub peer: std::net::IpAddr,
+        pub required_rx: u64,
+        pub state: BfdState,
+        pub switch: Name,
+    }
+
+    impl From<&BfdStatus> for BfdStatus {
+        fn from(value: &BfdStatus) -> Self {
+            value.clone()
+        }
+    }
+
+    impl BfdStatus {
+        pub fn builder() -> builder::BfdStatus {
+            Default::default()
+        }
+    }
+
     /// Represents a BGP announce set by id. The id can be used with other API
     /// calls to view and manage the announce set.
     ///
@@ -8587,6 +9021,20 @@ pub mod types {
     ///        }
     ///      ]
     ///    },
+    ///    "ssh_public_keys": {
+    ///      "description": "An allowlist of SSH public keys to be transferred
+    /// to the instance via cloud-init during instance creation.\n\nIf not
+    /// provided, all SSH public keys from the user's profile will be sent. If
+    /// an empty list is provided, no public keys will be transmitted to the
+    /// instance.",
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/NameOrId"
+    ///      }
+    ///    },
     ///    "start": {
     ///      "description": "Should this instance be started upon creation; true
     /// by default.",
@@ -8627,6 +9075,14 @@ pub mod types {
         /// The network interfaces to be created for this instance.
         #[serde(default = "defaults::instance_create_network_interfaces")]
         pub network_interfaces: InstanceNetworkInterfaceAttachment,
+        /// An allowlist of SSH public keys to be transferred to the instance
+        /// via cloud-init during instance creation.
+        ///
+        /// If not provided, all SSH public keys from the user's profile will be
+        /// sent. If an empty list is provided, no public keys will be
+        /// transmitted to the instance.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub ssh_public_keys: Option<Vec<NameOrId>>,
         /// Should this instance be started upon creation; true by default.
         #[serde(default = "defaults::default_bool::<true>")]
         pub start: bool,
@@ -20631,6 +21087,313 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
+        pub struct BfdSessionDisable {
+            remote: Result<std::net::IpAddr, String>,
+            switch: Result<super::Name, String>,
+        }
+
+        impl Default for BfdSessionDisable {
+            fn default() -> Self {
+                Self {
+                    remote: Err("no value supplied for remote".to_string()),
+                    switch: Err("no value supplied for switch".to_string()),
+                }
+            }
+        }
+
+        impl BfdSessionDisable {
+            pub fn remote<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<std::net::IpAddr>,
+                T::Error: std::fmt::Display,
+            {
+                self.remote = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for remote: {}", e));
+                self
+            }
+            pub fn switch<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::Name>,
+                T::Error: std::fmt::Display,
+            {
+                self.switch = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<BfdSessionDisable> for super::BfdSessionDisable {
+            type Error = super::error::ConversionError;
+            fn try_from(value: BfdSessionDisable) -> Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    remote: value.remote?,
+                    switch: value.switch?,
+                })
+            }
+        }
+
+        impl From<super::BfdSessionDisable> for BfdSessionDisable {
+            fn from(value: super::BfdSessionDisable) -> Self {
+                Self {
+                    remote: Ok(value.remote),
+                    switch: Ok(value.switch),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct BfdSessionEnable {
+            detection_threshold: Result<u8, String>,
+            local: Result<Option<std::net::IpAddr>, String>,
+            mode: Result<super::BfdMode, String>,
+            remote: Result<std::net::IpAddr, String>,
+            required_rx: Result<u64, String>,
+            switch: Result<super::Name, String>,
+        }
+
+        impl Default for BfdSessionEnable {
+            fn default() -> Self {
+                Self {
+                    detection_threshold: Err(
+                        "no value supplied for detection_threshold".to_string()
+                    ),
+                    local: Ok(Default::default()),
+                    mode: Err("no value supplied for mode".to_string()),
+                    remote: Err("no value supplied for remote".to_string()),
+                    required_rx: Err("no value supplied for required_rx".to_string()),
+                    switch: Err("no value supplied for switch".to_string()),
+                }
+            }
+        }
+
+        impl BfdSessionEnable {
+            pub fn detection_threshold<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<u8>,
+                T::Error: std::fmt::Display,
+            {
+                self.detection_threshold = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for detection_threshold: {}",
+                        e
+                    )
+                });
+                self
+            }
+            pub fn local<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<std::net::IpAddr>>,
+                T::Error: std::fmt::Display,
+            {
+                self.local = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for local: {}", e));
+                self
+            }
+            pub fn mode<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::BfdMode>,
+                T::Error: std::fmt::Display,
+            {
+                self.mode = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for mode: {}", e));
+                self
+            }
+            pub fn remote<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<std::net::IpAddr>,
+                T::Error: std::fmt::Display,
+            {
+                self.remote = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for remote: {}", e));
+                self
+            }
+            pub fn required_rx<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<u64>,
+                T::Error: std::fmt::Display,
+            {
+                self.required_rx = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for required_rx: {}", e));
+                self
+            }
+            pub fn switch<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::Name>,
+                T::Error: std::fmt::Display,
+            {
+                self.switch = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<BfdSessionEnable> for super::BfdSessionEnable {
+            type Error = super::error::ConversionError;
+            fn try_from(value: BfdSessionEnable) -> Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    detection_threshold: value.detection_threshold?,
+                    local: value.local?,
+                    mode: value.mode?,
+                    remote: value.remote?,
+                    required_rx: value.required_rx?,
+                    switch: value.switch?,
+                })
+            }
+        }
+
+        impl From<super::BfdSessionEnable> for BfdSessionEnable {
+            fn from(value: super::BfdSessionEnable) -> Self {
+                Self {
+                    detection_threshold: Ok(value.detection_threshold),
+                    local: Ok(value.local),
+                    mode: Ok(value.mode),
+                    remote: Ok(value.remote),
+                    required_rx: Ok(value.required_rx),
+                    switch: Ok(value.switch),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct BfdStatus {
+            detection_threshold: Result<u8, String>,
+            local: Result<Option<std::net::IpAddr>, String>,
+            mode: Result<super::BfdMode, String>,
+            peer: Result<std::net::IpAddr, String>,
+            required_rx: Result<u64, String>,
+            state: Result<super::BfdState, String>,
+            switch: Result<super::Name, String>,
+        }
+
+        impl Default for BfdStatus {
+            fn default() -> Self {
+                Self {
+                    detection_threshold: Err(
+                        "no value supplied for detection_threshold".to_string()
+                    ),
+                    local: Ok(Default::default()),
+                    mode: Err("no value supplied for mode".to_string()),
+                    peer: Err("no value supplied for peer".to_string()),
+                    required_rx: Err("no value supplied for required_rx".to_string()),
+                    state: Err("no value supplied for state".to_string()),
+                    switch: Err("no value supplied for switch".to_string()),
+                }
+            }
+        }
+
+        impl BfdStatus {
+            pub fn detection_threshold<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<u8>,
+                T::Error: std::fmt::Display,
+            {
+                self.detection_threshold = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for detection_threshold: {}",
+                        e
+                    )
+                });
+                self
+            }
+            pub fn local<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<std::net::IpAddr>>,
+                T::Error: std::fmt::Display,
+            {
+                self.local = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for local: {}", e));
+                self
+            }
+            pub fn mode<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::BfdMode>,
+                T::Error: std::fmt::Display,
+            {
+                self.mode = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for mode: {}", e));
+                self
+            }
+            pub fn peer<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<std::net::IpAddr>,
+                T::Error: std::fmt::Display,
+            {
+                self.peer = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for peer: {}", e));
+                self
+            }
+            pub fn required_rx<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<u64>,
+                T::Error: std::fmt::Display,
+            {
+                self.required_rx = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for required_rx: {}", e));
+                self
+            }
+            pub fn state<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::BfdState>,
+                T::Error: std::fmt::Display,
+            {
+                self.state = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                self
+            }
+            pub fn switch<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::Name>,
+                T::Error: std::fmt::Display,
+            {
+                self.switch = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<BfdStatus> for super::BfdStatus {
+            type Error = super::error::ConversionError;
+            fn try_from(value: BfdStatus) -> Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    detection_threshold: value.detection_threshold?,
+                    local: value.local?,
+                    mode: value.mode?,
+                    peer: value.peer?,
+                    required_rx: value.required_rx?,
+                    state: value.state?,
+                    switch: value.switch?,
+                })
+            }
+        }
+
+        impl From<super::BfdStatus> for BfdStatus {
+            fn from(value: super::BfdStatus) -> Self {
+                Self {
+                    detection_threshold: Ok(value.detection_threshold),
+                    local: Ok(value.local),
+                    mode: Ok(value.mode),
+                    peer: Ok(value.peer),
+                    required_rx: Ok(value.required_rx),
+                    state: Ok(value.state),
+                    switch: Ok(value.switch),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
         pub struct BgpAnnounceSet {
             description: Result<String, String>,
             id: Result<uuid::Uuid, String>,
@@ -25672,6 +26435,7 @@ pub mod types {
             name: Result<super::Name, String>,
             ncpus: Result<super::InstanceCpuCount, String>,
             network_interfaces: Result<super::InstanceNetworkInterfaceAttachment, String>,
+            ssh_public_keys: Result<Option<Vec<super::NameOrId>>, String>,
             start: Result<bool, String>,
             user_data: Result<String, String>,
         }
@@ -25687,6 +26451,7 @@ pub mod types {
                     name: Err("no value supplied for name".to_string()),
                     ncpus: Err("no value supplied for ncpus".to_string()),
                     network_interfaces: Ok(super::defaults::instance_create_network_interfaces()),
+                    ssh_public_keys: Ok(Default::default()),
                     start: Ok(super::defaults::default_bool::<true>()),
                     user_data: Ok(Default::default()),
                 }
@@ -25777,6 +26542,16 @@ pub mod types {
                 });
                 self
             }
+            pub fn ssh_public_keys<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<Vec<super::NameOrId>>>,
+                T::Error: std::fmt::Display,
+            {
+                self.ssh_public_keys = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for ssh_public_keys: {}", e)
+                });
+                self
+            }
             pub fn start<T>(mut self, value: T) -> Self
             where
                 T: std::convert::TryInto<bool>,
@@ -25811,6 +26586,7 @@ pub mod types {
                     name: value.name?,
                     ncpus: value.ncpus?,
                     network_interfaces: value.network_interfaces?,
+                    ssh_public_keys: value.ssh_public_keys?,
                     start: value.start?,
                     user_data: value.user_data?,
                 })
@@ -25828,6 +26604,7 @@ pub mod types {
                     name: Ok(value.name),
                     ncpus: Ok(value.ncpus),
                     network_interfaces: Ok(value.network_interfaces),
+                    ssh_public_keys: Ok(value.ssh_public_keys),
                     start: Ok(value.start),
                     user_data: Ok(value.user_data),
                 }
@@ -35856,6 +36633,32 @@ pub trait ClientInstancesExt {
     ///    .await;
     /// ```
     fn instance_serial_console_stream(&self) -> builder::InstanceSerialConsoleStream;
+    /// List the SSH public keys added to the instance via cloud-init during
+    /// instance creation
+    ///
+    /// Note that this list is a snapshot in time and will not reflect updates
+    /// made after the instance is created.
+    ///
+    /// Sends a `GET` request to `/v1/instances/{instance}/ssh-public-keys`
+    ///
+    /// Arguments:
+    /// - `instance`: Name or ID of the instance
+    /// - `limit`: Maximum number of items returned by a single call
+    /// - `page_token`: Token returned by previous call to retrieve the
+    ///   subsequent page
+    /// - `project`: Name or ID of the project
+    /// - `sort_by`
+    /// ```ignore
+    /// let response = client.instance_ssh_public_key_list()
+    ///    .instance(instance)
+    ///    .limit(limit)
+    ///    .page_token(page_token)
+    ///    .project(project)
+    ///    .sort_by(sort_by)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn instance_ssh_public_key_list(&self) -> builder::InstanceSshPublicKeyList;
     /// Boot an instance
     ///
     /// Sends a `POST` request to `/v1/instances/{instance}/start`
@@ -36045,6 +36848,10 @@ impl ClientInstancesExt for Client {
 
     fn instance_serial_console_stream(&self) -> builder::InstanceSerialConsoleStream {
         builder::InstanceSerialConsoleStream::new(self)
+    }
+
+    fn instance_ssh_public_key_list(&self) -> builder::InstanceSshPublicKeyList {
+        builder::InstanceSshPublicKeyList::new(self)
     }
 
     fn instance_start(&self) -> builder::InstanceStart {
@@ -37467,6 +38274,38 @@ pub trait ClientSystemNetworkingExt {
     ///    .await;
     /// ```
     fn networking_address_lot_block_list(&self) -> builder::NetworkingAddressLotBlockList;
+    /// Disable a BFD session
+    ///
+    /// Sends a `POST` request to `/v1/system/networking/bfd-disable`
+    ///
+    /// ```ignore
+    /// let response = client.networking_bfd_disable()
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn networking_bfd_disable(&self) -> builder::NetworkingBfdDisable;
+    /// Enable a BFD session
+    ///
+    /// Sends a `POST` request to `/v1/system/networking/bfd-enable`
+    ///
+    /// ```ignore
+    /// let response = client.networking_bfd_enable()
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn networking_bfd_enable(&self) -> builder::NetworkingBfdEnable;
+    /// Get BFD status
+    ///
+    /// Sends a `GET` request to `/v1/system/networking/bfd-status`
+    ///
+    /// ```ignore
+    /// let response = client.networking_bfd_status()
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn networking_bfd_status(&self) -> builder::NetworkingBfdStatus;
     /// List BGP configurations
     ///
     /// Sends a `GET` request to `/v1/system/networking/bgp`
@@ -37768,6 +38607,18 @@ impl ClientSystemNetworkingExt for Client {
 
     fn networking_address_lot_block_list(&self) -> builder::NetworkingAddressLotBlockList {
         builder::NetworkingAddressLotBlockList::new(self)
+    }
+
+    fn networking_bfd_disable(&self) -> builder::NetworkingBfdDisable {
+        builder::NetworkingBfdDisable::new(self)
+    }
+
+    fn networking_bfd_enable(&self) -> builder::NetworkingBfdEnable {
+        builder::NetworkingBfdEnable::new(self)
+    }
+
+    fn networking_bfd_status(&self) -> builder::NetworkingBfdStatus {
+        builder::NetworkingBfdStatus::new(self)
     }
 
     fn networking_bgp_config_list(&self) -> builder::NetworkingBgpConfigList {
@@ -43285,6 +44136,200 @@ pub mod builder {
                 200..=299 => ResponseValue::upgrade(response).await,
                 _ => Err(Error::UnexpectedResponse(response)),
             }
+        }
+    }
+
+    /// Builder for [`ClientInstancesExt::instance_ssh_public_key_list`]
+    ///
+    /// [`ClientInstancesExt::instance_ssh_public_key_list`]: super::ClientInstancesExt::instance_ssh_public_key_list
+    #[derive(Debug, Clone)]
+    pub struct InstanceSshPublicKeyList<'a> {
+        client: &'a super::Client,
+        instance: Result<types::NameOrId, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        project: Result<Option<types::NameOrId>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
+    }
+
+    impl<'a> InstanceSshPublicKeyList<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                instance: Err("instance was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                project: Ok(None),
+                sort_by: Ok(None),
+            }
+        }
+
+        pub fn instance<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.instance = value
+                .try_into()
+                .map_err(|_| "conversion to `NameOrId` for instance failed".to_string());
+            self
+        }
+
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `std :: num :: NonZeroU32` for limit failed".to_string()
+            });
+            self
+        }
+
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `String` for page_token failed".to_string());
+            self
+        }
+
+        pub fn project<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrId>,
+        {
+            self.project = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `NameOrId` for project failed".to_string());
+            self
+        }
+
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `NameOrIdSortMode` for sort_by failed".to_string());
+            self
+        }
+
+        /// Sends a `GET` request to `/v1/instances/{instance}/ssh-public-keys`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
+            let Self {
+                client,
+                instance,
+                limit,
+                page_token,
+                project,
+                sort_by,
+            } = self;
+            let instance = instance.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let project = project.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
+            let url = format!(
+                "{}/v1/instances/{}/ssh-public-keys",
+                client.baseurl,
+                encode_path(&instance.to_string()),
+            );
+            let mut query = Vec::with_capacity(4usize);
+            if let Some(v) = &limit {
+                query.push(("limit", v.to_string()));
+            }
+            if let Some(v) = &page_token {
+                query.push(("page_token", v.to_string()));
+            }
+            if let Some(v) = &project {
+                query.push(("project", v.to_string()));
+            }
+            if let Some(v) = &sort_by {
+                query.push(("sort_by", v.to_string()));
+            }
+            let request = client
+                .client
+                .get(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&query)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+
+        /// Streams `GET` requests to `/v1/instances/{instance}/ssh-public-keys`
+        pub fn stream(
+            self,
+        ) -> impl futures::Stream<Item = Result<types::SshKey, Error<types::Error>>> + Unpin + 'a
+        {
+            use futures::StreamExt;
+            use futures::TryFutureExt;
+            use futures::TryStreamExt;
+            let limit = self
+                .limit
+                .clone()
+                .ok()
+                .flatten()
+                .and_then(|x| std::num::NonZeroUsize::try_from(x).ok())
+                .map(std::num::NonZeroUsize::get)
+                .unwrap_or(usize::MAX);
+            let next = Self {
+                limit: Ok(None),
+                page_token: Ok(None),
+                project: Ok(None),
+                sort_by: Ok(None),
+                ..self.clone()
+            };
+            self.send()
+                .map_ok(move |page| {
+                    let page = page.into_inner();
+                    let first = futures::stream::iter(page.items).map(Ok);
+                    let rest = futures::stream::try_unfold(
+                        (page.next_page, next),
+                        |(next_page, next)| async {
+                            if next_page.is_none() {
+                                Ok(None)
+                            } else {
+                                Self {
+                                    page_token: Ok(next_page),
+                                    ..next.clone()
+                                }
+                                .send()
+                                .map_ok(|page| {
+                                    let page = page.into_inner();
+                                    Some((
+                                        futures::stream::iter(page.items).map(Ok),
+                                        (page.next_page, next),
+                                    ))
+                                })
+                                .await
+                            }
+                        },
+                    )
+                    .try_flatten();
+                    first.chain(rest)
+                })
+                .try_flatten_stream()
+                .take(limit)
+                .boxed()
         }
     }
 
@@ -51043,6 +52088,188 @@ pub mod builder {
                 .try_flatten_stream()
                 .take(limit)
                 .boxed()
+        }
+    }
+
+    /// Builder for [`ClientSystemNetworkingExt::networking_bfd_disable`]
+    ///
+    /// [`ClientSystemNetworkingExt::networking_bfd_disable`]: super::ClientSystemNetworkingExt::networking_bfd_disable
+    #[derive(Debug, Clone)]
+    pub struct NetworkingBfdDisable<'a> {
+        client: &'a super::Client,
+        body: Result<types::builder::BfdSessionDisable, String>,
+    }
+
+    impl<'a> NetworkingBfdDisable<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                body: Ok(types::builder::BfdSessionDisable::default()),
+            }
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::BfdSessionDisable>,
+            <V as std::convert::TryInto<types::BfdSessionDisable>>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| format!("conversion to `BfdSessionDisable` for body failed: {}", s));
+            self
+        }
+
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::BfdSessionDisable,
+            ) -> types::builder::BfdSessionDisable,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+
+        /// Sends a `POST` request to `/v1/system/networking/bfd-disable`
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
+            let Self { client, body } = self;
+            let body = body
+                .and_then(|v| types::BfdSessionDisable::try_from(v).map_err(|e| e.to_string()))
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/v1/system/networking/bfd-disable", client.baseurl,);
+            let request = client
+                .client
+                .post(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    /// Builder for [`ClientSystemNetworkingExt::networking_bfd_enable`]
+    ///
+    /// [`ClientSystemNetworkingExt::networking_bfd_enable`]: super::ClientSystemNetworkingExt::networking_bfd_enable
+    #[derive(Debug, Clone)]
+    pub struct NetworkingBfdEnable<'a> {
+        client: &'a super::Client,
+        body: Result<types::builder::BfdSessionEnable, String>,
+    }
+
+    impl<'a> NetworkingBfdEnable<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                body: Ok(types::builder::BfdSessionEnable::default()),
+            }
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::BfdSessionEnable>,
+            <V as std::convert::TryInto<types::BfdSessionEnable>>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| format!("conversion to `BfdSessionEnable` for body failed: {}", s));
+            self
+        }
+
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::BfdSessionEnable,
+            ) -> types::builder::BfdSessionEnable,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+
+        /// Sends a `POST` request to `/v1/system/networking/bfd-enable`
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
+            let Self { client, body } = self;
+            let body = body
+                .and_then(|v| types::BfdSessionEnable::try_from(v).map_err(|e| e.to_string()))
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/v1/system/networking/bfd-enable", client.baseurl,);
+            let request = client
+                .client
+                .post(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    /// Builder for [`ClientSystemNetworkingExt::networking_bfd_status`]
+    ///
+    /// [`ClientSystemNetworkingExt::networking_bfd_status`]: super::ClientSystemNetworkingExt::networking_bfd_status
+    #[derive(Debug, Clone)]
+    pub struct NetworkingBfdStatus<'a> {
+        client: &'a super::Client,
+    }
+
+    impl<'a> NetworkingBfdStatus<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self { client: client }
+        }
+
+        /// Sends a `GET` request to `/v1/system/networking/bfd-status`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<Vec<types::BfdStatus>>, Error<types::Error>> {
+            let Self { client } = self;
+            let url = format!("{}/v1/system/networking/bfd-status", client.baseurl,);
+            let request = client
+                .client
+                .get(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
         }
     }
 


### PR DESCRIPTION
Adds BFD management commands to the CLI.

Depends on

- oxidecomputer/omicron#4852