### PR TITLE
Ignore lock only integration changes

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           # Compare the integration branch with the target branch
           CHANGED_FILES=$(git diff integration..main --name-only | wc -l)
+          HAS_NON_LOCK_CHANGES=[ "$CHANGED_FILES" -gt 0 ] && ([ "$CHANGED_FILES" -gt 1 ] || [ $(git diff integration..main --name-only) != "Cargo.lock" ])
           TARGET_TO_INT="$(git rev-list --count $TARGET_BRANCH..$INT_BRANCH)"
           INT_TO_TARGET="$(git rev-list --count $INT_BRANCH..$TARGET_BRANCH)"
 
@@ -224,7 +225,14 @@ jobs:
 
             if [ -z "$NUMBER" -o "$STATE" != "OPEN" ]
             then
-              gh pr create -B $TARGET_BRANCH -H $INT_BRANCH --title "$title" --body-file body
+              # Only create a new PR if the changes between the integration branch and target branch
+              # affect more than the Cargo.lock file
+              if [ "$HAS_NON_LOCK_CHANGES" -eq 0 ]
+              then
+                gh pr create -B $TARGET_BRANCH -H $INT_BRANCH --title "$title" --body-file body
+              else
+                echo "Only integration changes is a modification to Cargo.lock. Skipping PR creation"
+              fi
             else
               echo "PR already exists: ($NUMBER) $URL . Updating..."
               gh pr edit "$NUMBER" --title "$title" --body-file body

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -231,7 +231,7 @@ jobs:
               then
                 gh pr create -B $TARGET_BRANCH -H $INT_BRANCH --title "$title" --body-file body
               else
-                echo "Only integration changes is a modification to Cargo.lock. Skipping PR creation"
+                echo "Only integration change is a modification to Cargo.lock. Skipping PR creation"
               fi
             else
               echo "PR already exists: ($NUMBER) $URL . Updating..."


### PR DESCRIPTION
Only create new integration PRs if there are non-lock changes. Fixes #510 

* When comparing the integration with the target branch we now inspect what has changed
  * (unchanged) If nothing has changed then we go in to the optional close logic
  * (new) If more than one file has changed and a PR does not exist then create one
  * (new) If exactly one file has changed and that file is `Cargo.lock` and a PR does not exist then do not create one
  * (unchanged) If one or more files have changed and a PR exists, then update it