### PR TITLE
Use BTreeMap instead of HashMap for Host config

### DIFF
--- a/sdk/src/config.rs
+++ b/sdk/src/config.rs
@@ -5,9 +5,10 @@
 // Copyright 2024 Oxide Computer Company
 
 use core::str::FromStr;
+use std::collections::BTreeMap;
 use std::fs::create_dir_all;
 use std::net::IpAddr;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use crate::OxideError;
 use serde::{Deserialize, Serialize};
@@ -61,7 +62,7 @@ pub struct Config {
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct Hosts {
     #[serde(flatten)]
-    pub hosts: HashMap<String, Host>,
+    pub hosts: BTreeMap<String, Host>,
 }
 
 impl Hosts {


### PR DESCRIPTION
Currently the CLI stores the hosts from the `host.toml` file in a `HashMap` which means that when a host has not been specified by a user this call gives us back an arbitrary host:

https://github.com/oxidecomputer/oxide.rs/blob/3ac6e327d8b7adc2cdfafab60110ce797084089e/sdk/src/context.rs#L53-L58

If we switch this to a `BTreeMap` we at least guarantee that the cli consistently selects the same host entry.

This is related to #301 