### PR TITLE
Ignore EPIPE in CLI

### DIFF
--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -19,7 +19,7 @@ use toml_edit::{Item, Table};
 use uuid::Uuid;
 
 use crate::context::Context;
-use crate::{AsHost, RunnableCmd};
+use crate::{println_nopipe, AsHost, RunnableCmd};
 
 /// Login, logout, and get the status of your authentication.
 ///
@@ -441,11 +441,11 @@ impl CmdAuthStatus {
             match client.current_user_view().send().await {
                 Ok(user) => {
                     log::debug!("success response for {} (env): {:?}", host_env, user);
-                    println!("Logged in to {} as {}", host_env, user.id)
+                    println_nopipe!("Logged in to {} as {}", host_env, user.id)
                 }
                 Err(e) => {
                     log::debug!("error response for {} (env): {}", host_env, e);
-                    println!("{}: {}", host_env, Self::error_msg(&e))
+                    println_nopipe!("{}: {}", host_env, Self::error_msg(&e))
                 }
             };
         } else {
@@ -467,9 +467,11 @@ impl CmdAuthStatus {
                     }
                 };
 
-                println!(
+                println_nopipe!(
                     "Profile \"{}\" ({}) status: {}",
-                    profile_name, profile_info.host, status
+                    profile_name,
+                    profile_info.host,
+                    status
                 );
             }
         }

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -28,6 +28,8 @@ use std::io::Write;
 use tabwriter::TabWriter;
 use uuid::Uuid;
 
+use crate::println_nopipe;
+
 // We do not yet support port breakouts, but the API is phrased in terms of
 // ports that can be broken out. The constant phy0 represents the first port
 // in a breakout.
@@ -875,14 +877,14 @@ impl AuthenticatedCmd for CmdPortConfig {
                     .map(|x| (x.id, x.name))
                     .collect();
 
-                println!(
+                println_nopipe!(
                     "{}{}{}",
                     p.switch_location.to_string().blue(),
                     "/".dimmed(),
                     p.port_name.blue(),
                 );
 
-                println!(
+                println_nopipe!(
                     "{}",
                     "=".repeat(p.port_name.len() + p.switch_location.to_string().len() + 1)
                         .dimmed()
@@ -900,7 +902,7 @@ impl AuthenticatedCmd for CmdPortConfig {
                     writeln!(&mut tw, "{:?}\t{:?}\t{:?}", l.autoneg, l.fec, l.speed,)?;
                 }
                 tw.flush()?;
-                println!();
+                println_nopipe!();
 
                 writeln!(
                     &mut tw,
@@ -923,7 +925,7 @@ impl AuthenticatedCmd for CmdPortConfig {
                     writeln!(&mut tw, "{}\t{}\t{:?}", addr, *alb.0.name, a.vlan_id)?;
                 }
                 tw.flush()?;
-                println!();
+                println_nopipe!();
 
                 writeln!(
                     &mut tw,
@@ -987,7 +989,7 @@ impl AuthenticatedCmd for CmdPortConfig {
                     )?;
                 }
                 tw.flush()?;
-                println!();
+                println_nopipe!();
 
                 // Uncomment to see full payload
                 //println!("");
@@ -1017,13 +1019,13 @@ impl AuthenticatedCmd for CmdBgpStatus {
             .iter()
             .partition(|x| x.switch == SwitchLocation::Switch0);
 
-        println!("{}", "switch0".dimmed());
-        println!("{}", "=======".dimmed());
+        println_nopipe!("{}", "switch0".dimmed());
+        println_nopipe!("{}", "=======".dimmed());
         show_status(&sw0)?;
-        println!();
+        println_nopipe!();
 
-        println!("{}", "switch1".dimmed());
-        println!("{}", "=======".dimmed());
+        println_nopipe!("{}", "switch1".dimmed());
+        println_nopipe!("{}", "=======".dimmed());
         show_status(&sw1)?;
 
         Ok(())
@@ -1078,12 +1080,12 @@ impl AuthenticatedCmd for CmdPortStatus {
         sw0.sort_by_key(|x| x.port_name.as_str());
         sw1.sort_by_key(|x| x.port_name.as_str());
 
-        println!("{}", "switch0".dimmed());
-        println!("{}", "=======".dimmed());
+        println_nopipe!("{}", "switch0".dimmed());
+        println_nopipe!("{}", "=======".dimmed());
         self.show_switch(client, "switch0", &sw0).await?;
 
-        println!("{}", "switch1".dimmed());
-        println!("{}", "=======".dimmed());
+        println_nopipe!("{}", "switch1".dimmed());
+        println_nopipe!("{}", "=======".dimmed());
         self.show_switch(client, "switch1", &sw1).await?;
 
         Ok(())
@@ -1228,9 +1230,9 @@ impl CmdPortStatus {
         }
 
         ltw.flush()?;
-        println!();
+        println_nopipe!();
         mtw.flush()?;
-        println!();
+        println_nopipe!();
 
         Ok(())
     }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -1,0 +1,107 @@
+/// A wrapper around print! that will not panic on EPIPE.
+/// Useful for avoiding spurious panics when piping to head(1).
+#[macro_export]
+macro_rules! print_nopipe {
+    // Ignore failure when printing an empty line.
+    () => {
+        {
+            use std::io::Write;
+            match write!(std::io::stdout()) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+    ($($arg:tt)*) => {
+        {
+            use std::io::Write;
+            match write!(std::io::stdout(), $($arg)*) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+}
+
+/// A wrapper around println! that will not panic on EPIPE.
+/// Useful for avoiding spurious panics when piping to head(1).
+#[macro_export]
+macro_rules! println_nopipe {
+    // Ignore failure when printing an empty line.
+    () => {
+        {
+            use std::io::Write;
+            match writeln!(std::io::stdout()) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+    ($($arg:tt)*) => {
+        {
+            use std::io::Write;
+            match writeln!(std::io::stdout(), $($arg)*) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+}
+
+/// A wrapper around eprint! that will not panic on EPIPE.
+/// Useful for avoiding spurious panics when piping to head(1).
+#[macro_export]
+macro_rules! eprint_nopipe {
+    // Ignore failure when printing an empty line.
+    () => {
+        {
+            use std::io::Write;
+            match write!(std::io::stderr()) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+    ($($arg:tt)*) => {
+        {
+            use std::io::Write;
+            match write!(std::io::stderr(), $($arg)*) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+}
+
+/// A wrapper around eprintln! that will not panic on EPIPE.
+/// Useful for avoiding spurious panics when piping to head(1).
+#[macro_export]
+macro_rules! eprintln_nopipe {
+    // Ignore failure when printing an empty line.
+    () => {
+        {
+            use std::io::Write;
+            match writeln!(std::io::stderr()) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+    ($($arg:tt)*) => {
+        {
+            use std::io::Write;
+            match writeln!(std::io::stderr(), $($arg)*) {
+                Ok(()) => (),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => (),
+                Err(e) => panic!("{e}"),
+            }
+        }
+    };
+}


### PR DESCRIPTION
Piping command output to a process that performs a partial read before closing the pipe, such as `head`, will cause an `EPIPE` to be raised on the next write attempt. The standard `(e)print(ln)!` macros will panic on any errors when writing, including `EPIPE`. One option to handle this is to switch to `write(ln)!`, but this will inject new requirements to handle `Result` where used, which can be onerous.

Create wrappers around the print macros to ignore `EPIPE`, and replace calls to the originals with them. Update `main` to ignore any `EPIPE`s returned from `writeln!` calls in subcommands.

We deliberately do not make this change to the `auth login/logout` subcommands as these are mutating the config. Failure to notify the user of the changes is fatal.

Before:

```sh
  $ oxide system networking switch-port-settings show | head -1
  switch0/qsfp0
  thread 'tokio-runtime-worker' panicked at library/std/src/io/stdio.rs:1021:9:
  failed printing to stdout: Broken pipe (os error 32)
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  thread 'main' panicked at cli/src/main.rs:102:10:
  called `Result::unwrap()` on an `Err` value: JoinError::Panic(Id(15), ...)
```

After:

```sh
  $ oxide system networking switch-port-settings show | head -1
  switch0/qsfp0
```