### PR TITLE
instance serial subcommand documentation fixups

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1505,7 +1505,7 @@
                 {
                   "long": "escape-string",
                   "short": "e",
-                  "help": "If this sequence of bytes is typed, the client will exit. Note that the string passed for this argument must be valid UTF-8, and is used verbatim without any parsing; in most shells, if you wish to include a special character (such as Enter or a Ctrl+letter combo), you can insert the character by preceding it with Ctrl+V at the command line. To disable the escape string altogether, provide an empty string to this flag (and to exit in such a case, use pkill or similar)"
+                  "help": "If this sequence of bytes is typed, the client will exit. Note that the string passed for this argument must be valid UTF-8, and is used verbatim without any parsing; in most shells, if you wish to include a special character (such as Enter or a Ctrl+letter combo), you can insert the character by preceding it with Ctrl+V at the command line. To disable the escape string altogether, provide an empty string to this flag (and to exit in such a case, use pkill or similar).\n\n[default: { Ctrl+], Ctrl+C }]\n-- which would appear in your shell as ^]^C if you provided it manually by typing { Ctrl+V, Ctrl+], Ctrl+V, Ctrl+C } at the command line."
                 },
                 {
                   "long": "instance",

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1505,7 +1505,7 @@
                 {
                   "long": "escape-string",
                   "short": "e",
-                  "help": "If this sequence of bytes is typed, the client will exit. Defaults to \"^]^C\" (Ctrl+], Ctrl+C). Note that the string passed for this argument must be valid UTF-8, and is used verbatim without any parsing; in most shells, if you wish to include a special character (such as Enter or a Ctrl+letter combo), you can insert the character by preceding it with Ctrl+V at the command line. To disable the escape string altogether, provide an empty string to this flag (and to exit in such a case, use pkill or similar)"
+                  "help": "If this sequence of bytes is typed, the client will exit. Note that the string passed for this argument must be valid UTF-8, and is used verbatim without any parsing; in most shells, if you wish to include a special character (such as Enter or a Ctrl+letter combo), you can insert the character by preceding it with Ctrl+V at the command line. To disable the escape string altogether, provide an empty string to this flag (and to exit in such a case, use pkill or similar)"
                 },
                 {
                   "long": "instance",

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1496,6 +1496,7 @@
             {
               "name": "console",
               "about": "Connect to an instance's serial console interactively.",
+              "long_about": "Connect to an instance's serial console interactively.\n\n(To pull output non-interactively, try `oxide instance serial history`)",
               "args": [
                 {
                   "long": "escape-prefix-length",
@@ -1531,6 +1532,7 @@
             {
               "name": "history",
               "about": "Fetch an instance's serial console output.",
+              "long_about": "Fetch an instance's serial console output.\n\n(To connect interactively and follow live output, try `oxide instance serial console`)",
               "args": [
                 {
                   "long": "byte-offset",

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -62,19 +62,23 @@ pub struct CmdInstanceSerialConsole {
     #[clap(long, short, default_value = "262144")]
     most_recent: u64,
 
-    /// If this sequence of bytes is typed, the client will exit.
-    /// Note that the string passed for this argument must be valid UTF-8,
-    /// and is used verbatim without any parsing; in most shells, if you wish
-    /// to include a special character (such as Enter or a Ctrl+letter combo),
-    /// you can insert the character by preceding it with Ctrl+V at the command
-    /// line.
-    /// To disable the escape string altogether, provide an empty string to
-    /// this flag (and to exit in such a case, use pkill or similar).
-    ///
-    /// [default: { Ctrl+], Ctrl+C }]
-    /// -- which would appear in your shell as ^]^C if you provided it manually
-    /// by typing { Ctrl+V, Ctrl+], Ctrl+V, Ctrl+C } at the command line.
-    #[clap(long, short, default_value = "\x1d\x03", hide_default_value = true)]
+    #[clap(
+        long,
+        short,
+        default_value = "\x1d\x03",
+        hide_default_value = true,
+        help = "If this sequence of bytes is typed, the client will exit. \
+Note that the string passed for this argument must be valid UTF-8, \
+and is used verbatim without any parsing; in most shells, if you wish \
+to include a special character (such as Enter or a Ctrl+letter combo), \
+you can insert the character by preceding it with Ctrl+V at the command line. \
+To disable the escape string altogether, provide an empty string to \
+this flag (and to exit in such a case, use pkill or similar).
+
+[default: { Ctrl+], Ctrl+C }]
+-- which would appear in your shell as ^]^C if you provided it manually \
+by typing { Ctrl+V, Ctrl+], Ctrl+V, Ctrl+C } at the command line."
+    )]
     escape_string: String,
 
     /// The number of bytes from the beginning of the escape string to pass

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -63,14 +63,18 @@ pub struct CmdInstanceSerialConsole {
     most_recent: u64,
 
     /// If this sequence of bytes is typed, the client will exit.
-    /// Defaults to "^]^C" (Ctrl+], Ctrl+C). Note that the string passed
-    /// for this argument must be valid UTF-8, and is used verbatim without
-    /// any parsing; in most shells, if you wish to include a special
-    /// character (such as Enter or a Ctrl+letter combo), you can insert
-    /// the character by preceding it with Ctrl+V at the command line.
+    /// Note that the string passed for this argument must be valid UTF-8,
+    /// and is used verbatim without any parsing; in most shells, if you wish
+    /// to include a special character (such as Enter or a Ctrl+letter combo),
+    /// you can insert the character by preceding it with Ctrl+V at the command
+    /// line.
     /// To disable the escape string altogether, provide an empty string to
     /// this flag (and to exit in such a case, use pkill or similar).
-    #[clap(long, short, default_value = "\x1d\x03")]
+    ///
+    /// [default: { Ctrl+], Ctrl+C }]
+    /// -- which would appear in your shell as ^]^C if you provided it manually
+    /// by typing { Ctrl+V, Ctrl+], Ctrl+V, Ctrl+C } at the command line.
+    #[clap(long, short, default_value = "\x1d\x03", hide_default_value = true)]
     escape_string: String,
 
     /// The number of bytes from the beginning of the escape string to pass

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -43,6 +43,8 @@ enum SerialSubCommand {
 }
 
 /// Connect to an instance's serial console interactively.
+///
+/// (To pull output non-interactively, try `oxide instance serial history`)
 #[derive(Parser, Debug, Clone)]
 #[command(verbatim_doc_comment)]
 #[command(name = "console")]
@@ -131,6 +133,8 @@ impl RunnableCmd for CmdInstanceSerialConsole {
 }
 
 /// Fetch an instance's serial console output.
+///
+/// (To connect interactively and follow live output, try `oxide instance serial console`)
 #[derive(Parser, Debug, Clone)]
 #[command(verbatim_doc_comment)]
 #[command(name = "history")]


### PR DESCRIPTION
Clarifies a couple things from recent issues.

### Instance serial subcommand cross-promotion doc strings

There was confusion in #667 about someone using `instance serial console` when they seemed to want `instance serial history`.
Put a note in each one's long\_about reminding the user of the other.

### Work around clap's default value formatting for instance serial console escape string

Seen in #573.

clap is somewhat stubborn about how it displays default values (seemingly intentionally so, with good reason for 99%+ of cases)

- even if we made a custom type for it, values must be able to round-trip through being a plain string, one way or another: https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes

- clap unconditionally outputs them in their `OsStr` form, which in our case just writes character values that the terminal skips, making it appear as an empty string: https://github.com/clap-rs/clap/blob/5be548dd54d0a001b1c5d2ad4b10019a062104a4/clap_builder/src/output/help_template.rs#L805
  (note: `to_string_lossy` isn't the culprit, they're valid UTF-8)

The somewhat unusual method we have of passing this parameter when it contains unprintable characters is motivated in part by wanting to ensure that the user is actually capable of inputting the character(s) they want to use, with their keyboard, in the terminal they're using.

However, we do have an escape-hatch (pun unintended): https://docs.rs/clap/latest/clap/struct.Arg.html#method.hide_default_value
    
So we'll just hide their version of it and substitute our own.
