### PR TITLE
Sort subcommands automatically in help output

### DIFF
--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -598,11 +598,12 @@ impl CommandExt for Command {
                 self.subcommand(
                     Command::new(first.to_owned())
                         .subcommand_required(true)
+                        .display_order(0)
                         .add_subcommand(rest, subcmd),
                 )
             }
         } else {
-            let new_subcmd = subcmd.into().name(path.to_owned());
+            let new_subcmd = subcmd.into().name(path.to_owned()).display_order(0);
             let has_subcommand = self.find_subcommand(path).is_some();
             if has_subcommand {
                 self.mut_subcommand(path, |cmd| {


### PR DESCRIPTION
By default `clap` will display subcommands in `--help` in the order they were added to the `Command`. In our case the order is random due to the split between commands from `progenitor` and custom commands added manually.

Set `display_order(0)` on subcommands to allow `clap` to sort them automatically.

Before:

```
  Commands:
    experimental
    certificate
    disk
    floating-ip
    group
    image
    instance
    project
    current-user
    ping          Ping API
    policy
    snapshot
    system
    silo
    ip-pool
    user
    utilization   Fetch resource utilization for user's current silo
    vpc
    auth          Login, logout, and get the status of your authentication.
    docs          Generate CLI docs in JSON format
    completion    Generate shell completion scripts for Oxide CLI commands.
    version       Prints version information about the CLI.
    api           Makes an authenticated HTTP request to the Oxide API and prints the response.
    help          Print this message or the help of the given subcommand(s)
```

After:

```
  Commands:
    api           Makes an authenticated HTTP request to the Oxide API and prints the response.
    auth          Login, logout, and get the status of your authentication.
    certificate
    completion    Generate shell completion scripts for Oxide CLI commands.
    current-user
    disk
    docs          Generate CLI docs in JSON format
    experimental
    floating-ip
    group
    image
    instance
    ip-pool
    ping          Ping API
    policy
    project
    silo
    snapshot
    system
    user
    utilization   Fetch resource utilization for user's current silo
    version       Prints version information about the CLI.
    vpc
    help          Print this message or the help of the given subcommand(s)
```