### PR TITLE
cli: handle EPIPE for version subcommand

### DIFF
--- a/cli/src/cmd_version.rs
+++ b/cli/src/cmd_version.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use clap::Parser;
 use oxide::Client;
 
+use crate::println_nopipe;
 use crate::{context::Context, RunnableCmd};
 
 pub mod built_info {
@@ -27,9 +28,9 @@ impl RunnableCmd for CmdVersion {
         let cli_version = built_info::PKG_VERSION;
         let api_version = Client::new("").api_version();
 
-        println!("Oxide CLI {}", cli_version);
+        println_nopipe!("Oxide CLI {}", cli_version);
 
-        println!(
+        println_nopipe!(
             "Built from commit: {} {}",
             built_info::GIT_COMMIT_HASH.unwrap(),
             if matches!(built_info::GIT_DIRTY, Some(true)) {
@@ -39,7 +40,7 @@ impl RunnableCmd for CmdVersion {
             }
         );
 
-        println!("Oxide API: {}", api_version);
+        println_nopipe!("Oxide API: {}", api_version);
 
         Ok(())
     }


### PR DESCRIPTION
EPIPE handling was added recently via {e}println_nopipe() macros, but wasn't used for the "version" subcommand.  This replaces println() calls with println_nopipe().

Before:
```
➜  oxide.rs git:(main) ./target/debug/oxide version | head -1
Oxide CLI 0.6.1+20240710.0
➜  oxide.rs git:(main) ./target/debug/oxide version | a
zsh: command not found: a
thread 'tokio-runtime-worker' panicked at library/std/src/io/stdio.rs:1021:9:
failed printing to stdout: Broken pipe (os error 32)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at cli/src/main.rs:105:10:
called `Result::unwrap()` on an `Err` value: JoinError::Panic(Id(9), ...)
➜  oxide.rs git:(main)
```

After:
```
➜  oxide.rs git:(trey/epipe_version) ./target/debug/oxide version | head -1
Oxide CLI 0.6.1+20240710.0
➜  oxide.rs git:(trey/epipe_version) ./target/debug/oxide version | a
zsh: command not found: a
➜  oxide.rs git:(trey/epipe_version)
```

Fixes: #773