### PR TITLE
Correct 'auth login' default scheme help string

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -89,7 +89,7 @@
             {
               "long": "host",
               "short": "H",
-              "help": "The host of the Oxide instance to authenticate with. This assumes http; specify an `http://` prefix if needed"
+              "help": "The host of the Oxide instance to authenticate with. This assumes https; specify an `http://` prefix if needed"
             },
             {
               "long": "no-browser",

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -135,7 +135,7 @@ pub struct CmdAuthLogin {
     with_token: bool,
 
     /// The host of the Oxide instance to authenticate with.
-    /// This assumes http; specify an `http://` prefix if needed.
+    /// This assumes https; specify an `http://` prefix if needed.
     #[clap(short = 'H', long, value_parser = parse_host)]
     host: url::Url,
 


### PR DESCRIPTION
Currently our help text for the `--host` flag on the `auth login` subcommand states that http is the default scheme, when [it is actually https](https://github.com/oxidecomputer/oxide.rs/blob/8801dc6f0342d6efff789d13691c951d8ee830f2/cli/src/cmd_auth.rs#L90).

Correct the comment.