### PR TITLE
Simplify printing error source

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -110,10 +110,7 @@ async fn main() {
             }
         }
 
-        let src = e.source().map(|s| format!(": {s}")).unwrap_or_default();
-        eprintln_nopipe!("{e}{src}");
-
-        eprintln_nopipe!("{e}");
+        eprintln_nopipe!("{e:#}");
         std::process::exit(1)
     }
 }


### PR DESCRIPTION
`anyhow::Error` supports using the `:#` format option to print the error sources as well as the base error.

Replace our customer logic to print the source with this.