### PR TITLE
Commands for common network operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1607,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,6 +2143,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "colored",
  "crossterm",
  "dialoguer",
  "dirs",
@@ -2132,12 +2152,14 @@ dependencies = [
  "expectorate",
  "futures",
  "httpmock",
+ "humantime",
  "indicatif",
  "log",
  "oauth2",
  "open",
  "oxide",
  "oxide-httpmock",
+ "oxnet",
  "predicates",
  "pretty_assertions",
  "rand",
@@ -2166,6 +2188,17 @@ dependencies = [
  "regex",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "oxnet"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/oxnet#f37a7aaf5ca96d87af5f8194c19b20e276b5d5e1"
+dependencies = [
+ "ipnetwork",
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ built = { version = "0.7.3", features = ["git2"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.7", features = ["derive", "string", "env"] }
 clap_complete = "4.5.7"
+colored = "2.1.0"
 crossterm = { version = "0.27.0", features = [ "event-stream" ] }
 dialoguer = "0.10.4"
 dirs = "4.0.0"
@@ -25,6 +26,7 @@ env_logger = "0.10.2"
 expectorate = { version = "1.1.0", features = ["predicates"] }
 futures = "0.3.30"
 httpmock = "0.6.8"
+humantime = "2"
 indicatif = "0.17"
 log = "0.4.22"
 newline-converter = "0.3.0"
@@ -32,6 +34,7 @@ oauth2 = "4.4.2"
 open = "4.2.0"
 oxide = { path = "sdk", version = "0.5.0" }
 oxide-httpmock = { path = "sdk-httpmock", version = "0.5.0" }
+oxnet = { git = "https://github.com/oxidecomputer/oxnet" }
 predicates = "3.1.0"
 pretty_assertions = "1.4.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,16 +24,19 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
+colored = { workspace = true }
 crossterm = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
+humantime = { workspace = true }
 indicatif = { workspace = true }
 log = { workspace = true }
 oauth2 = { workspace = true }
 open = { workspace = true }
 oxide = { workspace = true }
+oxnet = { workspace = true }
 predicates = { workspace = true }
 ratatui = { workspace = true }
 reqwest = { workspace = true, features = ["native-tls-vendored"] }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -2070,6 +2070,27 @@
           ]
         },
         {
+          "name": "link",
+          "subcommands": [
+            {
+              "name": "add",
+              "args": [
+                {
+                  "long": "autoneg",
+                  "help": "Whether or not to set autonegotiation"
+                },
+                {
+                  "long": "mtu",
+                  "help": "Maximum transmission unit for the link"
+                }
+              ]
+            },
+            {
+              "name": "del"
+            }
+          ]
+        },
+        {
           "name": "port",
           "subcommands": [
             {

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1977,11 +1977,131 @@
           "subcommands": [
             {
               "name": "add",
-              "about": "Add an address to a port configuration"
+              "about": "Add an address to a port configuration",
+              "args": [
+                {
+                  "long": "addr",
+                  "help": "Address to add"
+                },
+                {
+                  "long": "lot",
+                  "help": "Address lot to allocate from"
+                },
+                {
+                  "long": "port",
+                  "values": [
+                    "qsfp0",
+                    "qsfp1",
+                    "qsfp2",
+                    "qsfp3",
+                    "qsfp4",
+                    "qsfp5",
+                    "qsfp6",
+                    "qsfp7",
+                    "qsfp8",
+                    "qsfp9",
+                    "qsfp10",
+                    "qsfp11",
+                    "qsfp12",
+                    "qsfp13",
+                    "qsfp14",
+                    "qsfp15",
+                    "qsfp16",
+                    "qsfp17",
+                    "qsfp18",
+                    "qsfp19",
+                    "qsfp20",
+                    "qsfp21",
+                    "qsfp22",
+                    "qsfp23",
+                    "qsfp24",
+                    "qsfp25",
+                    "qsfp26",
+                    "qsfp27",
+                    "qsfp28",
+                    "qsfp29",
+                    "qsfp30",
+                    "qsfp31"
+                  ],
+                  "help": "Port to add the port to"
+                },
+                {
+                  "long": "rack",
+                  "help": "Id of the rack to add the address to"
+                },
+                {
+                  "long": "switch",
+                  "values": [
+                    "switch0",
+                    "switch1"
+                  ],
+                  "help": "Switch to add the address to"
+                },
+                {
+                  "long": "vlan",
+                  "help": "Optional VLAN to assign to the address"
+                }
+              ]
             },
             {
               "name": "del",
-              "about": "Remove an address from a port configuration"
+              "about": "Remove an address from a port configuration",
+              "args": [
+                {
+                  "long": "addr",
+                  "help": "Address to remove"
+                },
+                {
+                  "long": "port",
+                  "values": [
+                    "qsfp0",
+                    "qsfp1",
+                    "qsfp2",
+                    "qsfp3",
+                    "qsfp4",
+                    "qsfp5",
+                    "qsfp6",
+                    "qsfp7",
+                    "qsfp8",
+                    "qsfp9",
+                    "qsfp10",
+                    "qsfp11",
+                    "qsfp12",
+                    "qsfp13",
+                    "qsfp14",
+                    "qsfp15",
+                    "qsfp16",
+                    "qsfp17",
+                    "qsfp18",
+                    "qsfp19",
+                    "qsfp20",
+                    "qsfp21",
+                    "qsfp22",
+                    "qsfp23",
+                    "qsfp24",
+                    "qsfp25",
+                    "qsfp26",
+                    "qsfp27",
+                    "qsfp28",
+                    "qsfp29",
+                    "qsfp30",
+                    "qsfp31"
+                  ],
+                  "help": "Port to remove the address from"
+                },
+                {
+                  "long": "rack",
+                  "help": "Id of the rack to remove the address from"
+                },
+                {
+                  "long": "switch",
+                  "values": [
+                    "switch0",
+                    "switch1"
+                  ],
+                  "help": "Switch to remove the address from"
+                }
+              ]
             }
           ]
         },
@@ -1991,7 +2111,24 @@
           "subcommands": [
             {
               "name": "announce",
-              "about": "Make a BGP announcement"
+              "about": "Make a BGP announcement",
+              "args": [
+                {
+                  "long": "address-lot",
+                  "help": "The address lot to draw from"
+                },
+                {
+                  "long": "announce-set",
+                  "help": "The announce set to announce from"
+                },
+                {
+                  "long": "description"
+                },
+                {
+                  "long": "prefix",
+                  "help": "The prefix to announce"
+                }
+              ]
             },
             {
               "name": "config",
@@ -2006,12 +2143,20 @@
                       "about": "Add a BGP peer to a port configuration",
                       "args": [
                         {
+                          "long": "addr",
+                          "help": "Address of the peer to add"
+                        },
+                        {
                           "long": "allowed-exports",
                           "help": "Prefixes that may be exported to the peer. Empty list means all prefixes allowed"
                         },
                         {
                           "long": "allowed-imports",
                           "help": "Prefixes that may be imported form the peer. Empty list means all prefixes allowed"
+                        },
+                        {
+                          "long": "bgp-config",
+                          "help": "BGP configuration this peer is associated with"
                         },
                         {
                           "long": "communities",
@@ -2058,8 +2203,58 @@
                           "help": "Apply the provided multi-exit discriminator (MED) updates sent to the peer"
                         },
                         {
+                          "long": "port",
+                          "values": [
+                            "qsfp0",
+                            "qsfp1",
+                            "qsfp2",
+                            "qsfp3",
+                            "qsfp4",
+                            "qsfp5",
+                            "qsfp6",
+                            "qsfp7",
+                            "qsfp8",
+                            "qsfp9",
+                            "qsfp10",
+                            "qsfp11",
+                            "qsfp12",
+                            "qsfp13",
+                            "qsfp14",
+                            "qsfp15",
+                            "qsfp16",
+                            "qsfp17",
+                            "qsfp18",
+                            "qsfp19",
+                            "qsfp20",
+                            "qsfp21",
+                            "qsfp22",
+                            "qsfp23",
+                            "qsfp24",
+                            "qsfp25",
+                            "qsfp26",
+                            "qsfp27",
+                            "qsfp28",
+                            "qsfp29",
+                            "qsfp30",
+                            "qsfp31"
+                          ],
+                          "help": "Port to add the peer to"
+                        },
+                        {
+                          "long": "rack",
+                          "help": "Id of the rack to add the peer to"
+                        },
+                        {
                           "long": "remote-asn",
                           "help": "Require that a peer has a specified ASN"
+                        },
+                        {
+                          "long": "switch",
+                          "values": [
+                            "switch0",
+                            "switch1"
+                          ],
+                          "help": "Switch to add the peer to"
                         },
                         {
                           "long": "vlan-id",
@@ -2069,7 +2264,63 @@
                     },
                     {
                       "name": "del",
-                      "about": "Remove a BGP from a port configuration"
+                      "about": "Remove a BGP from a port configuration",
+                      "args": [
+                        {
+                          "long": "addr",
+                          "help": "Address of the peer to remove"
+                        },
+                        {
+                          "long": "port",
+                          "values": [
+                            "qsfp0",
+                            "qsfp1",
+                            "qsfp2",
+                            "qsfp3",
+                            "qsfp4",
+                            "qsfp5",
+                            "qsfp6",
+                            "qsfp7",
+                            "qsfp8",
+                            "qsfp9",
+                            "qsfp10",
+                            "qsfp11",
+                            "qsfp12",
+                            "qsfp13",
+                            "qsfp14",
+                            "qsfp15",
+                            "qsfp16",
+                            "qsfp17",
+                            "qsfp18",
+                            "qsfp19",
+                            "qsfp20",
+                            "qsfp21",
+                            "qsfp22",
+                            "qsfp23",
+                            "qsfp24",
+                            "qsfp25",
+                            "qsfp26",
+                            "qsfp27",
+                            "qsfp28",
+                            "qsfp29",
+                            "qsfp30",
+                            "qsfp31"
+                          ],
+                          "help": "Port to remove the peer from"
+                        },
+                        {
+                          "long": "rack",
+                          "help": "Id of the rack to remove the peer from"
+                        },
+                        {
+                          "long": "switch",
+                          "values": [
+                            "switch0",
+                            "switch1"
+                          ],
+                          "help": "Switch to remove the peer from"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -2080,8 +2331,74 @@
               "about": "Set a filtering specification for a peer",
               "args": [
                 {
+                  "long": "allowed",
+                  "help": "Prefixes to allow for the peer"
+                },
+                {
+                  "long": "direction",
+                  "values": [
+                    "import",
+                    "export"
+                  ],
+                  "help": "Whether to apply the filter to imported or exported prefixes"
+                },
+                {
                   "long": "no-filtering",
-                  "help": "Do not filter. Takes precedence over allowed list"
+                  "help": "Do not filter"
+                },
+                {
+                  "long": "peer",
+                  "help": "Peer to apply allow list to"
+                },
+                {
+                  "long": "port",
+                  "values": [
+                    "qsfp0",
+                    "qsfp1",
+                    "qsfp2",
+                    "qsfp3",
+                    "qsfp4",
+                    "qsfp5",
+                    "qsfp6",
+                    "qsfp7",
+                    "qsfp8",
+                    "qsfp9",
+                    "qsfp10",
+                    "qsfp11",
+                    "qsfp12",
+                    "qsfp13",
+                    "qsfp14",
+                    "qsfp15",
+                    "qsfp16",
+                    "qsfp17",
+                    "qsfp18",
+                    "qsfp19",
+                    "qsfp20",
+                    "qsfp21",
+                    "qsfp22",
+                    "qsfp23",
+                    "qsfp24",
+                    "qsfp25",
+                    "qsfp26",
+                    "qsfp27",
+                    "qsfp28",
+                    "qsfp29",
+                    "qsfp30",
+                    "qsfp31"
+                  ],
+                  "help": "Port to add the port to"
+                },
+                {
+                  "long": "rack",
+                  "help": "Id of the rack to add the address to"
+                },
+                {
+                  "long": "switch",
+                  "values": [
+                    "switch0",
+                    "switch1"
+                  ],
+                  "help": "Switch to add the address to"
                 }
               ]
             },
@@ -2091,7 +2408,17 @@
             },
             {
               "name": "withdraw",
-              "about": "Make a BGP announcement"
+              "about": "Make a BGP announcement",
+              "args": [
+                {
+                  "long": "announce-set",
+                  "help": "The announce set to withdraw from"
+                },
+                {
+                  "long": "prefix",
+                  "help": "The prefix to withdraw"
+                }
+              ]
             }
           ]
         },
@@ -2108,14 +2435,124 @@
                   "help": "Whether or not to set auto-negotiation"
                 },
                 {
+                  "long": "fec",
+                  "help": "The forward error correction mode of the link"
+                },
+                {
                   "long": "mtu",
                   "help": "Maximum transmission unit for the link"
+                },
+                {
+                  "long": "port",
+                  "values": [
+                    "qsfp0",
+                    "qsfp1",
+                    "qsfp2",
+                    "qsfp3",
+                    "qsfp4",
+                    "qsfp5",
+                    "qsfp6",
+                    "qsfp7",
+                    "qsfp8",
+                    "qsfp9",
+                    "qsfp10",
+                    "qsfp11",
+                    "qsfp12",
+                    "qsfp13",
+                    "qsfp14",
+                    "qsfp15",
+                    "qsfp16",
+                    "qsfp17",
+                    "qsfp18",
+                    "qsfp19",
+                    "qsfp20",
+                    "qsfp21",
+                    "qsfp22",
+                    "qsfp23",
+                    "qsfp24",
+                    "qsfp25",
+                    "qsfp26",
+                    "qsfp27",
+                    "qsfp28",
+                    "qsfp29",
+                    "qsfp30",
+                    "qsfp31"
+                  ],
+                  "help": "Port to add the link to"
+                },
+                {
+                  "long": "rack",
+                  "help": "Id of the rack to add the link to"
+                },
+                {
+                  "long": "speed",
+                  "help": "The speed of the link"
+                },
+                {
+                  "long": "switch",
+                  "values": [
+                    "switch0",
+                    "switch1"
+                  ],
+                  "help": "Switch to add the link to"
                 }
               ]
             },
             {
               "name": "del",
-              "about": "Remove a link from a port"
+              "about": "Remove a link from a port",
+              "args": [
+                {
+                  "long": "port",
+                  "values": [
+                    "qsfp0",
+                    "qsfp1",
+                    "qsfp2",
+                    "qsfp3",
+                    "qsfp4",
+                    "qsfp5",
+                    "qsfp6",
+                    "qsfp7",
+                    "qsfp8",
+                    "qsfp9",
+                    "qsfp10",
+                    "qsfp11",
+                    "qsfp12",
+                    "qsfp13",
+                    "qsfp14",
+                    "qsfp15",
+                    "qsfp16",
+                    "qsfp17",
+                    "qsfp18",
+                    "qsfp19",
+                    "qsfp20",
+                    "qsfp21",
+                    "qsfp22",
+                    "qsfp23",
+                    "qsfp24",
+                    "qsfp25",
+                    "qsfp26",
+                    "qsfp27",
+                    "qsfp28",
+                    "qsfp29",
+                    "qsfp30",
+                    "qsfp31"
+                  ],
+                  "help": "Port to remove the link from"
+                },
+                {
+                  "long": "rack",
+                  "help": "Id of the rack to remove the link from"
+                },
+                {
+                  "long": "switch",
+                  "values": [
+                    "switch0",
+                    "switch1"
+                  ],
+                  "help": "Switch to remove the link from"
+                }
+              ]
             }
           ]
         },
@@ -3366,26 +3803,6 @@
                   "name": "announce-set",
                   "subcommands": [
                     {
-                      "name": "create",
-                      "about": "Create new BGP announce set",
-                      "args": [
-                        {
-                          "long": "description"
-                        },
-                        {
-                          "long": "json-body",
-                          "help": "Path to a file that contains the full json body."
-                        },
-                        {
-                          "long": "json-body-template",
-                          "help": "XXX"
-                        },
-                        {
-                          "long": "name"
-                        }
-                      ]
-                    },
-                    {
                       "name": "delete",
                       "about": "Delete BGP announce set",
                       "args": [
@@ -3407,7 +3824,8 @@
                     },
                     {
                       "name": "update",
-                      "about": "Update a BGP announce set",
+                      "about": "Update BGP announce set",
+                      "long_about": "If the announce set exists, this endpoint replaces the existing announce set with the one specified.",
                       "args": [
                         {
                           "long": "description"

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1969,6 +1969,44 @@
       ]
     },
     {
+      "name": "net",
+      "subcommands": [
+        {
+          "name": "addr",
+          "subcommands": [
+            {
+              "name": "add"
+            },
+            {
+              "name": "del"
+            }
+          ]
+        },
+        {
+          "name": "bgp",
+          "subcommands": [
+            {
+              "name": "status",
+              "about": "Get the status of BGP."
+            }
+          ]
+        },
+        {
+          "name": "port",
+          "subcommands": [
+            {
+              "name": "config",
+              "about": "Get the configuration of switch ports."
+            },
+            {
+              "name": "status",
+              "about": "Get the status of switch ports."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "ping",
       "about": "Ping API",
       "long_about": "Always responds with Ok if it responds at all."

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1973,26 +1973,33 @@
       "subcommands": [
         {
           "name": "addr",
+          "about": "Address management",
           "subcommands": [
             {
-              "name": "add"
+              "name": "add",
+              "about": "Add an address to a port configuration"
             },
             {
-              "name": "del"
+              "name": "del",
+              "about": "Remove an address from a port configuration"
             }
           ]
         },
         {
           "name": "bgp",
+          "about": "BGP management",
           "subcommands": [
             {
               "name": "config",
+              "about": "Manage BGP configuration",
               "subcommands": [
                 {
                   "name": "peer",
+                  "about": "Manage BGP peer configuration",
                   "subcommands": [
                     {
                       "name": "add",
+                      "about": "Add a BGP peer to a port configuration",
                       "args": [
                         {
                           "long": "allowed-exports",
@@ -2057,7 +2064,8 @@
                       ]
                     },
                     {
-                      "name": "del"
+                      "name": "del",
+                      "about": "Remove a BGP from a port configuration"
                     }
                   ]
                 }
@@ -2065,19 +2073,21 @@
             },
             {
               "name": "status",
-              "about": "Get the status of BGP."
+              "about": "Observe BGP status"
             }
           ]
         },
         {
           "name": "link",
+          "about": "Link management",
           "subcommands": [
             {
               "name": "add",
+              "about": "Add a link to a port",
               "args": [
                 {
                   "long": "autoneg",
-                  "help": "Whether or not to set autonegotiation"
+                  "help": "Whether or not to set auto-negotiation"
                 },
                 {
                   "long": "mtu",
@@ -2086,20 +2096,22 @@
               ]
             },
             {
-              "name": "del"
+              "name": "del",
+              "about": "Remove a link from a port"
             }
           ]
         },
         {
           "name": "port",
+          "about": "Port management",
           "subcommands": [
             {
               "name": "config",
-              "about": "Get the configuration of switch ports."
+              "about": "Manage port configuration"
             },
             {
               "name": "status",
-              "about": "Get the status of switch ports."
+              "about": "Observe port status"
             }
           ]
         }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -3010,6 +3010,7 @@
           "subcommands": [
             {
               "name": "addr",
+              "about": "Manage switch port addresses.",
               "subcommands": [
                 {
                   "name": "add",
@@ -3334,6 +3335,8 @@
               "subcommands": [
                 {
                   "name": "announce",
+                  "about": "Announce a prefix over BGP.",
+                  "long_about": "Announce a prefix over BGP.\n\nThis command adds the provided prefix to the specified announce set. It is\nrequired that the prefix be available in the given address lot. The add is\nperformed as a read-modify-write on the specified address lot.",
                   "args": [
                     {
                       "long": "address-lot",
@@ -3468,6 +3471,8 @@
                 },
                 {
                   "name": "filter",
+                  "about": "Add a filtering requirement to a BGP session.",
+                  "long_about": "Add a filtering requirement to a BGP session.\n\nThe Oxide BGP implementation can filter prefixes received from peers\non import and filter prefixes sent to peers on export. This command\nprovides a way to specify import/export filtering. Filtering is a\nproperty of the BGP peering settings found in port settings configuration.\nThis command works by performing a read-modify-write on the port settings\nconfiguration identified by the specified rack/switch/port.",
                   "args": [
                     {
                       "long": "allowed",
@@ -3568,6 +3573,8 @@
                 },
                 {
                   "name": "peer",
+                  "about": "Manage BGP peers.",
+                  "long_about": "Manage BGP peers.\n\nThis command provides add and delete subcommands for managing BGP peers.\nBGP peer configuration is a part of a switch port settings configuration.\nThe peer add and remove subcommands perform read-modify-write operations\non switch port settings objects to manage BGP peer configurations.",
                   "subcommands": [
                     {
                       "name": "add",
@@ -3757,7 +3764,8 @@
                 },
                 {
                   "name": "show-status",
-                  "about": "Get the status of BGP."
+                  "about": "Get the status of BGP on the rack.",
+                  "long_about": "Get the status of BGP on the rack.\n\nThis will show the peering status for all peers on all switches."
                 },
                 {
                   "name": "status",
@@ -3765,6 +3773,8 @@
                 },
                 {
                   "name": "withdraw",
+                  "about": "Withdraw a prefix over BGP.",
+                  "long_about": "Withdraw a prefix over BGP.\n\nThis command removes the provided prefix to the specified announce set.\nThe remove is performed as a read-modify-write on the specified address lot.",
                   "args": [
                     {
                       "long": "announce-set",
@@ -3780,6 +3790,8 @@
             },
             {
               "name": "link",
+              "about": "Manage switch port links.",
+              "long_about": "Manage switch port links.\n\nLinks carry layer-2 Ethernet properties for a lane or set of lanes on a\nswitch port. Lane geometry is defined in physical port settings. At the\npresent time only single lane configurations are supported, and thus only\na single link per physical port is supported.",
               "subcommands": [
                 {
                   "name": "add",

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -2076,6 +2076,16 @@
               ]
             },
             {
+              "name": "filter",
+              "about": "Set a filtering specification for a peer",
+              "args": [
+                {
+                  "long": "no-filtering",
+                  "help": "Do not filter. Takes precedence over allowed list"
+                }
+              ]
+            },
+            {
               "name": "status",
               "about": "Observe BGP status"
             },

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1990,6 +1990,10 @@
           "about": "BGP management",
           "subcommands": [
             {
+              "name": "announce",
+              "about": "Make a BGP announcement"
+            },
+            {
               "name": "config",
               "about": "Manage BGP configuration",
               "subcommands": [
@@ -2074,6 +2078,10 @@
             {
               "name": "status",
               "about": "Observe BGP status"
+            },
+            {
+              "name": "withdraw",
+              "about": "Make a BGP announcement"
             }
           ]
         },
@@ -3384,6 +3392,26 @@
                         {
                           "long": "name-or-id",
                           "help": "A name or id to use when selecting BGP port settings"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "update",
+                      "about": "Update a BGP announce set",
+                      "args": [
+                        {
+                          "long": "description"
+                        },
+                        {
+                          "long": "json-body",
+                          "help": "Path to a file that contains the full json body."
+                        },
+                        {
+                          "long": "json-body-template",
+                          "help": "XXX"
+                        },
+                        {
+                          "long": "name"
                         }
                       ]
                     }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1986,6 +1986,84 @@
           "name": "bgp",
           "subcommands": [
             {
+              "name": "config",
+              "subcommands": [
+                {
+                  "name": "peer",
+                  "subcommands": [
+                    {
+                      "name": "add",
+                      "args": [
+                        {
+                          "long": "allowed-exports",
+                          "help": "Prefixes that may be exported to the peer. Empty list means all prefixes allowed"
+                        },
+                        {
+                          "long": "allowed-imports",
+                          "help": "Prefixes that may be imported form the peer. Empty list means all prefixes allowed"
+                        },
+                        {
+                          "long": "communities",
+                          "help": "Include the provided communities in updates sent to the peer"
+                        },
+                        {
+                          "long": "connect-retry",
+                          "help": "How long to to wait between TCP connection retries (seconds)"
+                        },
+                        {
+                          "long": "delay-open",
+                          "help": "How long to delay sending an open request after establishing a TCP session (seconds)"
+                        },
+                        {
+                          "long": "enforce-first-as",
+                          "help": "Enforce that the first AS in paths received from this peer is the peer's AS"
+                        },
+                        {
+                          "long": "hold-time",
+                          "help": "How long to hold peer connections between keepalives (seconds)"
+                        },
+                        {
+                          "long": "idle-hold-time",
+                          "help": "How long to hold a peer in idle before attempting a new session (seconds)"
+                        },
+                        {
+                          "long": "keepalive",
+                          "help": "How often to send keepalive requests (seconds)"
+                        },
+                        {
+                          "long": "local-pref",
+                          "help": "Apply a local preference to routes received from this peer"
+                        },
+                        {
+                          "long": "md5-auth-key",
+                          "help": "Use the given key for TCP-MD5 authentication with the peer"
+                        },
+                        {
+                          "long": "min-ttl",
+                          "help": "Require messages from a peer have a minimum IP time to live field"
+                        },
+                        {
+                          "long": "multi-exit-discriminator",
+                          "help": "Apply the provided multi-exit discriminator (MED) updates sent to the peer"
+                        },
+                        {
+                          "long": "remote-asn",
+                          "help": "Require that a peer has a specified ASN"
+                        },
+                        {
+                          "long": "vlan-id",
+                          "help": "Associate a VLAN ID with a peer"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "del"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "name": "status",
               "about": "Get the status of BGP."
             }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1969,610 +1969,6 @@
       ]
     },
     {
-      "name": "net",
-      "subcommands": [
-        {
-          "name": "addr",
-          "about": "Address management",
-          "subcommands": [
-            {
-              "name": "add",
-              "about": "Add an address to a port configuration",
-              "args": [
-                {
-                  "long": "addr",
-                  "help": "Address to add"
-                },
-                {
-                  "long": "lot",
-                  "help": "Address lot to allocate from"
-                },
-                {
-                  "long": "port",
-                  "values": [
-                    "qsfp0",
-                    "qsfp1",
-                    "qsfp2",
-                    "qsfp3",
-                    "qsfp4",
-                    "qsfp5",
-                    "qsfp6",
-                    "qsfp7",
-                    "qsfp8",
-                    "qsfp9",
-                    "qsfp10",
-                    "qsfp11",
-                    "qsfp12",
-                    "qsfp13",
-                    "qsfp14",
-                    "qsfp15",
-                    "qsfp16",
-                    "qsfp17",
-                    "qsfp18",
-                    "qsfp19",
-                    "qsfp20",
-                    "qsfp21",
-                    "qsfp22",
-                    "qsfp23",
-                    "qsfp24",
-                    "qsfp25",
-                    "qsfp26",
-                    "qsfp27",
-                    "qsfp28",
-                    "qsfp29",
-                    "qsfp30",
-                    "qsfp31"
-                  ],
-                  "help": "Port to add the port to"
-                },
-                {
-                  "long": "rack",
-                  "help": "Id of the rack to add the address to"
-                },
-                {
-                  "long": "switch",
-                  "values": [
-                    "switch0",
-                    "switch1"
-                  ],
-                  "help": "Switch to add the address to"
-                },
-                {
-                  "long": "vlan",
-                  "help": "Optional VLAN to assign to the address"
-                }
-              ]
-            },
-            {
-              "name": "del",
-              "about": "Remove an address from a port configuration",
-              "args": [
-                {
-                  "long": "addr",
-                  "help": "Address to remove"
-                },
-                {
-                  "long": "port",
-                  "values": [
-                    "qsfp0",
-                    "qsfp1",
-                    "qsfp2",
-                    "qsfp3",
-                    "qsfp4",
-                    "qsfp5",
-                    "qsfp6",
-                    "qsfp7",
-                    "qsfp8",
-                    "qsfp9",
-                    "qsfp10",
-                    "qsfp11",
-                    "qsfp12",
-                    "qsfp13",
-                    "qsfp14",
-                    "qsfp15",
-                    "qsfp16",
-                    "qsfp17",
-                    "qsfp18",
-                    "qsfp19",
-                    "qsfp20",
-                    "qsfp21",
-                    "qsfp22",
-                    "qsfp23",
-                    "qsfp24",
-                    "qsfp25",
-                    "qsfp26",
-                    "qsfp27",
-                    "qsfp28",
-                    "qsfp29",
-                    "qsfp30",
-                    "qsfp31"
-                  ],
-                  "help": "Port to remove the address from"
-                },
-                {
-                  "long": "rack",
-                  "help": "Id of the rack to remove the address from"
-                },
-                {
-                  "long": "switch",
-                  "values": [
-                    "switch0",
-                    "switch1"
-                  ],
-                  "help": "Switch to remove the address from"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "bgp",
-          "about": "BGP management",
-          "subcommands": [
-            {
-              "name": "announce",
-              "about": "Make a BGP announcement",
-              "args": [
-                {
-                  "long": "address-lot",
-                  "help": "The address lot to draw from"
-                },
-                {
-                  "long": "announce-set",
-                  "help": "The announce set to announce from"
-                },
-                {
-                  "long": "description"
-                },
-                {
-                  "long": "prefix",
-                  "help": "The prefix to announce"
-                }
-              ]
-            },
-            {
-              "name": "config",
-              "about": "Manage BGP configuration",
-              "subcommands": [
-                {
-                  "name": "peer",
-                  "about": "Manage BGP peer configuration",
-                  "subcommands": [
-                    {
-                      "name": "add",
-                      "about": "Add a BGP peer to a port configuration",
-                      "args": [
-                        {
-                          "long": "addr",
-                          "help": "Address of the peer to add"
-                        },
-                        {
-                          "long": "allowed-exports",
-                          "help": "Prefixes that may be exported to the peer. Empty list means all prefixes allowed"
-                        },
-                        {
-                          "long": "allowed-imports",
-                          "help": "Prefixes that may be imported form the peer. Empty list means all prefixes allowed"
-                        },
-                        {
-                          "long": "bgp-config",
-                          "help": "BGP configuration this peer is associated with"
-                        },
-                        {
-                          "long": "communities",
-                          "help": "Include the provided communities in updates sent to the peer"
-                        },
-                        {
-                          "long": "connect-retry",
-                          "help": "How long to to wait between TCP connection retries (seconds)"
-                        },
-                        {
-                          "long": "delay-open",
-                          "help": "How long to delay sending an open request after establishing a TCP session (seconds)"
-                        },
-                        {
-                          "long": "enforce-first-as",
-                          "help": "Enforce that the first AS in paths received from this peer is the peer's AS"
-                        },
-                        {
-                          "long": "hold-time",
-                          "help": "How long to hold peer connections between keepalives (seconds)"
-                        },
-                        {
-                          "long": "idle-hold-time",
-                          "help": "How long to hold a peer in idle before attempting a new session (seconds)"
-                        },
-                        {
-                          "long": "keepalive",
-                          "help": "How often to send keepalive requests (seconds)"
-                        },
-                        {
-                          "long": "local-pref",
-                          "help": "Apply a local preference to routes received from this peer"
-                        },
-                        {
-                          "long": "md5-auth-key",
-                          "help": "Use the given key for TCP-MD5 authentication with the peer"
-                        },
-                        {
-                          "long": "min-ttl",
-                          "help": "Require messages from a peer have a minimum IP time to live field"
-                        },
-                        {
-                          "long": "multi-exit-discriminator",
-                          "help": "Apply the provided multi-exit discriminator (MED) updates sent to the peer"
-                        },
-                        {
-                          "long": "port",
-                          "values": [
-                            "qsfp0",
-                            "qsfp1",
-                            "qsfp2",
-                            "qsfp3",
-                            "qsfp4",
-                            "qsfp5",
-                            "qsfp6",
-                            "qsfp7",
-                            "qsfp8",
-                            "qsfp9",
-                            "qsfp10",
-                            "qsfp11",
-                            "qsfp12",
-                            "qsfp13",
-                            "qsfp14",
-                            "qsfp15",
-                            "qsfp16",
-                            "qsfp17",
-                            "qsfp18",
-                            "qsfp19",
-                            "qsfp20",
-                            "qsfp21",
-                            "qsfp22",
-                            "qsfp23",
-                            "qsfp24",
-                            "qsfp25",
-                            "qsfp26",
-                            "qsfp27",
-                            "qsfp28",
-                            "qsfp29",
-                            "qsfp30",
-                            "qsfp31"
-                          ],
-                          "help": "Port to add the peer to"
-                        },
-                        {
-                          "long": "rack",
-                          "help": "Id of the rack to add the peer to"
-                        },
-                        {
-                          "long": "remote-asn",
-                          "help": "Require that a peer has a specified ASN"
-                        },
-                        {
-                          "long": "switch",
-                          "values": [
-                            "switch0",
-                            "switch1"
-                          ],
-                          "help": "Switch to add the peer to"
-                        },
-                        {
-                          "long": "vlan-id",
-                          "help": "Associate a VLAN ID with a peer"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "del",
-                      "about": "Remove a BGP from a port configuration",
-                      "args": [
-                        {
-                          "long": "addr",
-                          "help": "Address of the peer to remove"
-                        },
-                        {
-                          "long": "port",
-                          "values": [
-                            "qsfp0",
-                            "qsfp1",
-                            "qsfp2",
-                            "qsfp3",
-                            "qsfp4",
-                            "qsfp5",
-                            "qsfp6",
-                            "qsfp7",
-                            "qsfp8",
-                            "qsfp9",
-                            "qsfp10",
-                            "qsfp11",
-                            "qsfp12",
-                            "qsfp13",
-                            "qsfp14",
-                            "qsfp15",
-                            "qsfp16",
-                            "qsfp17",
-                            "qsfp18",
-                            "qsfp19",
-                            "qsfp20",
-                            "qsfp21",
-                            "qsfp22",
-                            "qsfp23",
-                            "qsfp24",
-                            "qsfp25",
-                            "qsfp26",
-                            "qsfp27",
-                            "qsfp28",
-                            "qsfp29",
-                            "qsfp30",
-                            "qsfp31"
-                          ],
-                          "help": "Port to remove the peer from"
-                        },
-                        {
-                          "long": "rack",
-                          "help": "Id of the rack to remove the peer from"
-                        },
-                        {
-                          "long": "switch",
-                          "values": [
-                            "switch0",
-                            "switch1"
-                          ],
-                          "help": "Switch to remove the peer from"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "filter",
-              "about": "Set a filtering specification for a peer",
-              "args": [
-                {
-                  "long": "allowed",
-                  "help": "Prefixes to allow for the peer"
-                },
-                {
-                  "long": "direction",
-                  "values": [
-                    "import",
-                    "export"
-                  ],
-                  "help": "Whether to apply the filter to imported or exported prefixes"
-                },
-                {
-                  "long": "no-filtering",
-                  "help": "Do not filter"
-                },
-                {
-                  "long": "peer",
-                  "help": "Peer to apply allow list to"
-                },
-                {
-                  "long": "port",
-                  "values": [
-                    "qsfp0",
-                    "qsfp1",
-                    "qsfp2",
-                    "qsfp3",
-                    "qsfp4",
-                    "qsfp5",
-                    "qsfp6",
-                    "qsfp7",
-                    "qsfp8",
-                    "qsfp9",
-                    "qsfp10",
-                    "qsfp11",
-                    "qsfp12",
-                    "qsfp13",
-                    "qsfp14",
-                    "qsfp15",
-                    "qsfp16",
-                    "qsfp17",
-                    "qsfp18",
-                    "qsfp19",
-                    "qsfp20",
-                    "qsfp21",
-                    "qsfp22",
-                    "qsfp23",
-                    "qsfp24",
-                    "qsfp25",
-                    "qsfp26",
-                    "qsfp27",
-                    "qsfp28",
-                    "qsfp29",
-                    "qsfp30",
-                    "qsfp31"
-                  ],
-                  "help": "Port to add the port to"
-                },
-                {
-                  "long": "rack",
-                  "help": "Id of the rack to add the address to"
-                },
-                {
-                  "long": "switch",
-                  "values": [
-                    "switch0",
-                    "switch1"
-                  ],
-                  "help": "Switch to add the address to"
-                }
-              ]
-            },
-            {
-              "name": "status",
-              "about": "Observe BGP status"
-            },
-            {
-              "name": "withdraw",
-              "about": "Make a BGP announcement",
-              "args": [
-                {
-                  "long": "announce-set",
-                  "help": "The announce set to withdraw from"
-                },
-                {
-                  "long": "prefix",
-                  "help": "The prefix to withdraw"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "link",
-          "about": "Link management",
-          "subcommands": [
-            {
-              "name": "add",
-              "about": "Add a link to a port",
-              "args": [
-                {
-                  "long": "autoneg",
-                  "help": "Whether or not to set auto-negotiation"
-                },
-                {
-                  "long": "fec",
-                  "help": "The forward error correction mode of the link"
-                },
-                {
-                  "long": "mtu",
-                  "help": "Maximum transmission unit for the link"
-                },
-                {
-                  "long": "port",
-                  "values": [
-                    "qsfp0",
-                    "qsfp1",
-                    "qsfp2",
-                    "qsfp3",
-                    "qsfp4",
-                    "qsfp5",
-                    "qsfp6",
-                    "qsfp7",
-                    "qsfp8",
-                    "qsfp9",
-                    "qsfp10",
-                    "qsfp11",
-                    "qsfp12",
-                    "qsfp13",
-                    "qsfp14",
-                    "qsfp15",
-                    "qsfp16",
-                    "qsfp17",
-                    "qsfp18",
-                    "qsfp19",
-                    "qsfp20",
-                    "qsfp21",
-                    "qsfp22",
-                    "qsfp23",
-                    "qsfp24",
-                    "qsfp25",
-                    "qsfp26",
-                    "qsfp27",
-                    "qsfp28",
-                    "qsfp29",
-                    "qsfp30",
-                    "qsfp31"
-                  ],
-                  "help": "Port to add the link to"
-                },
-                {
-                  "long": "rack",
-                  "help": "Id of the rack to add the link to"
-                },
-                {
-                  "long": "speed",
-                  "help": "The speed of the link"
-                },
-                {
-                  "long": "switch",
-                  "values": [
-                    "switch0",
-                    "switch1"
-                  ],
-                  "help": "Switch to add the link to"
-                }
-              ]
-            },
-            {
-              "name": "del",
-              "about": "Remove a link from a port",
-              "args": [
-                {
-                  "long": "port",
-                  "values": [
-                    "qsfp0",
-                    "qsfp1",
-                    "qsfp2",
-                    "qsfp3",
-                    "qsfp4",
-                    "qsfp5",
-                    "qsfp6",
-                    "qsfp7",
-                    "qsfp8",
-                    "qsfp9",
-                    "qsfp10",
-                    "qsfp11",
-                    "qsfp12",
-                    "qsfp13",
-                    "qsfp14",
-                    "qsfp15",
-                    "qsfp16",
-                    "qsfp17",
-                    "qsfp18",
-                    "qsfp19",
-                    "qsfp20",
-                    "qsfp21",
-                    "qsfp22",
-                    "qsfp23",
-                    "qsfp24",
-                    "qsfp25",
-                    "qsfp26",
-                    "qsfp27",
-                    "qsfp28",
-                    "qsfp29",
-                    "qsfp30",
-                    "qsfp31"
-                  ],
-                  "help": "Port to remove the link from"
-                },
-                {
-                  "long": "rack",
-                  "help": "Id of the rack to remove the link from"
-                },
-                {
-                  "long": "switch",
-                  "values": [
-                    "switch0",
-                    "switch1"
-                  ],
-                  "help": "Switch to remove the link from"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "port",
-          "about": "Port management",
-          "subcommands": [
-            {
-              "name": "config",
-              "about": "Manage port configuration"
-            },
-            {
-              "name": "status",
-              "about": "Observe port status"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "ping",
       "about": "Ping API",
       "long_about": "Always responds with Ok if it responds at all."
@@ -3584,6 +2980,10 @@
                   ]
                 },
                 {
+                  "name": "show-status",
+                  "about": "Get the status of switch ports."
+                },
+                {
                   "name": "status",
                   "about": "Get switch port status",
                   "args": [
@@ -3608,6 +3008,139 @@
         {
           "name": "networking",
           "subcommands": [
+            {
+              "name": "addr",
+              "subcommands": [
+                {
+                  "name": "add",
+                  "about": "Add an address to a port configuration",
+                  "args": [
+                    {
+                      "long": "addr",
+                      "help": "Address to add"
+                    },
+                    {
+                      "long": "lot",
+                      "help": "Address lot to allocate from"
+                    },
+                    {
+                      "long": "port",
+                      "values": [
+                        "qsfp0",
+                        "qsfp1",
+                        "qsfp2",
+                        "qsfp3",
+                        "qsfp4",
+                        "qsfp5",
+                        "qsfp6",
+                        "qsfp7",
+                        "qsfp8",
+                        "qsfp9",
+                        "qsfp10",
+                        "qsfp11",
+                        "qsfp12",
+                        "qsfp13",
+                        "qsfp14",
+                        "qsfp15",
+                        "qsfp16",
+                        "qsfp17",
+                        "qsfp18",
+                        "qsfp19",
+                        "qsfp20",
+                        "qsfp21",
+                        "qsfp22",
+                        "qsfp23",
+                        "qsfp24",
+                        "qsfp25",
+                        "qsfp26",
+                        "qsfp27",
+                        "qsfp28",
+                        "qsfp29",
+                        "qsfp30",
+                        "qsfp31"
+                      ],
+                      "help": "Port to add the port to"
+                    },
+                    {
+                      "long": "rack",
+                      "help": "Id of the rack to add the address to"
+                    },
+                    {
+                      "long": "switch",
+                      "values": [
+                        "switch0",
+                        "switch1"
+                      ],
+                      "help": "Switch to add the address to"
+                    },
+                    {
+                      "long": "vlan",
+                      "help": "Optional VLAN to assign to the address"
+                    }
+                  ]
+                },
+                {
+                  "name": "del",
+                  "about": "Remove an address from a port configuration",
+                  "args": [
+                    {
+                      "long": "addr",
+                      "help": "Address to remove"
+                    },
+                    {
+                      "long": "port",
+                      "values": [
+                        "qsfp0",
+                        "qsfp1",
+                        "qsfp2",
+                        "qsfp3",
+                        "qsfp4",
+                        "qsfp5",
+                        "qsfp6",
+                        "qsfp7",
+                        "qsfp8",
+                        "qsfp9",
+                        "qsfp10",
+                        "qsfp11",
+                        "qsfp12",
+                        "qsfp13",
+                        "qsfp14",
+                        "qsfp15",
+                        "qsfp16",
+                        "qsfp17",
+                        "qsfp18",
+                        "qsfp19",
+                        "qsfp20",
+                        "qsfp21",
+                        "qsfp22",
+                        "qsfp23",
+                        "qsfp24",
+                        "qsfp25",
+                        "qsfp26",
+                        "qsfp27",
+                        "qsfp28",
+                        "qsfp29",
+                        "qsfp30",
+                        "qsfp31"
+                      ],
+                      "help": "Port to remove the address from"
+                    },
+                    {
+                      "long": "rack",
+                      "help": "Id of the rack to remove the address from"
+                    },
+                    {
+                      "long": "switch",
+                      "values": [
+                        "switch0",
+                        "switch1"
+                      ],
+                      "help": "Switch to remove the address from"
+                    }
+                  ]
+                }
+              ]
+            },
             {
               "name": "address-lot",
               "subcommands": [
@@ -3800,6 +3333,26 @@
               "name": "bgp",
               "subcommands": [
                 {
+                  "name": "announce",
+                  "args": [
+                    {
+                      "long": "address-lot",
+                      "help": "The address lot to draw from"
+                    },
+                    {
+                      "long": "announce-set",
+                      "help": "The announce set to announce from"
+                    },
+                    {
+                      "long": "description"
+                    },
+                    {
+                      "long": "prefix",
+                      "help": "The prefix to announce"
+                    }
+                  ]
+                },
+                {
                   "name": "announce-set",
                   "subcommands": [
                     {
@@ -3914,6 +3467,81 @@
                   ]
                 },
                 {
+                  "name": "filter",
+                  "args": [
+                    {
+                      "long": "allowed",
+                      "help": "Prefixes to allow for the peer"
+                    },
+                    {
+                      "long": "direction",
+                      "values": [
+                        "import",
+                        "export"
+                      ],
+                      "help": "Whether to apply the filter to imported or exported prefixes"
+                    },
+                    {
+                      "long": "no-filtering",
+                      "help": "Do not filter"
+                    },
+                    {
+                      "long": "peer",
+                      "help": "Peer to apply allow list to"
+                    },
+                    {
+                      "long": "port",
+                      "values": [
+                        "qsfp0",
+                        "qsfp1",
+                        "qsfp2",
+                        "qsfp3",
+                        "qsfp4",
+                        "qsfp5",
+                        "qsfp6",
+                        "qsfp7",
+                        "qsfp8",
+                        "qsfp9",
+                        "qsfp10",
+                        "qsfp11",
+                        "qsfp12",
+                        "qsfp13",
+                        "qsfp14",
+                        "qsfp15",
+                        "qsfp16",
+                        "qsfp17",
+                        "qsfp18",
+                        "qsfp19",
+                        "qsfp20",
+                        "qsfp21",
+                        "qsfp22",
+                        "qsfp23",
+                        "qsfp24",
+                        "qsfp25",
+                        "qsfp26",
+                        "qsfp27",
+                        "qsfp28",
+                        "qsfp29",
+                        "qsfp30",
+                        "qsfp31"
+                      ],
+                      "help": "Port to add the port to"
+                    },
+                    {
+                      "long": "rack",
+                      "help": "Id of the rack to add the address to"
+                    },
+                    {
+                      "long": "switch",
+                      "values": [
+                        "switch0",
+                        "switch1"
+                      ],
+                      "help": "Switch to add the address to"
+                    }
+                  ]
+                },
+                {
                   "name": "history",
                   "about": "Get BGP router message history",
                   "args": [
@@ -3939,8 +3567,347 @@
                   ]
                 },
                 {
+                  "name": "peer",
+                  "subcommands": [
+                    {
+                      "name": "add",
+                      "about": "Add a BGP peer to a port configuration",
+                      "args": [
+                        {
+                          "long": "addr",
+                          "help": "Address of the peer to add"
+                        },
+                        {
+                          "long": "allowed-exports",
+                          "help": "Prefixes that may be exported to the peer. Empty list means all prefixes allowed"
+                        },
+                        {
+                          "long": "allowed-imports",
+                          "help": "Prefixes that may be imported form the peer. Empty list means all prefixes allowed"
+                        },
+                        {
+                          "long": "bgp-config",
+                          "help": "BGP configuration this peer is associated with"
+                        },
+                        {
+                          "long": "communities",
+                          "help": "Include the provided communities in updates sent to the peer"
+                        },
+                        {
+                          "long": "connect-retry",
+                          "help": "How long to to wait between TCP connection retries (seconds)"
+                        },
+                        {
+                          "long": "delay-open",
+                          "help": "How long to delay sending an open request after establishing a TCP session (seconds)"
+                        },
+                        {
+                          "long": "enforce-first-as",
+                          "help": "Enforce that the first AS in paths received from this peer is the peer's AS"
+                        },
+                        {
+                          "long": "hold-time",
+                          "help": "How long to hold peer connections between keepalives (seconds)"
+                        },
+                        {
+                          "long": "idle-hold-time",
+                          "help": "How long to hold a peer in idle before attempting a new session (seconds)"
+                        },
+                        {
+                          "long": "keepalive",
+                          "help": "How often to send keepalive requests (seconds)"
+                        },
+                        {
+                          "long": "local-pref",
+                          "help": "Apply a local preference to routes received from this peer"
+                        },
+                        {
+                          "long": "md5-auth-key",
+                          "help": "Use the given key for TCP-MD5 authentication with the peer"
+                        },
+                        {
+                          "long": "min-ttl",
+                          "help": "Require messages from a peer have a minimum IP time to live field"
+                        },
+                        {
+                          "long": "multi-exit-discriminator",
+                          "help": "Apply the provided multi-exit discriminator (MED) updates sent to the peer"
+                        },
+                        {
+                          "long": "port",
+                          "values": [
+                            "qsfp0",
+                            "qsfp1",
+                            "qsfp2",
+                            "qsfp3",
+                            "qsfp4",
+                            "qsfp5",
+                            "qsfp6",
+                            "qsfp7",
+                            "qsfp8",
+                            "qsfp9",
+                            "qsfp10",
+                            "qsfp11",
+                            "qsfp12",
+                            "qsfp13",
+                            "qsfp14",
+                            "qsfp15",
+                            "qsfp16",
+                            "qsfp17",
+                            "qsfp18",
+                            "qsfp19",
+                            "qsfp20",
+                            "qsfp21",
+                            "qsfp22",
+                            "qsfp23",
+                            "qsfp24",
+                            "qsfp25",
+                            "qsfp26",
+                            "qsfp27",
+                            "qsfp28",
+                            "qsfp29",
+                            "qsfp30",
+                            "qsfp31"
+                          ],
+                          "help": "Port to add the peer to"
+                        },
+                        {
+                          "long": "rack",
+                          "help": "Id of the rack to add the peer to"
+                        },
+                        {
+                          "long": "remote-asn",
+                          "help": "Require that a peer has a specified ASN"
+                        },
+                        {
+                          "long": "switch",
+                          "values": [
+                            "switch0",
+                            "switch1"
+                          ],
+                          "help": "Switch to add the peer to"
+                        },
+                        {
+                          "long": "vlan-id",
+                          "help": "Associate a VLAN ID with a peer"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "del",
+                      "about": "Remove a BGP from a port configuration",
+                      "args": [
+                        {
+                          "long": "addr",
+                          "help": "Address of the peer to remove"
+                        },
+                        {
+                          "long": "port",
+                          "values": [
+                            "qsfp0",
+                            "qsfp1",
+                            "qsfp2",
+                            "qsfp3",
+                            "qsfp4",
+                            "qsfp5",
+                            "qsfp6",
+                            "qsfp7",
+                            "qsfp8",
+                            "qsfp9",
+                            "qsfp10",
+                            "qsfp11",
+                            "qsfp12",
+                            "qsfp13",
+                            "qsfp14",
+                            "qsfp15",
+                            "qsfp16",
+                            "qsfp17",
+                            "qsfp18",
+                            "qsfp19",
+                            "qsfp20",
+                            "qsfp21",
+                            "qsfp22",
+                            "qsfp23",
+                            "qsfp24",
+                            "qsfp25",
+                            "qsfp26",
+                            "qsfp27",
+                            "qsfp28",
+                            "qsfp29",
+                            "qsfp30",
+                            "qsfp31"
+                          ],
+                          "help": "Port to remove the peer from"
+                        },
+                        {
+                          "long": "rack",
+                          "help": "Id of the rack to remove the peer from"
+                        },
+                        {
+                          "long": "switch",
+                          "values": [
+                            "switch0",
+                            "switch1"
+                          ],
+                          "help": "Switch to remove the peer from"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "show-status",
+                  "about": "Get the status of BGP."
+                },
+                {
                   "name": "status",
                   "about": "Get BGP peer status"
+                },
+                {
+                  "name": "withdraw",
+                  "args": [
+                    {
+                      "long": "announce-set",
+                      "help": "The announce set to withdraw from"
+                    },
+                    {
+                      "long": "prefix",
+                      "help": "The prefix to withdraw"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "link",
+              "subcommands": [
+                {
+                  "name": "add",
+                  "about": "Add a link to a port",
+                  "args": [
+                    {
+                      "long": "autoneg",
+                      "help": "Whether or not to set auto-negotiation"
+                    },
+                    {
+                      "long": "fec",
+                      "help": "The forward error correction mode of the link"
+                    },
+                    {
+                      "long": "mtu",
+                      "help": "Maximum transmission unit for the link"
+                    },
+                    {
+                      "long": "port",
+                      "values": [
+                        "qsfp0",
+                        "qsfp1",
+                        "qsfp2",
+                        "qsfp3",
+                        "qsfp4",
+                        "qsfp5",
+                        "qsfp6",
+                        "qsfp7",
+                        "qsfp8",
+                        "qsfp9",
+                        "qsfp10",
+                        "qsfp11",
+                        "qsfp12",
+                        "qsfp13",
+                        "qsfp14",
+                        "qsfp15",
+                        "qsfp16",
+                        "qsfp17",
+                        "qsfp18",
+                        "qsfp19",
+                        "qsfp20",
+                        "qsfp21",
+                        "qsfp22",
+                        "qsfp23",
+                        "qsfp24",
+                        "qsfp25",
+                        "qsfp26",
+                        "qsfp27",
+                        "qsfp28",
+                        "qsfp29",
+                        "qsfp30",
+                        "qsfp31"
+                      ],
+                      "help": "Port to add the link to"
+                    },
+                    {
+                      "long": "rack",
+                      "help": "Id of the rack to add the link to"
+                    },
+                    {
+                      "long": "speed",
+                      "help": "The speed of the link"
+                    },
+                    {
+                      "long": "switch",
+                      "values": [
+                        "switch0",
+                        "switch1"
+                      ],
+                      "help": "Switch to add the link to"
+                    }
+                  ]
+                },
+                {
+                  "name": "del",
+                  "about": "Remove a link from a port",
+                  "args": [
+                    {
+                      "long": "port",
+                      "values": [
+                        "qsfp0",
+                        "qsfp1",
+                        "qsfp2",
+                        "qsfp3",
+                        "qsfp4",
+                        "qsfp5",
+                        "qsfp6",
+                        "qsfp7",
+                        "qsfp8",
+                        "qsfp9",
+                        "qsfp10",
+                        "qsfp11",
+                        "qsfp12",
+                        "qsfp13",
+                        "qsfp14",
+                        "qsfp15",
+                        "qsfp16",
+                        "qsfp17",
+                        "qsfp18",
+                        "qsfp19",
+                        "qsfp20",
+                        "qsfp21",
+                        "qsfp22",
+                        "qsfp23",
+                        "qsfp24",
+                        "qsfp25",
+                        "qsfp26",
+                        "qsfp27",
+                        "qsfp28",
+                        "qsfp29",
+                        "qsfp30",
+                        "qsfp31"
+                      ],
+                      "help": "Port to remove the link from"
+                    },
+                    {
+                      "long": "rack",
+                      "help": "Id of the rack to remove the link from"
+                    },
+                    {
+                      "long": "switch",
+                      "values": [
+                        "switch0",
+                        "switch1"
+                      ],
+                      "help": "Switch to remove the link from"
+                    }
+                  ]
                 }
               ]
             },
@@ -4083,6 +4050,10 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "name": "show",
+                  "about": "Get the configuration of switch ports."
                 },
                 {
                   "name": "view",

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -442,6 +442,9 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::NetworkingBgpAnnounceSetCreate => {
             Some("system networking bgp announce-set create")
         }
+        CliCommand::NetworkingBgpAnnounceSetUpdate => {
+            Some("system networking bgp announce-set update")
+        }
         CliCommand::NetworkingBgpAnnounceSetDelete => {
             Some("system networking bgp announce-set delete")
         }

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -439,9 +439,6 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::NetworkingBgpConfigCreate => Some("system networking bgp config create"),
         CliCommand::NetworkingBgpConfigDelete => Some("system networking bgp config delete"),
         CliCommand::NetworkingBgpConfigList => Some("system networking bgp config list"),
-        CliCommand::NetworkingBgpAnnounceSetCreate => {
-            Some("system networking bgp announce-set create")
-        }
         CliCommand::NetworkingBgpAnnounceSetUpdate => {
             Some("system networking bgp announce-set update")
         }

--- a/cli/src/cmd_disk.rs
+++ b/cli/src/cmd_disk.rs
@@ -323,7 +323,7 @@ impl RunnableCmd for CmdDiskImport {
                 disk_source: DiskSource::ImportingBlocks {
                     block_size: disk_block_size.clone(),
                 },
-                size: disk_size.try_into()?,
+                size: disk_size.into(),
             })
             .send()
             .await?;

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -36,9 +36,16 @@ pub struct CmdNet {
 
 #[derive(Parser, Debug, Clone)]
 enum NetSubCommand {
+    /// Address management.
     Addr(CmdAddr),
+
+    /// Port management.
     Port(CmdPort),
+
+    /// Link management.
     Link(CmdLink),
+
+    /// BGP management.
     Bgp(CmdBgp),
 }
 
@@ -62,7 +69,10 @@ impl RunnableCmd for CmdPort {
 
 #[derive(Parser, Debug, Clone)]
 enum PortSubCommand {
+    /// Manage port configuration.
     Config(CmdPortConfig),
+
+    /// Observe port status.
     Status(CmdPortStatus),
 }
 
@@ -86,7 +96,10 @@ impl RunnableCmd for CmdLink {
 
 #[derive(Parser, Debug, Clone)]
 enum LinkSubCommand {
+    /// Add a link to a port.
     Add(CmdLinkAdd),
+
+    /// Remove a link from a port.
     Del(CmdLinkDel),
 }
 
@@ -105,7 +118,7 @@ pub struct CmdLinkAdd {
     #[arg(value_enum)]
     port: Port,
 
-    /// Whether or not to set autonegotiation
+    /// Whether or not to set auto-negotiation
     #[arg(long)]
     pub autoneg: bool,
 
@@ -205,7 +218,10 @@ impl RunnableCmd for CmdBgp {
 #[allow(clippy::large_enum_variant)]
 #[derive(Parser, Debug, Clone)]
 enum BgpSubCommand {
+    /// Observe BGP status.
     Status(CmdBgpStatus),
+
+    /// Manage BGP configuration.
     Config(CmdBgpConfig),
 }
 
@@ -229,7 +245,10 @@ impl RunnableCmd for CmdAddr {
 
 #[derive(Parser, Debug, Clone)]
 enum AddrSubCommand {
+    /// Add an address to a port configuration.
     Add(CmdAddrAdd),
+
+    /// Remove an address from a port configuration.
     Del(CmdAddrDel),
 }
 
@@ -357,6 +376,7 @@ impl RunnableCmd for CmdBgpConfig {
 
 #[derive(Parser, Debug, Clone)]
 enum BgpConfigSubCommand {
+    /// Manage BGP peer configuration.
     Peer(CmdBgpPeer),
 }
 
@@ -380,7 +400,10 @@ impl RunnableCmd for CmdBgpPeer {
 
 #[derive(Parser, Debug, Clone)]
 enum BgpConfigPeerSubCommand {
+    /// Add a BGP peer to a port configuration.
     Add(CmdBgpPeerAdd),
+
+    /// Remove a BGP from a port configuration.
     Del(CmdBgpPeerDel),
 }
 
@@ -907,8 +930,6 @@ impl CmdPortStatus {
                 .await
                 .ok()
                 .map(|x| x.into_inner().0);
-
-            //println!("{:?}", status);
 
             let link = status.as_ref().map(|x| {
                 let ls: LinkStatus =

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -1,0 +1,828 @@
+use std::collections::HashMap;
+
+use crate::RunnableCmd;
+use anyhow::Result;
+use async_trait::async_trait;
+use clap::Parser;
+use colored::*;
+use oxide::{
+    context::Context,
+    types::{
+        Address, AddressConfig, BgpPeerConfig, BgpPeerStatus, IpNet, LinkConfigCreate,
+        LldpServiceConfigCreate, NameOrId, Route, RouteConfig, SwitchInterfaceConfigCreate,
+        SwitchInterfaceKind, SwitchInterfaceKind2, SwitchLocation, SwitchPort,
+        SwitchPortConfigCreate, SwitchPortGeometry, SwitchPortGeometry2, SwitchPortSettingsCreate,
+    },
+    Client, ClientSystemHardwareExt, ClientSystemNetworkingExt,
+};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use tabwriter::TabWriter;
+use uuid::Uuid;
+
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "net")]
+pub struct CmdNet {
+    #[clap(subcommand)]
+    subcmd: NetSubCommand,
+}
+
+#[derive(Parser, Debug, Clone)]
+enum NetSubCommand {
+    Addr(CmdAddr),
+    Port(CmdPort),
+    Bgp(CmdBgp),
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "port")]
+pub struct CmdPort {
+    #[clap(subcommand)]
+    subcmd: PortSubCommand,
+}
+
+#[async_trait]
+impl RunnableCmd for CmdPort {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        match &self.subcmd {
+            PortSubCommand::Config(cmd) => cmd.run(ctx).await,
+            PortSubCommand::Status(cmd) => cmd.run(ctx).await,
+        }
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+enum PortSubCommand {
+    Config(CmdPortConfig),
+    Status(CmdPortStatus),
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "bgp")]
+pub struct CmdBgp {
+    #[clap(subcommand)]
+    subcmd: BgpSubCommand,
+}
+
+#[async_trait]
+impl RunnableCmd for CmdBgp {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        match &self.subcmd {
+            BgpSubCommand::Status(cmd) => cmd.run(ctx).await,
+        }
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+enum BgpSubCommand {
+    Status(CmdBgpStatus),
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "addr")]
+pub struct CmdAddr {
+    #[clap(subcommand)]
+    subcmd: AddrSubCommand,
+}
+
+#[derive(Parser, Debug, Clone)]
+enum AddrSubCommand {
+    Add(CmdAddrAdd),
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum Switch {
+    Switch0,
+    Switch1,
+}
+
+impl std::fmt::Display for Switch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{self:?}").to_lowercase())
+    }
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum Port {
+    Qsfp0,
+    Qsfp1,
+    Qsfp2,
+    Qsfp3,
+    Qsfp4,
+    Qsfp5,
+    Qsfp6,
+    Qsfp7,
+    Qsfp8,
+    Qsfp9,
+    Qsfp10,
+    Qsfp11,
+    Qsfp12,
+    Qsfp13,
+    Qsfp14,
+    Qsfp15,
+    Qsfp16,
+    Qsfp17,
+    Qsfp18,
+    Qsfp19,
+    Qsfp20,
+    Qsfp21,
+    Qsfp22,
+    Qsfp23,
+    Qsfp24,
+    Qsfp25,
+    Qsfp26,
+    Qsfp27,
+    Qsfp28,
+    Qsfp29,
+    Qsfp30,
+    Qsfp31,
+}
+
+impl std::fmt::Display for Port {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{self:?}").to_lowercase())
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "addr")]
+pub struct CmdAddrAdd {
+    rack: Uuid,
+    #[arg(value_enum)]
+    switch: Switch,
+    #[arg(value_enum)]
+    port: Port,
+    addr: oxnet::Ipv4Net,
+    lot: NameOrId,
+    vlan: Option<u16>,
+}
+
+#[async_trait]
+impl RunnableCmd for CmdNet {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        match &self.subcmd {
+            NetSubCommand::Addr(cmd) => cmd.run(ctx).await,
+            NetSubCommand::Port(cmd) => cmd.run(ctx).await,
+            NetSubCommand::Bgp(cmd) => cmd.run(ctx).await,
+        }
+    }
+}
+
+impl CmdAddrAdd {
+    async fn modify_settings_for_address(&self, settings_id: Uuid, ctx: &Context) -> Result<()> {
+        let mut settings = self.create_current(settings_id, ctx).await?;
+        let addr = Address {
+            address: IpNet::V4(self.addr.to_string().parse().unwrap()),
+            address_lot: self.lot.clone(),
+            vlan_id: self.vlan,
+        };
+        match settings.addresses.get_mut("phy0") {
+            Some(ac) => {
+                ac.addresses.push(addr);
+            }
+            None => {
+                settings.addresses.insert(
+                    String::from("phy0"),
+                    AddressConfig {
+                        addresses: vec![addr],
+                    },
+                );
+            }
+        }
+        ctx.client()?
+            .networking_switch_port_settings_create()
+            .body(settings)
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    // NOTE: This bonanza of befuckerry is needed to translate the current
+    //       switch port settings view into a corresponding switch port
+    //       settings create request. It's the preliminary step for a read-
+    //       modify-write operation.
+    async fn create_current(
+        &self,
+        settings_id: Uuid,
+        ctx: &Context,
+    ) -> Result<SwitchPortSettingsCreate> {
+        let list = ctx
+            .client()?
+            .networking_switch_port_settings_list()
+            .limit(u32::MAX)
+            .send()
+            .await
+            .unwrap()
+            .into_inner()
+            .items;
+
+        let name = list
+            .iter()
+            .find(|x| x.id == settings_id)
+            .ok_or(anyhow::anyhow!("settings not found for {}", settings_id))?
+            .name
+            .clone();
+
+        let current = ctx
+            .client()?
+            .networking_switch_port_settings_view()
+            .port(settings_id)
+            .send()
+            .await
+            .unwrap()
+            .into_inner();
+
+        let mut block_to_lot = HashMap::new();
+        let lots = ctx
+            .client()?
+            .networking_address_lot_list()
+            .limit(u32::MAX)
+            .send()
+            .await
+            .unwrap()
+            .into_inner()
+            .items;
+        for lot in lots.iter() {
+            let lot_blocks = ctx
+                .client()?
+                .networking_address_lot_block_list()
+                .address_lot(lot.id)
+                .limit(u32::MAX)
+                .send()
+                .await
+                .unwrap()
+                .into_inner()
+                .items;
+            for block in lot_blocks.iter() {
+                block_to_lot.insert(block.id, lot.id);
+            }
+        }
+
+        let addrs: Vec<Address> = current
+            .addresses
+            .clone()
+            .into_iter()
+            .map(|x| Address {
+                address: x.address,
+                address_lot: NameOrId::Id(block_to_lot[&x.address_lot_block_id]),
+                vlan_id: x.vlan_id,
+            })
+            .collect();
+
+        let mut addresses = HashMap::new();
+        addresses.insert(String::from("phy0"), AddressConfig { addresses: addrs });
+
+        let mut bgp_peers = HashMap::new();
+        bgp_peers.insert(
+            String::from("phy0"),
+            BgpPeerConfig {
+                peers: current.bgp_peers,
+            },
+        );
+
+        let groups: Vec<NameOrId> = current
+            .groups
+            .iter()
+            .map(|x| NameOrId::Id(x.port_settings_group_id))
+            .collect();
+
+        let mut interfaces: HashMap<String, SwitchInterfaceConfigCreate> = current
+            .interfaces
+            .iter()
+            .map(|x| {
+                (
+                    x.interface_name.clone(),
+                    SwitchInterfaceConfigCreate {
+                        kind: match x.kind {
+                            SwitchInterfaceKind2::Primary => SwitchInterfaceKind::Primary,
+                            SwitchInterfaceKind2::Loopback => SwitchInterfaceKind::Loopback,
+                            SwitchInterfaceKind2::Vlan => {
+                                todo!("vlan interface outside vlan interfaces?")
+                            }
+                        },
+                        v6_enabled: x.v6_enabled,
+                    },
+                )
+            })
+            .collect();
+
+        for v in current.vlan_interfaces.iter() {
+            interfaces.insert(
+                format!("vlan-{}", v.vlan_id),
+                SwitchInterfaceConfigCreate {
+                    kind: SwitchInterfaceKind::Vlan(v.vlan_id),
+                    v6_enabled: false,
+                },
+            );
+        }
+
+        let links: HashMap<String, LinkConfigCreate> = current
+            .links
+            .iter()
+            .enumerate()
+            .map(|(i, x)| {
+                (
+                    format!("phy{}", i),
+                    LinkConfigCreate {
+                        autoneg: x.autoneg,
+                        fec: x.fec,
+                        lldp: LldpServiceConfigCreate {
+                            //TODO
+                            enabled: false,
+                            lldp_config: None,
+                        },
+                        mtu: x.mtu,
+                        speed: x.speed,
+                    },
+                )
+            })
+            .collect();
+
+        let port_config = SwitchPortConfigCreate {
+            geometry: match current.port.geometry {
+                SwitchPortGeometry2::Qsfp28x1 => SwitchPortGeometry::Qsfp28x1,
+                SwitchPortGeometry2::Qsfp28x2 => SwitchPortGeometry::Qsfp28x2,
+                SwitchPortGeometry2::Sfp28x4 => SwitchPortGeometry::Sfp28x4,
+            },
+        };
+
+        let route_config = RouteConfig {
+            routes: current
+                .routes
+                .iter()
+                .map(|x| Route {
+                    dst: x.dst.clone(),
+                    gw: x.gw.to_string().parse().unwrap(),
+                    vid: x.vlan_id,
+                })
+                .collect(),
+        };
+
+        let mut routes = HashMap::new();
+        routes.insert(String::from("phy0"), route_config);
+
+        let create = SwitchPortSettingsCreate {
+            addresses,
+            bgp_peers,
+            description: String::from("switch port settings"),
+            groups,
+            interfaces,
+            links,
+            name: name.parse().unwrap(),
+            port_config,
+            routes,
+        };
+
+        Ok(create)
+    }
+}
+
+#[async_trait]
+impl RunnableCmd for CmdAddr {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        match &self.subcmd {
+            AddrSubCommand::Add(cmd) => cmd.run(ctx).await,
+        }
+    }
+}
+
+#[async_trait]
+impl RunnableCmd for CmdAddrAdd {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        let ports = ctx
+            .client()?
+            .networking_switch_port_list()
+            .limit(u32::MAX)
+            .send()
+            .await
+            .unwrap()
+            .into_inner()
+            .items;
+
+        let port = ports
+            .into_iter()
+            .find(|x| x.rack_id == self.rack && x.port_name == self.port.to_string())
+            .ok_or(anyhow::anyhow!(
+                "port {} not found for rack {}",
+                self.port,
+                self.rack
+            ))?;
+
+        match port.port_settings_id {
+            Some(id) => self.modify_settings_for_address(id, ctx).await,
+            None => Err(anyhow::anyhow!(
+                "Cannot add address to port without settings. \
+                Port settings with a link configuration is required"
+            )),
+        }
+    }
+}
+
+/// Get the configuration of switch ports.
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "net port config")]
+pub struct CmdPortConfig {}
+
+#[async_trait]
+impl RunnableCmd for CmdPortConfig {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        let c = ctx.client()?;
+
+        let ports = c
+            .networking_switch_port_list()
+            .limit(u32::MAX)
+            .send()
+            .await?
+            .into_inner()
+            .items;
+
+        let mut tw = TabWriter::new(std::io::stdout()).ansi(true);
+
+        // TODO bad API, having to pull all address lots to work backwards from
+        // address reference to address lot block is terribad
+        let addr_lots = c
+            .networking_address_lot_list()
+            .limit(u32::MAX)
+            .send()
+            .await?
+            .into_inner()
+            .items;
+
+        let mut addr_lot_blocks = Vec::new();
+        for a in addr_lots.iter() {
+            let blocks = c
+                .networking_address_lot_block_list()
+                .address_lot(a.id)
+                .limit(u32::MAX)
+                .send()
+                .await?
+                .into_inner()
+                .items;
+
+            for b in blocks.iter() {
+                addr_lot_blocks.push((a.clone(), b.clone()));
+            }
+        }
+
+        for p in &ports {
+            if let Some(id) = p.port_settings_id {
+                let config = c
+                    .networking_switch_port_settings_view()
+                    .port(id)
+                    .send()
+                    .await?
+                    .into_inner();
+
+                println!(
+                    "{}{}{}",
+                    p.switch_location.to_string().blue(),
+                    "/".dimmed(),
+                    p.port_name.blue(),
+                );
+
+                println!(
+                    "{}",
+                    "=".repeat(p.port_name.len() + p.switch_location.to_string().len() + 1)
+                        .dimmed()
+                );
+
+                writeln!(
+                    &mut tw,
+                    "{}\t{}\t{}",
+                    "Autoneg".dimmed(),
+                    "Fec".dimmed(),
+                    "Speed".dimmed(),
+                )?;
+
+                for l in &config.links {
+                    writeln!(&mut tw, "{:?}\t{:?}\t{:?}", l.autoneg, l.fec, l.speed,)?;
+                }
+                tw.flush()?;
+                println!("");
+
+                writeln!(&mut tw, "{}\t{}", "Address".dimmed(), "Lot".dimmed())?;
+                for a in &config.addresses {
+                    let addr = match &a.address {
+                        oxide::types::IpNet::V4(a) => a.to_string(),
+                        oxide::types::IpNet::V6(a) => a.to_string(),
+                    };
+
+                    let alb = addr_lot_blocks
+                        .iter()
+                        .find(|x| x.1.id == a.address_lot_block_id)
+                        .unwrap();
+
+                    writeln!(&mut tw, "{}\t{}", addr, *alb.0.name)?;
+                }
+                tw.flush()?;
+                println!("");
+
+                writeln!(
+                    &mut tw,
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    "BGP Peer".dimmed(),
+                    "Export".dimmed(),
+                    "Import".dimmed(),
+                    "Communities".dimmed(),
+                    "Connect Retry".dimmed(),
+                    "Delay Open".dimmed(),
+                    "Enforce First AS".dimmed(),
+                    "Hold Time".dimmed(),
+                    "Idle Hold Time".dimmed(),
+                    "Keepalive".dimmed(),
+                    "Local Pref".dimmed(),
+                    "Md5 Auth".dimmed(),
+                    "Min TTL".dimmed(),
+                    "MED".dimmed(),
+                    "Remote ASN".dimmed(),
+                    "VLAN".dimmed(),
+                )?;
+                for p in &config.bgp_peers {
+                    writeln!(
+                        &mut tw,
+                        "{}\t{:?}\t{:?}\t{:?}\t{}\t{}\t{}\t{}\t{}\t{}\t{:?}\t{:?}\t{:?}\t{:?}\t{:?}\t{:?}",
+                        p.addr,
+                        p.allowed_export,
+                        p.allowed_import,
+                        p.communities,
+                        p.connect_retry,
+                        p.delay_open,
+                        p.enforce_first_as,
+                        p.hold_time,
+                        p.idle_hold_time,
+                        p.keepalive,
+                        p.local_pref,
+                        p.md5_auth_key,
+                        p.min_ttl,
+                        p.multi_exit_discriminator,
+                        p.remote_asn,
+                        p.vlan_id,
+                    )?;
+                }
+                tw.flush()?;
+                println!("");
+
+                // Uncomment to see full payload
+                //println!("");
+                //println!("{:#?}", config);
+                //println!("");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Get the status of BGP.
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "net bgp status")]
+pub struct CmdBgpStatus {}
+
+#[async_trait]
+impl RunnableCmd for CmdBgpStatus {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        let c = ctx.client()?;
+
+        let status = c.networking_bgp_status().send().await?.into_inner();
+
+        let (sw0, sw1) = status
+            .iter()
+            .partition(|x| x.switch == SwitchLocation::Switch0);
+
+        println!("{}", "switch0".dimmed());
+        println!("{}", "=======".dimmed());
+        show_status(&sw0)?;
+        println!();
+
+        println!("{}", "switch1".dimmed());
+        println!("{}", "=======".dimmed());
+        show_status(&sw1)?;
+
+        Ok(())
+    }
+}
+
+fn show_status(st: &Vec<&BgpPeerStatus>) -> Result<()> {
+    let mut tw = TabWriter::new(std::io::stdout()).ansi(true);
+    writeln!(
+        &mut tw,
+        "{}\t{}\t{}\t{}\t{}",
+        "Peer Address".dimmed(),
+        "Local ASN".dimmed(),
+        "Remote ASN".dimmed(),
+        "Session State".dimmed(),
+        "State Duration".dimmed(),
+    )?;
+    for s in st {
+        writeln!(
+            tw,
+            "{}\t{}\t{}\t{:?}\t{}",
+            s.addr,
+            s.local_asn,
+            s.remote_asn,
+            s.state,
+            humantime::Duration::from(std::time::Duration::from_millis(s.state_duration_millis)),
+        )?;
+    }
+    tw.flush()?;
+    Ok(())
+}
+
+/// Get the status of switch ports.
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(name = "net port status")]
+pub struct CmdPortStatus {}
+
+#[async_trait]
+impl RunnableCmd for CmdPortStatus {
+    async fn run(&self, ctx: &Context) -> Result<()> {
+        let c = ctx.client()?;
+
+        let ports = c
+            .networking_switch_port_list()
+            .limit(u32::MAX)
+            .send()
+            .await?
+            .into_inner()
+            .items;
+
+        let (mut sw0, mut sw1): (Vec<&SwitchPort>, Vec<&SwitchPort>) = ports
+            .iter()
+            .partition(|x| x.switch_location.as_str() == "switch0");
+
+        sw0.sort_by_key(|x| x.port_name.as_str());
+        sw1.sort_by_key(|x| x.port_name.as_str());
+
+        println!("{}", "switch0".dimmed());
+        println!("{}", "=======".dimmed());
+        self.show_switch(&c, "switch0", &sw0).await?;
+
+        println!("{}", "switch1".dimmed());
+        println!("{}", "=======".dimmed());
+        self.show_switch(&c, "switch1", &sw1).await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct MacAddr {
+    a: [u8; 6],
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct LinkStatus {
+    address: MacAddr,
+    enabled: bool,
+    autoneg: bool,
+    fec: String,
+    link_state: String,
+    fsm_state: String,
+    media: String,
+    speed: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiverPower {
+    /// The measurement is represents average optical power, in mW.
+    Average(f32),
+
+    /// The measurement represents a peak-to-peak, in mW.
+    PeakToPeak(f32),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct Monitors {
+    receiver_power: Vec<ReceiverPower>,
+    transmitter_bias_current: Vec<f32>,
+    transmitter_power: Vec<f32>,
+}
+
+impl CmdPortStatus {
+    async fn show_switch(&self, c: &Client, sw: &str, ports: &Vec<&SwitchPort>) -> Result<()> {
+        let mut ltw = TabWriter::new(std::io::stdout()).ansi(true);
+        let mut mtw = TabWriter::new(std::io::stdout()).ansi(true);
+
+        writeln!(
+            &mut ltw,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "Port".dimmed(),
+            "Configured".dimmed(),
+            "Enabled".dimmed(),
+            "MAC".dimmed(),
+            "Autoneg".dimmed(),
+            "FEC".dimmed(),
+            "Link/FSM State".dimmed(),
+            "Media".dimmed(),
+            "Speed".dimmed(),
+        )?;
+
+        writeln!(
+            &mut mtw,
+            "{}\t{}\t{}",
+            "Receiver Power".dimmed(),
+            "Transmitter Bias Current".dimmed(),
+            "Transmitter Power".dimmed(),
+        )?;
+
+        for p in ports {
+            let status = c
+                .networking_switch_port_status()
+                .port(&p.port_name)
+                .rack_id(p.rack_id)
+                .switch_location(sw)
+                .send()
+                .await
+                .ok()
+                .map(|x| x.into_inner().0);
+
+            //println!("{:?}", status);
+
+            let link = status.as_ref().map(|x| {
+                let ls: LinkStatus =
+                    serde_json::from_value(x.get("link").unwrap().clone()).unwrap();
+                ls
+            });
+
+            writeln!(
+                &mut ltw,
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                p.port_name,
+                p.port_settings_id.is_some(),
+                link.as_ref()
+                    .map(|x| x.enabled.to_string())
+                    .unwrap_or("-".to_string()),
+                link.as_ref()
+                    .map(|x| format!(
+                        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                        x.address.a[0],
+                        x.address.a[1],
+                        x.address.a[2],
+                        x.address.a[3],
+                        x.address.a[4],
+                        x.address.a[5]
+                    ))
+                    .unwrap_or("-".to_string()),
+                link.as_ref()
+                    .map(|x| x.autoneg.to_string())
+                    .unwrap_or("-".to_string()),
+                link.as_ref()
+                    .map(|x| x.fec.clone())
+                    .unwrap_or("-".to_string()),
+                link.as_ref()
+                    .map(|x| format!("{}/{}", x.link_state, x.fsm_state))
+                    .unwrap_or("-".to_string()),
+                link.as_ref()
+                    .map(|x| x.media.clone())
+                    .unwrap_or("-".to_string()),
+                link.as_ref()
+                    .map(|x| x.speed.clone())
+                    .unwrap_or("-".to_string()),
+            )?;
+
+            let monitors: Option<Monitors> = match status.as_ref() {
+                Some(x) => match x.get("monitors") {
+                    Some(x) => match serde_json::from_value(x.clone()) {
+                        Ok(x) => Some(x),
+                        Err(_) => None,
+                    },
+                    None => None,
+                },
+                None => None,
+            };
+
+            writeln!(
+                &mut mtw,
+                "{}\t{}\t{}",
+                monitors
+                    .as_ref()
+                    .map(|x| format!("{:?}", x.receiver_power))
+                    .unwrap_or("-".to_string()),
+                monitors
+                    .as_ref()
+                    .map(|x| format!("{:?}", x.transmitter_bias_current))
+                    .unwrap_or("-".to_string()),
+                monitors
+                    .as_ref()
+                    .map(|x| format!("{:?}", x.transmitter_power))
+                    .unwrap_or("-".to_string()),
+            )?;
+        }
+
+        ltw.flush()?;
+        println!();
+        mtw.flush()?;
+        println!();
+
+        Ok(())
+    }
+}

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -36,29 +36,6 @@ const PHY0: &str = "phy0";
 
 #[derive(Parser, Debug, Clone)]
 #[command(verbatim_doc_comment)]
-#[command(name = "net")]
-pub struct CmdNet {
-    #[clap(subcommand)]
-    subcmd: NetSubCommand,
-}
-
-#[derive(Parser, Debug, Clone)]
-enum NetSubCommand {
-    /// Address management.
-    Addr(CmdAddr),
-
-    /// Port management.
-    Port(CmdPort),
-
-    /// Link management.
-    Link(CmdLink),
-
-    /// BGP management.
-    Bgp(CmdBgp),
-}
-
-#[derive(Parser, Debug, Clone)]
-#[command(verbatim_doc_comment)]
 #[command(name = "port")]
 pub struct CmdPort {
     #[clap(subcommand)]
@@ -458,18 +435,6 @@ enum AddrSubCommand {
 
     /// Remove an address from a port configuration.
     Del(CmdAddrDel),
-}
-
-#[async_trait]
-impl RunnableCmd for CmdNet {
-    async fn run(&self, ctx: &Context) -> Result<()> {
-        match &self.subcmd {
-            NetSubCommand::Addr(cmd) => cmd.run(ctx).await,
-            NetSubCommand::Port(cmd) => cmd.run(ctx).await,
-            NetSubCommand::Link(cmd) => cmd.run(ctx).await,
-            NetSubCommand::Bgp(cmd) => cmd.run(ctx).await,
-        }
-    }
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -1380,6 +1345,7 @@ async fn create_current(settings_id: Uuid, ctx: &Context) -> Result<SwitchPortSe
 
     Ok(create)
 }
+
 #[derive(clap::ValueEnum, Clone, Debug)]
 enum Switch {
     Switch0,

--- a/cli/src/generated_cli.rs
+++ b/cli/src/generated_cli.rs
@@ -167,9 +167,6 @@ impl<T: CliConfig> Cli<T> {
             CliCommand::NetworkingBgpAnnounceSetUpdate => {
                 Self::cli_networking_bgp_announce_set_update()
             }
-            CliCommand::NetworkingBgpAnnounceSetCreate => {
-                Self::cli_networking_bgp_announce_set_create()
-            }
             CliCommand::NetworkingBgpAnnounceSetDelete => {
                 Self::cli_networking_bgp_announce_set_delete()
             }
@@ -4243,38 +4240,11 @@ impl<T: CliConfig> Cli<T> {
                     .action(clap::ArgAction::SetTrue)
                     .help("XXX"),
             )
-            .about("Update a BGP announce set")
-    }
-
-    pub fn cli_networking_bgp_announce_set_create() -> clap::Command {
-        clap::Command::new("")
-            .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required_unless_present("json-body"),
+            .about("Update BGP announce set")
+            .long_about(
+                "If the announce set exists, this endpoint replaces the existing announce set \
+                 with the one specified.",
             )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required_unless_present("json-body"),
-            )
-            .arg(
-                clap::Arg::new("json-body")
-                    .long("json-body")
-                    .value_name("JSON-FILE")
-                    .required(true)
-                    .value_parser(clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
-            )
-            .arg(
-                clap::Arg::new("json-body-template")
-                    .long("json-body-template")
-                    .action(clap::ArgAction::SetTrue)
-                    .help("XXX"),
-            )
-            .about("Create new BGP announce set")
     }
 
     pub fn cli_networking_bgp_announce_set_delete() -> clap::Command {
@@ -6245,10 +6215,6 @@ impl<T: CliConfig> Cli<T> {
             }
             CliCommand::NetworkingBgpAnnounceSetUpdate => {
                 self.execute_networking_bgp_announce_set_update(matches)
-                    .await
-            }
-            CliCommand::NetworkingBgpAnnounceSetCreate => {
-                self.execute_networking_bgp_announce_set_create(matches)
                     .await
             }
             CliCommand::NetworkingBgpAnnounceSetDelete => {
@@ -10897,41 +10863,6 @@ impl<T: CliConfig> Cli<T> {
         }
     }
 
-    pub async fn execute_networking_bgp_announce_set_create(
-        &self,
-        matches: &clap::ArgMatches,
-    ) -> anyhow::Result<()> {
-        let mut request = self.client.networking_bgp_announce_set_create();
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::BgpAnnounceSetCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        self.config
-            .execute_networking_bgp_announce_set_create(matches, &mut request)?;
-        let result = request.send().await;
-        match result {
-            Ok(r) => {
-                self.config.success_item(&r);
-                Ok(())
-            }
-            Err(r) => {
-                self.config.error(&r);
-                Err(anyhow::Error::new(r))
-            }
-        }
-    }
-
     pub async fn execute_networking_bgp_announce_set_delete(
         &self,
         matches: &clap::ArgMatches,
@@ -14036,14 +13967,6 @@ pub trait CliConfig {
         Ok(())
     }
 
-    fn execute_networking_bgp_announce_set_create(
-        &self,
-        matches: &clap::ArgMatches,
-        request: &mut builder::NetworkingBgpAnnounceSetCreate,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     fn execute_networking_bgp_announce_set_delete(
         &self,
         matches: &clap::ArgMatches,
@@ -14649,7 +14572,6 @@ pub enum CliCommand {
     NetworkingBgpConfigDelete,
     NetworkingBgpAnnounceSetList,
     NetworkingBgpAnnounceSetUpdate,
-    NetworkingBgpAnnounceSetCreate,
     NetworkingBgpAnnounceSetDelete,
     NetworkingBgpMessageHistory,
     NetworkingBgpImportedRoutesIpv4,
@@ -14851,7 +14773,6 @@ impl CliCommand {
             CliCommand::NetworkingBgpConfigDelete,
             CliCommand::NetworkingBgpAnnounceSetList,
             CliCommand::NetworkingBgpAnnounceSetUpdate,
-            CliCommand::NetworkingBgpAnnounceSetCreate,
             CliCommand::NetworkingBgpAnnounceSetDelete,
             CliCommand::NetworkingBgpMessageHistory,
             CliCommand::NetworkingBgpImportedRoutesIpv4,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,6 +23,7 @@ mod cmd_completion;
 mod cmd_disk;
 mod cmd_docs;
 mod cmd_instance;
+mod cmd_net;
 mod cmd_timeseries;
 
 mod cmd_version;
@@ -51,6 +52,7 @@ pub fn make_cli() -> NewCli<'static> {
         .add_custom::<cmd_instance::CmdInstanceFromImage>("instance from-image")
         .add_custom::<cmd_completion::CmdCompletion>("completion")
         .add_custom::<cmd_timeseries::CmdTimeseriesDashboard>("experimental timeseries dashboard")
+        .add_custom::<cmd_net::CmdNet>("net")
 }
 
 #[tokio::main]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -52,7 +52,15 @@ pub fn make_cli() -> NewCli<'static> {
         .add_custom::<cmd_instance::CmdInstanceFromImage>("instance from-image")
         .add_custom::<cmd_completion::CmdCompletion>("completion")
         .add_custom::<cmd_timeseries::CmdTimeseriesDashboard>("experimental timeseries dashboard")
-        .add_custom::<cmd_net::CmdNet>("net")
+        .add_custom::<cmd_net::CmdAddr>("system networking addr")
+        .add_custom::<cmd_net::CmdLink>("system networking link")
+        .add_custom::<cmd_net::CmdPortConfig>("system networking switch-port-settings show")
+        .add_custom::<cmd_net::CmdPortStatus>("system hardware switch-port show-status")
+        .add_custom::<cmd_net::CmdBgpStatus>("system networking bgp show-status")
+        .add_custom::<cmd_net::CmdBgpPeer>("system networking bgp peer")
+        .add_custom::<cmd_net::CmdBgpAnnounce>("system networking bgp announce")
+        .add_custom::<cmd_net::CmdBgpWithdraw>("system networking bgp withdraw")
+        .add_custom::<cmd_net::CmdBgpFilter>("system networking bgp filter")
 }
 
 #[tokio::main]

--- a/cli/tests/data/json-body-required.txt
+++ b/cli/tests/data/json-body-required.txt
@@ -2,6 +2,7 @@ oxide image create
 oxide policy update
 oxide project policy update
 oxide system networking address-lot create
+oxide system networking bgp announce-set update
 oxide system networking bgp announce-set create
 oxide system networking switch-port-settings create
 oxide system policy update

--- a/cli/tests/data/json-body-required.txt
+++ b/cli/tests/data/json-body-required.txt
@@ -1,10 +1,6 @@
 oxide image create
 oxide policy update
 oxide project policy update
-oxide system networking address-lot create
-oxide system networking bgp announce-set update
-oxide system networking switch-port-settings create
-oxide system policy update
 oxide silo idp local user create
 oxide silo idp local user set-password
 oxide silo create
@@ -13,3 +9,7 @@ oxide vpc firewall-rules update
 oxide vpc router route create
 oxide vpc router route update
 oxide disk create
+oxide system policy update
+oxide system networking address-lot create
+oxide system networking switch-port-settings create
+oxide system networking bgp announce-set update

--- a/cli/tests/data/json-body-required.txt
+++ b/cli/tests/data/json-body-required.txt
@@ -3,7 +3,6 @@ oxide policy update
 oxide project policy update
 oxide system networking address-lot create
 oxide system networking bgp announce-set update
-oxide system networking bgp announce-set create
 oxide system networking switch-port-settings create
 oxide system policy update
 oxide silo idp local user create

--- a/cli/tests/data/test_switch_port_settings_show.stdout
+++ b/cli/tests/data/test_switch_port_settings_show.stdout
@@ -1,0 +1,26 @@
+switch0/qsfp0
+=============
+Autoneg  Fec   Speed
+false    None  Speed100G
+
+Address          Lot            VLAN
+169.254.10.2/30  initial-infra  None
+169.254.30.2/30  initial-infra  Some(300)
+
+BGP Peer      Config   Export             Import          Communities  Connect Retry  Delay Open  Enforce First AS  Hold Time  Idle Hold Time  Keepalive  Local Pref  Md5 Auth  Min TTL  MED   Remote ASN  VLAN
+169.254.10.1  as65547  [198.51.100.0/24]  [no filtering]  []           3              3           false             6          3               2          None        None      None     None  None        None
+169.254.30.1  as65547  [203.0.113.0/24]   [no filtering]  []           0              0           false             6          0               2          None        None      None     None  None        Some(300)
+
+switch1/qsfp0
+=============
+Autoneg  Fec   Speed
+false    None  Speed100G
+
+Address          Lot            VLAN
+169.254.20.2/30  initial-infra  None
+169.254.40.2/30  initial-infra  Some(400)
+
+BGP Peer      Config   Export             Import          Communities  Connect Retry  Delay Open  Enforce First AS  Hold Time  Idle Hold Time  Keepalive  Local Pref  Md5 Auth  Min TTL  MED   Remote ASN  VLAN
+169.254.20.1  as65547  [198.51.100.0/24]  [no filtering]  []           3              3           false             6          3               2          None        None      None     None  None        None
+169.254.40.1  as65547  [203.0.113.0/24]   [no filtering]  []           0              0           false             6          0               2          None        None      None     None  None        Some(400)
+

--- a/cli/tests/test_net.rs
+++ b/cli/tests/test_net.rs
@@ -1,0 +1,309 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+use assert_cmd::Command;
+use chrono::prelude::*;
+use httpmock::MockServer;
+use oxide::types::{
+    AddressLot, AddressLotBlock, AddressLotBlockResultsPage, AddressLotKind, AddressLotResultsPage,
+    BgpConfig, BgpConfigResultsPage, BgpPeer, ImportExportPolicy, LinkFec, LinkSpeed, NameOrId,
+    SwitchPort, SwitchPortAddressConfig, SwitchPortConfig, SwitchPortGeometry2,
+    SwitchPortLinkConfig, SwitchPortResultsPage, SwitchPortSettings, SwitchPortSettingsView,
+};
+use oxide_httpmock::MockServerExt;
+use uuid::Uuid;
+
+#[test]
+fn test_port_config() {
+    let server = MockServer::start();
+
+    let rack_id = Uuid::new_v4();
+    let switch0_qsfp0_settings_id = Uuid::new_v4();
+    let switch1_qsfp0_settings_id = Uuid::new_v4();
+    let lot_id = Uuid::new_v4();
+    let lot_block_id = Uuid::new_v4();
+
+    let ports = SwitchPortResultsPage {
+        items: vec![
+            SwitchPort {
+                id: Uuid::new_v4(),
+                port_name: String::from("qsfp0"),
+                port_settings_id: Some(switch0_qsfp0_settings_id),
+                rack_id,
+                switch_location: String::from("switch0"),
+            },
+            SwitchPort {
+                id: Uuid::new_v4(),
+                port_name: String::from("qsfp0"),
+                port_settings_id: Some(switch1_qsfp0_settings_id),
+                rack_id,
+                switch_location: String::from("switch1"),
+            },
+        ],
+        next_page: None,
+    };
+
+    let mock_ports = server.networking_switch_port_list(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&ports);
+    });
+
+    let lots = AddressLotResultsPage {
+        items: vec![AddressLot {
+            description: String::from("Initial infrastructure address lot"),
+            id: lot_id,
+            kind: AddressLotKind::Infra,
+            name: "initial-infra".parse().unwrap(),
+            time_created: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+            time_modified: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+        }],
+        next_page: None,
+    };
+
+    let mock_lots = server.networking_address_lot_list(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&lots);
+    });
+
+    let lot_blocks = AddressLotBlockResultsPage {
+        items: vec![AddressLotBlock {
+            first_address: "198.51.100.0".parse().unwrap(),
+            last_address: "198.51.100.254".parse().unwrap(),
+            id: lot_block_id,
+        }],
+        next_page: None,
+    };
+
+    let mock_lot_blocks = server.networking_address_lot_block_list(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&lot_blocks);
+    });
+
+    let bgp_configs = BgpConfigResultsPage {
+        items: vec![BgpConfig {
+            asn: 65547,
+            description: String::from("as65547"),
+            id: Uuid::new_v4(),
+            name: "as65547".parse().unwrap(),
+            vrf: None,
+            time_created: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+            time_modified: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+        }],
+        next_page: None,
+    };
+
+    let mock_bgp_configs = server.networking_bgp_config_list(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&bgp_configs);
+    });
+
+    let switch0_qsfp0_view = SwitchPortSettingsView {
+        addresses: vec![
+            SwitchPortAddressConfig {
+                address: "169.254.10.2/30".parse().unwrap(),
+                address_lot_block_id: lot_block_id,
+                interface_name: String::from("phy0"),
+                port_settings_id: switch0_qsfp0_settings_id,
+                vlan_id: None,
+            },
+            SwitchPortAddressConfig {
+                address: "169.254.30.2/30".parse().unwrap(),
+                address_lot_block_id: lot_block_id,
+                interface_name: String::from("phy0"),
+                port_settings_id: switch0_qsfp0_settings_id,
+                vlan_id: Some(300),
+            },
+        ],
+        bgp_peers: vec![
+            BgpPeer {
+                interface_name: String::from("phy0"),
+                addr: "169.254.10.1".parse().unwrap(),
+                bgp_config: NameOrId::Id(bgp_configs.items[0].id),
+                allowed_export: ImportExportPolicy::Allow(vec!["198.51.100.0/24".parse().unwrap()]),
+                allowed_import: ImportExportPolicy::NoFiltering,
+                communities: Vec::new(),
+                connect_retry: 3,
+                delay_open: 3,
+                enforce_first_as: false,
+                hold_time: 6,
+                idle_hold_time: 3,
+                keepalive: 2,
+                local_pref: None,
+                md5_auth_key: None,
+                min_ttl: None,
+                multi_exit_discriminator: None,
+                remote_asn: None,
+                vlan_id: None,
+            },
+            BgpPeer {
+                interface_name: String::from("phy0"),
+                addr: "169.254.30.1".parse().unwrap(),
+                bgp_config: NameOrId::Id(bgp_configs.items[0].id),
+                allowed_export: ImportExportPolicy::Allow(vec!["203.0.113.0/24".parse().unwrap()]),
+                allowed_import: ImportExportPolicy::NoFiltering,
+                communities: Vec::new(),
+                connect_retry: 0,
+                delay_open: 0,
+                enforce_first_as: false,
+                hold_time: 6,
+                idle_hold_time: 0,
+                keepalive: 2,
+                local_pref: None,
+                md5_auth_key: None,
+                min_ttl: None,
+                multi_exit_discriminator: None,
+                remote_asn: None,
+                vlan_id: Some(300),
+            },
+        ],
+        groups: Vec::new(),
+        interfaces: Vec::new(),
+        link_lldp: Vec::new(),
+        links: vec![SwitchPortLinkConfig {
+            autoneg: false,
+            fec: LinkFec::None,
+            link_name: String::from("phy0"),
+            lldp_service_config_id: Uuid::new_v4(),
+            mtu: 1500,
+            port_settings_id: switch1_qsfp0_settings_id,
+            speed: LinkSpeed::Speed100G,
+        }],
+        port: SwitchPortConfig {
+            geometry: SwitchPortGeometry2::Qsfp28x1,
+            port_settings_id: switch1_qsfp0_settings_id,
+        },
+        routes: Vec::new(),
+        settings: SwitchPortSettings {
+            description: String::from("default uplink 0 switch port settings"),
+            id: switch1_qsfp0_settings_id,
+            name: "default-uplink0".parse().unwrap(),
+            time_created: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+            time_modified: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+        },
+        vlan_interfaces: Vec::new(),
+    };
+    let switch1_qsfp0_view = SwitchPortSettingsView {
+        addresses: vec![
+            SwitchPortAddressConfig {
+                address: "169.254.20.2/30".parse().unwrap(),
+                address_lot_block_id: lot_block_id,
+                interface_name: String::from("phy0"),
+                port_settings_id: switch0_qsfp0_settings_id,
+                vlan_id: None,
+            },
+            SwitchPortAddressConfig {
+                address: "169.254.40.2/30".parse().unwrap(),
+                address_lot_block_id: lot_block_id,
+                interface_name: String::from("phy0"),
+                port_settings_id: switch0_qsfp0_settings_id,
+                vlan_id: Some(400),
+            },
+        ],
+        bgp_peers: vec![
+            BgpPeer {
+                interface_name: String::from("phy0"),
+                addr: "169.254.20.1".parse().unwrap(),
+                bgp_config: NameOrId::Id(bgp_configs.items[0].id),
+                allowed_export: ImportExportPolicy::Allow(vec!["198.51.100.0/24".parse().unwrap()]),
+                allowed_import: ImportExportPolicy::NoFiltering,
+                communities: Vec::new(),
+                connect_retry: 3,
+                delay_open: 3,
+                enforce_first_as: false,
+                hold_time: 6,
+                idle_hold_time: 3,
+                keepalive: 2,
+                local_pref: None,
+                md5_auth_key: None,
+                min_ttl: None,
+                multi_exit_discriminator: None,
+                remote_asn: None,
+                vlan_id: None,
+            },
+            BgpPeer {
+                interface_name: String::from("phy0"),
+                addr: "169.254.40.1".parse().unwrap(),
+                bgp_config: NameOrId::Id(bgp_configs.items[0].id),
+                allowed_export: ImportExportPolicy::Allow(vec!["203.0.113.0/24".parse().unwrap()]),
+                allowed_import: ImportExportPolicy::NoFiltering,
+                communities: Vec::new(),
+                connect_retry: 0,
+                delay_open: 0,
+                enforce_first_as: false,
+                hold_time: 6,
+                idle_hold_time: 0,
+                keepalive: 2,
+                local_pref: None,
+                md5_auth_key: None,
+                min_ttl: None,
+                multi_exit_discriminator: None,
+                remote_asn: None,
+                vlan_id: Some(400),
+            },
+        ],
+        groups: Vec::new(),
+        interfaces: Vec::new(),
+        link_lldp: Vec::new(),
+        links: vec![SwitchPortLinkConfig {
+            autoneg: false,
+            fec: LinkFec::None,
+            link_name: String::from("phy0"),
+            lldp_service_config_id: Uuid::new_v4(),
+            mtu: 1500,
+            port_settings_id: switch1_qsfp0_settings_id,
+            speed: LinkSpeed::Speed100G,
+        }],
+        port: SwitchPortConfig {
+            geometry: SwitchPortGeometry2::Qsfp28x1,
+            port_settings_id: switch1_qsfp0_settings_id,
+        },
+        routes: Vec::new(),
+        settings: SwitchPortSettings {
+            description: String::from("default uplink 1 switch port settings"),
+            id: switch1_qsfp0_settings_id,
+            name: "default-uplink1".parse().unwrap(),
+            time_created: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+            time_modified: Utc.with_ymd_and_hms(2024, 7, 8, 9, 10, 11).unwrap(),
+        },
+        vlan_interfaces: Vec::new(),
+    };
+
+    let mock_switch0_qsfp0_settings_view =
+        server.networking_switch_port_settings_view(|when, then| {
+            when.port(&NameOrId::Id(ports.items[0].port_settings_id.unwrap()));
+            then.ok(&switch0_qsfp0_view);
+        });
+
+    let mock_switch1_qsfp0_settings_view =
+        server.networking_switch_port_settings_view(|when, then| {
+            when.port(&NameOrId::Id(ports.items[1].port_settings_id.unwrap()));
+            then.ok(&switch1_qsfp0_view);
+        });
+
+    env_logger::init();
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("system")
+        .arg("networking")
+        .arg("switch-port-settings")
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(expectorate::eq_file_or_panic(
+            "tests/data/test_switch_port_settings_show.stdout",
+        ));
+
+    mock_ports.assert();
+    mock_lots.assert();
+    mock_lot_blocks.assert();
+    mock_bgp_configs.assert_hits(2);
+    mock_switch0_qsfp0_settings_view.assert();
+    mock_switch1_qsfp0_settings_view.assert();
+}

--- a/oxide.json
+++ b/oxide.json
@@ -19800,7 +19800,8 @@
         "enum": [
           "count",
           "bytes",
-          "seconds"
+          "seconds",
+          "nanoseconds"
         ]
       },
       "User": {

--- a/oxide.json
+++ b/oxide.json
@@ -6634,43 +6634,9 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Update a BGP announce set",
+        "summary": "Update BGP announce set",
+        "description": "If the announce set exists, this endpoint replaces the existing announce set with the one specified.",
         "operationId": "networking_bgp_announce_set_update",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BgpAnnounceSetCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "successful creation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BgpAnnounceSet"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "system/networking"
-        ],
-        "summary": "Create new BGP announce set",
-        "operationId": "networking_bgp_announce_set_create",
         "requestBody": {
           "content": {
             "application/json": {

--- a/oxide.json
+++ b/oxide.json
@@ -6630,6 +6630,41 @@
           }
         }
       },
+      "put": {
+        "tags": [
+          "system/networking"
+        ],
+        "summary": "Update a BGP announce set",
+        "operationId": "networking_bgp_announce_set_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BgpAnnounceSetCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BgpAnnounceSet"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "post": {
         "tags": [
           "system/networking"
@@ -19798,7 +19833,8 @@
         "type": "string",
         "enum": [
           "count",
-          "bytes"
+          "bytes",
+          "seconds"
         ]
       },
       "User": {

--- a/sdk-httpmock/src/generated_httpmock.rs
+++ b/sdk-httpmock/src/generated_httpmock.rs
@@ -10806,65 +10806,6 @@ pub mod operations {
         }
     }
 
-    pub struct NetworkingBgpAnnounceSetCreateWhen(httpmock::When);
-    impl NetworkingBgpAnnounceSetCreateWhen {
-        pub fn new(inner: httpmock::When) -> Self {
-            Self(
-                inner.method(httpmock::Method::POST).path_matches(
-                    regex::Regex::new("^/v1/system/networking/bgp-announce$").unwrap(),
-                ),
-            )
-        }
-
-        pub fn into_inner(self) -> httpmock::When {
-            self.0
-        }
-
-        pub fn body(self, value: &types::BgpAnnounceSetCreate) -> Self {
-            Self(self.0.json_body_obj(value))
-        }
-    }
-
-    pub struct NetworkingBgpAnnounceSetCreateThen(httpmock::Then);
-    impl NetworkingBgpAnnounceSetCreateThen {
-        pub fn new(inner: httpmock::Then) -> Self {
-            Self(inner)
-        }
-
-        pub fn into_inner(self) -> httpmock::Then {
-            self.0
-        }
-
-        pub fn created(self, value: &types::BgpAnnounceSet) -> Self {
-            Self(
-                self.0
-                    .status(201u16)
-                    .header("content-type", "application/json")
-                    .json_body_obj(value),
-            )
-        }
-
-        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
-            assert_eq!(status / 100u16, 4u16);
-            Self(
-                self.0
-                    .status(status)
-                    .header("content-type", "application/json")
-                    .json_body_obj(value),
-            )
-        }
-
-        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
-            assert_eq!(status / 100u16, 5u16);
-            Self(
-                self.0
-                    .status(status)
-                    .header("content-type", "application/json")
-                    .json_body_obj(value),
-            )
-        }
-    }
-
     pub struct NetworkingBgpAnnounceSetDeleteWhen(httpmock::When);
     impl NetworkingBgpAnnounceSetDeleteWhen {
         pub fn new(inner: httpmock::When) -> Self {
@@ -16228,12 +16169,6 @@ pub trait MockServerExt {
             operations::NetworkingBgpAnnounceSetUpdateWhen,
             operations::NetworkingBgpAnnounceSetUpdateThen,
         );
-    fn networking_bgp_announce_set_create<F>(&self, config_fn: F) -> httpmock::Mock
-    where
-        F: FnOnce(
-            operations::NetworkingBgpAnnounceSetCreateWhen,
-            operations::NetworkingBgpAnnounceSetCreateThen,
-        );
     fn networking_bgp_announce_set_delete<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(
@@ -18177,21 +18112,6 @@ impl MockServerExt for httpmock::MockServer {
             config_fn(
                 operations::NetworkingBgpAnnounceSetUpdateWhen::new(when),
                 operations::NetworkingBgpAnnounceSetUpdateThen::new(then),
-            )
-        })
-    }
-
-    fn networking_bgp_announce_set_create<F>(&self, config_fn: F) -> httpmock::Mock
-    where
-        F: FnOnce(
-            operations::NetworkingBgpAnnounceSetCreateWhen,
-            operations::NetworkingBgpAnnounceSetCreateThen,
-        ),
-    {
-        self.mock(|when, then| {
-            config_fn(
-                operations::NetworkingBgpAnnounceSetCreateWhen::new(when),
-                operations::NetworkingBgpAnnounceSetCreateThen::new(then),
             )
         })
     }

--- a/sdk-httpmock/src/generated_httpmock.rs
+++ b/sdk-httpmock/src/generated_httpmock.rs
@@ -10747,6 +10747,65 @@ pub mod operations {
         }
     }
 
+    pub struct NetworkingBgpAnnounceSetUpdateWhen(httpmock::When);
+    impl NetworkingBgpAnnounceSetUpdateWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner.method(httpmock::Method::PUT).path_matches(
+                    regex::Regex::new("^/v1/system/networking/bgp-announce$").unwrap(),
+                ),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn body(self, value: &types::BgpAnnounceSetCreate) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+
+    pub struct NetworkingBgpAnnounceSetUpdateThen(httpmock::Then);
+    impl NetworkingBgpAnnounceSetUpdateThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn created(self, value: &types::BgpAnnounceSet) -> Self {
+            Self(
+                self.0
+                    .status(201u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
     pub struct NetworkingBgpAnnounceSetCreateWhen(httpmock::When);
     impl NetworkingBgpAnnounceSetCreateWhen {
         pub fn new(inner: httpmock::When) -> Self {
@@ -16163,6 +16222,12 @@ pub trait MockServerExt {
             operations::NetworkingBgpAnnounceSetListWhen,
             operations::NetworkingBgpAnnounceSetListThen,
         );
+    fn networking_bgp_announce_set_update<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::NetworkingBgpAnnounceSetUpdateWhen,
+            operations::NetworkingBgpAnnounceSetUpdateThen,
+        );
     fn networking_bgp_announce_set_create<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(
@@ -18097,6 +18162,21 @@ impl MockServerExt for httpmock::MockServer {
             config_fn(
                 operations::NetworkingBgpAnnounceSetListWhen::new(when),
                 operations::NetworkingBgpAnnounceSetListThen::new(then),
+            )
+        })
+    }
+
+    fn networking_bgp_announce_set_update<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::NetworkingBgpAnnounceSetUpdateWhen,
+            operations::NetworkingBgpAnnounceSetUpdateThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::NetworkingBgpAnnounceSetUpdateWhen::new(when),
+                operations::NetworkingBgpAnnounceSetUpdateThen::new(then),
             )
         })
     }

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -48504,7 +48504,10 @@ pub trait ClientSystemNetworkingExt {
     ///    .await;
     /// ```
     fn networking_bgp_announce_set_list(&self) -> builder::NetworkingBgpAnnounceSetList;
-    /// Update a BGP announce set
+    /// Update BGP announce set
+    ///
+    /// If the announce set exists, this endpoint replaces the existing announce
+    /// set with the one specified.
     ///
     /// Sends a `PUT` request to `/v1/system/networking/bgp-announce`
     ///
@@ -48515,17 +48518,6 @@ pub trait ClientSystemNetworkingExt {
     ///    .await;
     /// ```
     fn networking_bgp_announce_set_update(&self) -> builder::NetworkingBgpAnnounceSetUpdate;
-    /// Create new BGP announce set
-    ///
-    /// Sends a `POST` request to `/v1/system/networking/bgp-announce`
-    ///
-    /// ```ignore
-    /// let response = client.networking_bgp_announce_set_create()
-    ///    .body(body)
-    ///    .send()
-    ///    .await;
-    /// ```
-    fn networking_bgp_announce_set_create(&self) -> builder::NetworkingBgpAnnounceSetCreate;
     /// Delete BGP announce set
     ///
     /// Sends a `DELETE` request to `/v1/system/networking/bgp-announce`
@@ -48816,10 +48808,6 @@ impl ClientSystemNetworkingExt for Client {
 
     fn networking_bgp_announce_set_update(&self) -> builder::NetworkingBgpAnnounceSetUpdate {
         builder::NetworkingBgpAnnounceSetUpdate::new(self)
-    }
-
-    fn networking_bgp_announce_set_create(&self) -> builder::NetworkingBgpAnnounceSetCreate {
-        builder::NetworkingBgpAnnounceSetCreate::new(self)
     }
 
     fn networking_bgp_announce_set_delete(&self) -> builder::NetworkingBgpAnnounceSetDelete {
@@ -63788,82 +63776,6 @@ pub mod builder {
             let mut request = client
                 .client
                 .put(url)
-                .header(
-                    reqwest::header::ACCEPT,
-                    reqwest::header::HeaderValue::from_static("application/json"),
-                )
-                .json(&body)
-                .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
-                )),
-                500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
-                )),
-                _ => Err(Error::UnexpectedResponse(response)),
-            }
-        }
-    }
-
-    /// Builder for
-    /// [`ClientSystemNetworkingExt::networking_bgp_announce_set_create`]
-    ///
-    /// [`ClientSystemNetworkingExt::networking_bgp_announce_set_create`]: super::ClientSystemNetworkingExt::networking_bgp_announce_set_create
-    #[derive(Debug, Clone)]
-    pub struct NetworkingBgpAnnounceSetCreate<'a> {
-        client: &'a super::Client,
-        body: Result<types::builder::BgpAnnounceSetCreate, String>,
-    }
-
-    impl<'a> NetworkingBgpAnnounceSetCreate<'a> {
-        pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                client: client,
-                body: Ok(types::builder::BgpAnnounceSetCreate::default()),
-            }
-        }
-
-        pub fn body<V>(mut self, value: V) -> Self
-        where
-            V: std::convert::TryInto<types::BgpAnnounceSetCreate>,
-            <V as std::convert::TryInto<types::BgpAnnounceSetCreate>>::Error: std::fmt::Display,
-        {
-            self.body = value.try_into().map(From::from).map_err(|s| {
-                format!(
-                    "conversion to `BgpAnnounceSetCreate` for body failed: {}",
-                    s
-                )
-            });
-            self
-        }
-
-        pub fn body_map<F>(mut self, f: F) -> Self
-        where
-            F: std::ops::FnOnce(
-                types::builder::BgpAnnounceSetCreate,
-            ) -> types::builder::BgpAnnounceSetCreate,
-        {
-            self.body = self.body.map(f);
-            self
-        }
-
-        /// Sends a `POST` request to `/v1/system/networking/bgp-announce`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::BgpAnnounceSet>, Error<types::Error>> {
-            let Self { client, body } = self;
-            let body = body
-                .and_then(|v| types::BgpAnnounceSetCreate::try_from(v).map_err(|e| e.to_string()))
-                .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/networking/bgp-announce", client.baseurl,);
-            #[allow(unused_mut)]
-            let mut request = client
-                .client
-                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -23261,7 +23261,8 @@ pub mod types {
     ///  "enum": [
     ///    "count",
     ///    "bytes",
-    ///    "seconds"
+    ///    "seconds",
+    ///    "nanoseconds"
     ///  ]
     /// }
     /// ```
@@ -23286,6 +23287,8 @@ pub mod types {
         Bytes,
         #[serde(rename = "seconds")]
         Seconds,
+        #[serde(rename = "nanoseconds")]
+        Nanoseconds,
     }
 
     impl From<&Units> for Units {
@@ -23300,6 +23303,7 @@ pub mod types {
                 Self::Count => "count".to_string(),
                 Self::Bytes => "bytes".to_string(),
                 Self::Seconds => "seconds".to_string(),
+                Self::Nanoseconds => "nanoseconds".to_string(),
             }
         }
     }
@@ -23311,6 +23315,7 @@ pub mod types {
                 "count" => Ok(Self::Count),
                 "bytes" => Ok(Self::Bytes),
                 "seconds" => Ok(Self::Seconds),
+                "nanoseconds" => Ok(Self::Nanoseconds),
                 _ => Err("invalid value".into()),
             }
         }


### PR DESCRIPTION
We have a transactional API for port settings objects. The port settings object is somewhat complex. The port settings object returned by GET requests to view port settings is not exactly the same as the port settings object used to create/update port settings with PUT/POST requests. This makes it rather grueling to manage port settings.

This PR adds client-side read/modify/write routines for managing individual items within port settings such as addresses.

Also pulls in the observability stuff from #661.

An example of using these new commands is [here](https://github.com/oxidecomputer/testbed/blob/vlan-ry-testing/a4x2/scripts/pop/connect-to-cloud.sh), which demonstrates creating a new BGP connection to a cloud provider. An example of using the observability stuff pulled in from #661 is in [this comment](https://github.com/oxidecomputer/omicron/pull/6001#issuecomment-2209531821) analyzing an Omicron bug.