### PR TITLE
Sort subcommands in CLI help text

### DIFF
--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -215,7 +215,27 @@ impl<'a> NewCli<'a> {
         self
     }
 
-    pub async fn run(self) -> Result<()> {
+    fn sort_commands(&mut self) {
+        let subcommands: BTreeMap<_, _> = self
+            .parser
+            .get_subcommands()
+            .map(|subcmd| (subcmd.get_name(), subcmd.clone()))
+            .collect();
+
+        let sorted_subcommands: Vec<_> = subcommands
+            .into_values()
+            .enumerate()
+            .map(|(i, subcmd)| subcmd.display_order(i))
+            .collect();
+
+        for (orig, sorted) in self.parser.get_subcommands_mut().zip(sorted_subcommands) {
+            *orig = sorted;
+        }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        self.sort_commands();
+
         let Self { parser, runner } = self;
         let matches = parser.get_matches();
 


### PR DESCRIPTION
By default `clap` will display subcommands in `--help` in the order they were added to the `Command`. In our case the order is random due to the split between commands from `progenitor` and custom commands added manually.

Manually set the `display_order` to lexically sort the subcommands.

Before:

```
  Commands:
    experimental
    certificate
    disk
    floating-ip
    group
    image
    instance
    project
    current-user
    ping          Ping API
    policy
    snapshot
    system
    silo
    ip-pool
    user
    utilization   Fetch resource utilization for user's current silo
    vpc
    auth          Login, logout, and get the status of your authentication.
    docs          Generate CLI docs in JSON format
    completion    Generate shell completion scripts for Oxide CLI commands.
    version       Prints version information about the CLI.
    api           Makes an authenticated HTTP request to the Oxide API and prints the response.
    help          Print this message or the help of the given subcommand(s)
```

After:

```
  Commands:
    api           Makes an authenticated HTTP request to the Oxide API and prints the response.
    auth          Login, logout, and get the status of your authentication.
    certificate
    completion    Generate shell completion scripts for Oxide CLI commands.
    current-user
    disk
    docs          Generate CLI docs in JSON format
    experimental
    floating-ip
    group
    image
    instance
    ip-pool
    ping          Ping API
    policy
    project
    silo
    snapshot
    system
    user
    utilization   Fetch resource utilization for user's current silo
    version       Prints version information about the CLI.
    vpc
    help          Print this message or the help of the given subcommand(s)
```