### PR TITLE
serial console: update thouart, no raw until output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "thouart"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/thouart.git#f960190b90261549361930924e22911af4fbe6fa"
+source = "git+https://github.com/oxidecomputer/thouart.git#1f22ae2457a2023b1e21613cf1228c7c3e80c37f"
 dependencies = [
  "futures",
  "libc",


### PR DESCRIPTION
wait until we actually receive binary websocket frames before putting the terminal into raw-mode, such that we don't unnecessarily make a round trip to and from raw mode (with the implied terminal state jumbling) if, for example, the instance doesn't even exist (or isn't Running)

(change in https://github.com/oxidecomputer/thouart/pull/17)

resolves strange clearing-after-error-report issue seen on mac (#668)