### PR TITLE
CLI: print error source

### DIFF
--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -487,6 +487,27 @@ impl CmdAuthStatus {
 #[cfg(test)]
 mod tests {
     #[test]
+    fn test_cmd_auth_login() {
+        use assert_cmd::Command;
+        use predicates::str;
+
+        let bad_url = "sys.oxide.invalid";
+
+        // Validate connection error details are printed
+        Command::cargo_bin("oxide")
+            .unwrap()
+            .arg("auth")
+            .arg("login")
+            .arg("--host")
+            .arg(bad_url)
+            .assert()
+            .failure()
+            .stderr(str::starts_with(format!(
+                "Request failed: error sending request for url (https://{bad_url}/device/auth):"
+            )));
+    }
+
+    #[test]
     fn test_parse_host() {
         use super::parse_host;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -101,7 +101,8 @@ async fn main() {
         .await
         .unwrap();
     if let Err(e) = result {
-        eprintln!("{e}");
+        let src = e.source().map(|s| format!(": {s}")).unwrap_or_default();
+        eprintln!("{e}{src}");
         std::process::exit(1)
     }
 }


### PR DESCRIPTION
Currently the `oxide` binary will print the error returned when a
subcommand fails, but not any `source` errors attached to it. In the
context of connection failures from the `auth login` subcommand, the
output was only `Request failed`, giving the user no context on why the
failure occurred.
      
If present, append the source of the error to the user-facing message.
      
Previously:
```sh
$ oxide auth login --host oxide.invalid
Request failed
```
      
Now:
```sh
$ oxide auth login --host oxide.invalid
Request failed: error sending request for url (http://oxide.invalid/device/auth): error trying to connect: dns error: failed to lookup address information: nodename nor servname  provided, or not known
```