### PR TITLE
Accept profile argument in all subcommands

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -71,6 +71,10 @@
           "help": "Make additional HTTP requests to fetch all pages of results"
         },
         {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        },
+        {
           "long": "raw-field",
           "short": "f",
           "help": "Add a string parameter in key=value format"
@@ -81,6 +85,12 @@
       "name": "auth",
       "about": "Login, logout, and get the status of your authentication.",
       "long_about": "Login, logout, and get the status of your authentication.\n\nManage `oxide`'s authentication state.",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "login",
@@ -99,6 +109,10 @@
             {
               "long": "no-browser",
               "help": "Print the authentication URL rather than opening a browser window"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -116,18 +130,34 @@
               "long": "force",
               "short": "f",
               "help": "Skip confirmation prompt"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
         {
           "name": "status",
           "about": "Verifies and displays information about your authentication state.",
-          "long_about": "Verifies and displays information about your authentication state.\n\nThis command validates the authentication state for each profile in the\ncurrent configuration."
+          "long_about": "Verifies and displays information about your authentication state.\n\nThis command validates the authentication state for each profile in the\ncurrent configuration.",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ]
         }
       ]
     },
     {
       "name": "certificate",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -157,6 +187,10 @@
               "long": "name"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "service",
               "values": [
                 "external_api"
@@ -172,6 +206,10 @@
           "args": [
             {
               "long": "certificate"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -183,6 +221,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "sort-by",
@@ -201,6 +243,10 @@
           "args": [
             {
               "long": "certificate"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         }
@@ -211,6 +257,10 @@
       "about": "Generate shell completion scripts for Oxide CLI commands.",
       "long_about": "Generate shell completion scripts for Oxide CLI commands.\n\nThis command generates scripts for various shells that can be used to\nenable completion.\n\n## Installation\n\n### Bash\n\nAdd this to your `~/.bash_profile`:\n\n```sh\neval \"$(oxide completion -s bash)\"\n```\n\n### Zsh\n\nGenerate an `_oxide` completion script and put it somewhere in your\n`$fpath`, for example:\n\n```sh\noxide completion -s zsh > ~/.zfunc/_oxide\n```\n\nand check that you have the following lines in your `~/.zshrc`:\n\n```sh\nautoload -U compinit\ncompinit -i\n```\n\n### Fish\n\nGenerate an `oxide.fish` completion script:\n\n```sh\noxide completion -s fish > ~/.config/fish/completions/oxide.fish\n```\n\n### PowerShell\n\nOpen your profile script with:\n\n```sh\nmkdir -Path (Split-Path -Parent $profile)\nnotepad $profile\n```\n\nAdd the following line and save the file:\n\n```powershell\nInvoke-Expression -Command $(oxide completion -s powershell | Out-String)\n```\n\n### Elvish\n\nGenerate an `oxide.elv` completion script and put it in a module search\ndirectory, for example:\n\n```sh\noxide completion -s elvish > ~/.local/share/elvish/lib/oxide.elv\n```\n\nand import this by adding the following to `~/.config/elvish/rc.elv`\n\n```\nuse oxide\n```",
       "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        },
         {
           "long": "shell",
           "short": "s",
@@ -227,6 +277,12 @@
     },
     {
       "name": "current-user",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "groups",
@@ -235,6 +291,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "sort-by",
@@ -246,6 +306,12 @@
         },
         {
           "name": "ssh-key",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "create",
@@ -267,6 +333,10 @@
                   "long": "name"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "public-key",
                   "help": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"
                 }
@@ -277,6 +347,10 @@
               "about": "Delete SSH public key",
               "long_about": "Delete an SSH public key associated with the currently authenticated user.",
               "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
                 {
                   "long": "ssh-key",
                   "help": "Name or ID of the SSH key"
@@ -291,6 +365,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "sort-by",
@@ -308,6 +386,10 @@
               "long_about": "Fetch SSH public key associated with the currently authenticated user.",
               "args": [
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "ssh-key",
                   "help": "Name or ID of the SSH key"
                 }
@@ -317,12 +399,24 @@
         },
         {
           "name": "view",
-          "about": "Fetch user for current session"
+          "about": "Fetch user for current session",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ]
         }
       ]
     },
     {
       "name": "disk",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -343,6 +437,10 @@
               "long": "name"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -359,6 +457,10 @@
             {
               "long": "disk",
               "help": "Name or ID of the disk"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -412,6 +514,10 @@
               "help": "Path to the file to import"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -438,6 +544,10 @@
                   "help": "XXX"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 },
@@ -457,6 +567,10 @@
                   "help": "Name or ID of the disk"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -470,6 +584,10 @@
                 {
                   "long": "disk",
                   "help": "Name or ID of the disk"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -500,6 +618,10 @@
                   "long": "offset"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -514,6 +636,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -531,6 +657,12 @@
         },
         {
           "name": "metrics",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -567,6 +699,10 @@
                   "help": "Query result order"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 },
@@ -587,6 +723,10 @@
               "help": "Name or ID of the disk"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -596,13 +736,31 @@
     },
     {
       "name": "docs",
-      "about": "Generate CLI docs in JSON format"
+      "about": "Generate CLI docs in JSON format",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ]
     },
     {
       "name": "experimental",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "probe",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "create",
@@ -626,6 +784,10 @@
                   "long": "name"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 },
@@ -643,6 +805,10 @@
                   "help": "Name or ID of the probe"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -655,6 +821,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -679,6 +849,10 @@
                   "help": "Name or ID of the probe"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -688,6 +862,12 @@
         },
         {
           "name": "timeseries",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "dashboard",
@@ -697,6 +877,10 @@
                   "long": "interval",
                   "short": "i",
                   "help": "The interval on which to update the dashboard display, in seconds"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 }
               ]
             },
@@ -714,6 +898,10 @@
                   "help": "XXX"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "query",
                   "help": "A timeseries query string, written in the Oximeter query language."
                 }
@@ -721,6 +909,12 @@
             },
             {
               "name": "schema",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "list",
@@ -729,6 +923,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 }
@@ -740,6 +938,12 @@
     },
     {
       "name": "floating-ip",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "attach",
@@ -768,6 +972,10 @@
             {
               "long": "parent",
               "help": "Name or ID of the resource that this IP address should be attached to"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -802,6 +1010,10 @@
               "help": "The parent IP pool that a floating IP is pulled from. If unset, the default pool is selected."
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -814,6 +1026,10 @@
             {
               "long": "floating-ip",
               "help": "Name or ID of the floating IP"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -830,6 +1046,10 @@
               "help": "Name or ID of the floating IP"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -842,6 +1062,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -880,6 +1104,10 @@
               "long": "name"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -894,6 +1122,10 @@
               "help": "Name or ID of the floating IP"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -903,6 +1135,12 @@
     },
     {
       "name": "group",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "list",
@@ -911,6 +1149,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "sort-by",
@@ -924,6 +1166,12 @@
     },
     {
       "name": "image",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -949,6 +1197,10 @@
               "help": "The family of the operating system (e.g. Debian, Ubuntu, etc.)"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -968,6 +1220,10 @@
               "help": "Name or ID of the image"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -983,6 +1239,10 @@
               "help": "Name or ID of the image"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -996,6 +1256,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -1021,6 +1285,10 @@
               "help": "Name or ID of the image"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -1036,6 +1304,10 @@
               "help": "Name or ID of the image"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -1045,6 +1317,12 @@
     },
     {
       "name": "instance",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -1074,6 +1352,10 @@
               "long": "ncpus"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -1100,6 +1382,10 @@
               "help": "Name or ID of the instance"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -1107,6 +1393,12 @@
         },
         {
           "name": "disk",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "attach",
@@ -1127,6 +1419,10 @@
                 {
                   "long": "json-body-template",
                   "help": "XXX"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -1155,6 +1451,10 @@
                   "help": "XXX"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -1171,6 +1471,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -1190,6 +1494,12 @@
         },
         {
           "name": "external-ip",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "attach-ephemeral",
@@ -1212,6 +1522,10 @@
                   "help": "Name or ID of the IP pool used to allocate an address"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -1226,6 +1540,10 @@
                   "help": "Name or ID of the instance"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -1238,6 +1556,10 @@
                 {
                   "long": "instance",
                   "help": "Name or ID of the instance"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -1276,6 +1598,10 @@
               "help": "Instance CPU count"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Project for image and instance"
             },
@@ -1298,6 +1624,10 @@
               "help": "Maximum number of items returned by a single call"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -1313,6 +1643,12 @@
         },
         {
           "name": "nic",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "create",
@@ -1339,6 +1675,10 @@
                 },
                 {
                   "long": "name"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -1368,6 +1708,10 @@
                   "help": "Name or ID of the network interface"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
                 }
@@ -1384,6 +1728,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -1434,6 +1782,10 @@
                   "help": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error."
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
                 }
@@ -1452,6 +1804,10 @@
                   "help": "Name or ID of the network interface"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `instance` is provided as a `Name`"
                 }
@@ -1468,6 +1824,10 @@
               "help": "Name or ID of the instance"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -1476,6 +1836,12 @@
         {
           "name": "serial",
           "about": "Connect to or retrieve data from the instance's serial console.",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "console",
@@ -1500,6 +1866,10 @@
                   "long": "most-recent",
                   "short": "m",
                   "help": "The number of bytes from the most recent output to retrieve as context before connecting to the interactive session directly"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -1539,6 +1909,10 @@
                   "help": "Maximum number of bytes of buffered serial console contents to return. If the requested range (starting at --byte-offset) runs to the end of the available buffer, the data returned will be shorter (and if --json is provided, the actual final offset will be provided)"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "short": "p",
                   "help": "Name or ID of the project"
@@ -1549,6 +1923,12 @@
         },
         {
           "name": "ssh-key",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -1562,6 +1942,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "project",
@@ -1588,6 +1972,10 @@
               "help": "Name or ID of the instance"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -1600,6 +1988,10 @@
             {
               "long": "instance",
               "help": "Name or ID of the instance"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -1616,6 +2008,10 @@
               "help": "Name or ID of the instance"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -1625,6 +2021,12 @@
     },
     {
       "name": "ip-pool",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -1643,6 +2045,10 @@
             },
             {
               "long": "name"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -1653,6 +2059,10 @@
             {
               "long": "pool",
               "help": "Name or ID of the IP pool"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -1663,6 +2073,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "sort-by",
@@ -1676,6 +2090,12 @@
         },
         {
           "name": "range",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "add",
@@ -1699,6 +2119,10 @@
                 {
                   "long": "pool",
                   "help": "Name or ID of the IP pool"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 }
               ]
             },
@@ -1714,6 +2138,10 @@
                 {
                   "long": "pool",
                   "help": "Name or ID of the IP pool"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 }
               ]
             },
@@ -1738,6 +2166,10 @@
                 {
                   "long": "pool",
                   "help": "Name or ID of the IP pool"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 }
               ]
             }
@@ -1745,9 +2177,21 @@
         },
         {
           "name": "service",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "range",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "add",
@@ -1767,6 +2211,10 @@
                     },
                     {
                       "long": "last"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
@@ -1778,6 +2226,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 }
@@ -1800,17 +2252,33 @@
                 },
                 {
                   "long": "last"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 }
               ]
             },
             {
               "name": "view",
-              "about": "Fetch Oxide service IP pool"
+              "about": "Fetch Oxide service IP pool",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ]
             }
           ]
         },
         {
           "name": "silo",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "link",
@@ -1838,6 +2306,10 @@
                   "help": "Name or ID of the IP pool"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo"
                 }
               ]
@@ -1855,6 +2327,10 @@
                   "help": "Name or ID of the IP pool"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "sort-by",
                   "values": [
                     "id_ascending"
@@ -1869,6 +2345,10 @@
               "args": [
                 {
                   "long": "pool"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "silo"
@@ -1900,6 +2380,10 @@
                   "long": "pool"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo"
                 }
               ]
@@ -1927,6 +2411,10 @@
             {
               "long": "pool",
               "help": "Name or ID of the IP pool"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -1937,6 +2425,10 @@
             {
               "long": "pool",
               "help": "Name or ID of the IP pool"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -1947,6 +2439,10 @@
             {
               "long": "pool",
               "help": "Name or ID of the IP pool"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         }
@@ -1955,10 +2451,22 @@
     {
       "name": "ping",
       "about": "Ping API",
-      "long_about": "Always responds with Ok if it responds at all."
+      "long_about": "Always responds with Ok if it responds at all.",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ]
     },
     {
       "name": "policy",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "update",
@@ -1971,17 +2479,33 @@
             {
               "long": "json-body-template",
               "help": "XXX"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
         {
           "name": "view",
-          "about": "Fetch current silo's IAM policy"
+          "about": "Fetch current silo's IAM policy",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ]
         }
       ]
     },
     {
       "name": "project",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -2000,6 +2524,10 @@
             },
             {
               "long": "name"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -2008,6 +2536,10 @@
           "about": "Delete project",
           "args": [
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -2015,6 +2547,12 @@
         },
         {
           "name": "ip-pool",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -2023,6 +2561,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "sort-by",
@@ -2041,6 +2583,10 @@
                 {
                   "long": "pool",
                   "help": "Name or ID of the IP pool"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 }
               ]
             }
@@ -2055,6 +2601,10 @@
               "help": "Maximum number of items returned by a single call"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "sort-by",
               "values": [
                 "name_ascending",
@@ -2066,6 +2616,12 @@
         },
         {
           "name": "policy",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "update",
@@ -2080,6 +2636,10 @@
                   "help": "XXX"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project"
                 }
@@ -2089,6 +2649,10 @@
               "name": "view",
               "about": "Fetch project's IAM policy",
               "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
                 {
                   "long": "project",
                   "help": "Name or ID of the project"
@@ -2116,6 +2680,10 @@
               "long": "name"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -2126,6 +2694,10 @@
           "about": "Fetch project",
           "args": [
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -2135,6 +2707,12 @@
     },
     {
       "name": "silo",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -2171,6 +2749,10 @@
             },
             {
               "long": "name"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             }
           ]
         },
@@ -2180,6 +2762,10 @@
           "long_about": "Delete a silo by name or ID.",
           "args": [
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "silo",
               "help": "Name or ID of the silo"
             }
@@ -2187,6 +2773,12 @@
         },
         {
           "name": "idp",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -2195,6 +2787,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "silo",
@@ -2212,9 +2808,21 @@
             },
             {
               "name": "local",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "user",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ],
                   "subcommands": [
                     {
                       "name": "create",
@@ -2234,6 +2842,10 @@
                           "help": "XXX"
                         },
                         {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
+                        },
+                        {
                           "long": "silo",
                           "help": "Name or ID of the silo"
                         }
@@ -2243,6 +2855,10 @@
                       "name": "delete",
                       "about": "Delete user",
                       "args": [
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
+                        },
                         {
                           "long": "silo",
                           "help": "Name or ID of the silo"
@@ -2267,6 +2883,10 @@
                           "help": "XXX"
                         },
                         {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
+                        },
+                        {
                           "long": "silo",
                           "help": "Name or ID of the silo"
                         },
@@ -2282,6 +2902,12 @@
             },
             {
               "name": "saml",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "create",
@@ -2320,6 +2946,10 @@
                       "long": "name"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "silo",
                       "help": "Name or ID of the silo"
                     },
@@ -2342,6 +2972,10 @@
                   "about": "Fetch SAML IdP",
                   "args": [
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "provider",
                       "help": "Name or ID of the SAML identity provider"
                     },
@@ -2357,6 +2991,12 @@
         },
         {
           "name": "ip-pool",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -2366,6 +3006,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "silo",
@@ -2393,6 +3037,10 @@
               "help": "Maximum number of items returned by a single call"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "sort-by",
               "values": [
                 "name_ascending",
@@ -2404,6 +3052,12 @@
         },
         {
           "name": "policy",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "update",
@@ -2418,6 +3072,10 @@
                   "help": "XXX"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo",
                   "help": "Name or ID of the silo"
                 }
@@ -2428,6 +3086,10 @@
               "about": "Fetch silo IAM policy",
               "args": [
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo",
                   "help": "Name or ID of the silo"
                 }
@@ -2437,6 +3099,12 @@
         },
         {
           "name": "quotas",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -2445,6 +3113,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "sort-by",
@@ -2476,6 +3148,10 @@
                   "help": "The amount of RAM (in bytes) available for running instances in the Silo"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo",
                   "help": "Name or ID of the silo"
                 },
@@ -2490,6 +3166,10 @@
               "about": "Fetch resource quotas for silo",
               "args": [
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo",
                   "help": "Name or ID of the silo"
                 }
@@ -2499,6 +3179,12 @@
         },
         {
           "name": "user",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -2507,6 +3193,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "silo",
@@ -2525,6 +3215,10 @@
               "about": "Fetch built-in (system) user",
               "args": [
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo",
                   "help": "Name or ID of the silo"
                 },
@@ -2538,6 +3232,12 @@
         },
         {
           "name": "utilization",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -2546,6 +3246,10 @@
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 },
                 {
                   "long": "sort-by",
@@ -2562,6 +3266,10 @@
               "about": "Fetch current utilization for given silo",
               "args": [
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "silo",
                   "help": "Name or ID of the silo"
                 }
@@ -2575,6 +3283,10 @@
           "long_about": "Fetch silo by name or ID.",
           "args": [
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "silo",
               "help": "Name or ID of the silo"
             }
@@ -2584,6 +3296,12 @@
     },
     {
       "name": "snapshot",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -2609,6 +3327,10 @@
               "long": "name"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -2618,6 +3340,10 @@
           "name": "delete",
           "about": "Delete snapshot",
           "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
             {
               "long": "project",
               "help": "Name or ID of the project"
@@ -2635,6 +3361,10 @@
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
             },
             {
               "long": "project",
@@ -2655,6 +3385,10 @@
           "about": "Fetch snapshot",
           "args": [
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -2668,12 +3402,30 @@
     },
     {
       "name": "system",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "hardware",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "disk",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "list",
@@ -2682,6 +3434,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "sort-by",
@@ -2698,6 +3454,10 @@
                     {
                       "long": "disk-id",
                       "help": "ID of the physical disk"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 }
@@ -2705,6 +3465,12 @@
             },
             {
               "name": "rack",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "list",
@@ -2713,6 +3479,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "sort-by",
@@ -2727,6 +3497,10 @@
                   "about": "Fetch rack",
                   "args": [
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "rack-id",
                       "help": "The rack's unique ID."
                     }
@@ -2736,6 +3510,12 @@
             },
             {
               "name": "sled",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "add",
@@ -2753,6 +3533,10 @@
                       "long": "part"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "serial"
                     }
                   ]
@@ -2764,6 +3548,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "sled-id",
@@ -2786,6 +3574,10 @@
                       "help": "Maximum number of items returned by a single call"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "sled-id",
                       "help": "ID of the sled"
                     },
@@ -2806,6 +3598,10 @@
                       "help": "Maximum number of items returned by a single call"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "sort-by",
                       "values": [
                         "id_ascending"
@@ -2820,6 +3616,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
@@ -2834,6 +3634,10 @@
                     {
                       "long": "json-body-template",
                       "help": "XXX"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "sled-id",
@@ -2854,6 +3658,10 @@
                   "about": "Fetch sled",
                   "args": [
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "sled-id",
                       "help": "ID of the sled"
                     }
@@ -2863,6 +3671,12 @@
             },
             {
               "name": "switch",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "list",
@@ -2871,6 +3685,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "sort-by",
@@ -2885,6 +3703,10 @@
                   "about": "Fetch switch",
                   "args": [
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "switch-id",
                       "help": "ID of the switch"
                     }
@@ -2894,6 +3716,12 @@
             },
             {
               "name": "switch-port",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "apply-settings",
@@ -2916,6 +3744,10 @@
                       "help": "A name or id to use when applying switch port settings."
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "rack-id",
                       "help": "A rack id to use when selecting switch ports."
                     },
@@ -2932,6 +3764,10 @@
                     {
                       "long": "port",
                       "help": "A name to use when selecting switch ports."
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "rack-id",
@@ -2952,6 +3788,10 @@
                       "help": "Maximum number of items returned by a single call"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "sort-by",
                       "values": [
                         "id_ascending"
@@ -2965,7 +3805,13 @@
                 },
                 {
                   "name": "show-status",
-                  "about": "Get the status of switch ports."
+                  "about": "Get the status of switch ports.",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ]
                 },
                 {
                   "name": "status",
@@ -2974,6 +3820,10 @@
                     {
                       "long": "port",
                       "help": "A name to use when selecting switch ports."
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "rack-id",
@@ -2991,10 +3841,22 @@
         },
         {
           "name": "networking",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "addr",
               "about": "Manage switch port addresses.",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "add",
@@ -3045,6 +3907,10 @@
                         "qsfp31"
                       ],
                       "help": "Port to add the port to"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "rack",
@@ -3111,6 +3977,10 @@
                       "help": "Port to remove the address from"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "rack",
                       "help": "Id of the rack to remove the address from"
                     },
@@ -3128,9 +3998,21 @@
             },
             {
               "name": "address-lot",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "block",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ],
                   "subcommands": [
                     {
                       "name": "list",
@@ -3143,6 +4025,10 @@
                         {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
+                        },
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
                         },
                         {
                           "long": "sort-by",
@@ -3179,6 +4065,10 @@
                     },
                     {
                       "long": "name"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
@@ -3189,6 +4079,10 @@
                     {
                       "long": "address-lot",
                       "help": "Name or ID of the address lot"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
@@ -3199,6 +4093,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "sort-by",
@@ -3214,6 +4112,12 @@
             },
             {
               "name": "allow-list",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "update",
@@ -3232,17 +4136,33 @@
                     {
                       "long": "json-body-template",
                       "help": "XXX"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
                 {
                   "name": "view",
-                  "about": "Get user-facing services IP allowlist"
+                  "about": "Get user-facing services IP allowlist",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ]
                 }
               ]
             },
             {
               "name": "bfd",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "disable",
@@ -3255,6 +4175,10 @@
                     {
                       "long": "json-body-template",
                       "help": "XXX"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "remote",
@@ -3295,6 +4219,10 @@
                       "help": "Select either single-hop (RFC 5881) or multi-hop (RFC 5883)"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "remote",
                       "help": "Address of the remote peer to establish a BFD session with."
                     },
@@ -3310,12 +4238,24 @@
                 },
                 {
                   "name": "status",
-                  "about": "Get BFD status"
+                  "about": "Get BFD status",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ]
                 }
               ]
             },
             {
               "name": "bgp",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "announce",
@@ -3336,11 +4276,21 @@
                     {
                       "long": "prefix",
                       "help": "The prefix to announce"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
                 {
                   "name": "announce-set",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ],
                   "subcommands": [
                     {
                       "name": "delete",
@@ -3349,6 +4299,10 @@
                         {
                           "long": "name-or-id",
                           "help": "A name or id to use when selecting BGP port settings"
+                        },
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
                         }
                       ]
                     },
@@ -3359,6 +4313,10 @@
                         {
                           "long": "name-or-id",
                           "help": "A name or id to use when selecting BGP port settings"
+                        },
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
                         }
                       ]
                     },
@@ -3380,6 +4338,10 @@
                         },
                         {
                           "long": "name"
+                        },
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
                         }
                       ]
                     }
@@ -3387,6 +4349,12 @@
                 },
                 {
                   "name": "config",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ],
                   "subcommands": [
                     {
                       "name": "create",
@@ -3414,6 +4382,10 @@
                           "long": "name"
                         },
                         {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
+                        },
+                        {
                           "long": "vrf",
                           "help": "Optional virtual routing and forwarding identifier for this BGP configuration."
                         }
@@ -3426,6 +4398,10 @@
                         {
                           "long": "name-or-id",
                           "help": "A name or id to use when selecting BGP config."
+                        },
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
                         }
                       ]
                     },
@@ -3440,6 +4416,10 @@
                         {
                           "long": "name-or-id",
                           "help": "A name or id to use when selecting BGP config."
+                        },
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
                         },
                         {
                           "long": "sort-by",
@@ -3517,6 +4497,10 @@
                       "help": "Port to add the port to"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "rack",
                       "help": "Id of the rack to add the address to"
                     },
@@ -3537,11 +4521,21 @@
                     {
                       "long": "asn",
                       "help": "The ASN to filter on. Required."
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
                 {
                   "name": "imported",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ],
                   "subcommands": [
                     {
                       "name": "ipv4",
@@ -3550,6 +4544,10 @@
                         {
                           "long": "asn",
                           "help": "The ASN to filter on. Required."
+                        },
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
                         }
                       ]
                     }
@@ -3559,6 +4557,12 @@
                   "name": "peer",
                   "about": "Manage BGP peers.",
                   "long_about": "Manage BGP peers.\n\nThis command provides add and delete subcommands for managing BGP peers.\nBGP peer configuration is a part of a switch port settings configuration.\nThe peer add and remove subcommands perform read-modify-write operations\non switch port settings objects to manage BGP peer configurations.",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ],
                   "subcommands": [
                     {
                       "name": "add",
@@ -3663,6 +4667,10 @@
                           "help": "Port to add the peer to"
                         },
                         {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
+                        },
+                        {
                           "long": "rack",
                           "help": "Id of the rack to add the peer to"
                         },
@@ -3731,6 +4739,10 @@
                           "help": "Port to remove the peer from"
                         },
                         {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands"
+                        },
+                        {
                           "long": "rack",
                           "help": "Id of the rack to remove the peer from"
                         },
@@ -3749,11 +4761,23 @@
                 {
                   "name": "show-status",
                   "about": "Get the status of BGP on the rack.",
-                  "long_about": "Get the status of BGP on the rack.\n\nThis will show the peering status for all peers on all switches."
+                  "long_about": "Get the status of BGP on the rack.\n\nThis will show the peering status for all peers on all switches.",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ]
                 },
                 {
                   "name": "status",
-                  "about": "Get BGP peer status"
+                  "about": "Get BGP peer status",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ]
                 },
                 {
                   "name": "withdraw",
@@ -3767,6 +4791,10 @@
                     {
                       "long": "prefix",
                       "help": "The prefix to withdraw"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 }
@@ -3776,6 +4804,12 @@
               "name": "link",
               "about": "Manage switch port links.",
               "long_about": "Manage switch port links.\n\nLinks carry layer-2 Ethernet properties for a lane or set of lanes on a\nswitch port. Lane geometry is defined in physical port settings. At the\npresent time only single lane configurations are supported, and thus only\na single link per physical port is supported.",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "add",
@@ -3830,6 +4864,10 @@
                         "qsfp31"
                       ],
                       "help": "Port to add the link to"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "rack",
@@ -3892,6 +4930,10 @@
                       "help": "Port to remove the link from"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "rack",
                       "help": "Id of the rack to remove the link from"
                     },
@@ -3909,6 +4951,12 @@
             },
             {
               "name": "loopback-address",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "create",
@@ -3943,6 +4991,10 @@
                       "help": "The subnet mask to use for the address."
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "rack-id",
                       "help": "The containing the switch this loopback address will be configured on."
                     },
@@ -3959,6 +5011,10 @@
                     {
                       "long": "address",
                       "help": "The IP address and subnet mask to use when selecting the loopback address."
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "rack-id",
@@ -3983,6 +5039,10 @@
                       "help": "Maximum number of items returned by a single call"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "sort-by",
                       "values": [
                         "id_ascending"
@@ -3994,6 +5054,12 @@
             },
             {
               "name": "switch-port-settings",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "create",
@@ -4012,6 +5078,10 @@
                     },
                     {
                       "long": "name"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
@@ -4022,6 +5092,10 @@
                     {
                       "long": "port-settings",
                       "help": "An optional name or id to use when selecting port settings."
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 },
@@ -4038,6 +5112,10 @@
                       "help": "An optional name or id to use when selecting port settings."
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "sort-by",
                       "values": [
                         "name_ascending",
@@ -4049,7 +5127,13 @@
                 },
                 {
                   "name": "show",
-                  "about": "Get the configuration of switch ports."
+                  "about": "Get the configuration of switch ports.",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ]
                 },
                 {
                   "name": "view",
@@ -4058,6 +5142,10 @@
                     {
                       "long": "port",
                       "help": "A name or id to use when selecting switch port settings info objects."
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     }
                   ]
                 }
@@ -4067,6 +5155,12 @@
         },
         {
           "name": "policy",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "update",
@@ -4079,12 +5173,22 @@
                 {
                   "long": "json-body-template",
                   "help": "XXX"
+                },
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
                 }
               ]
             },
             {
               "name": "view",
-              "about": "Fetch top-level IAM policy"
+              "about": "Fetch top-level IAM policy",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ]
             }
           ]
         }
@@ -4092,6 +5196,12 @@
     },
     {
       "name": "user",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "list",
@@ -4105,6 +5215,10 @@
               "help": "Maximum number of items returned by a single call"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "sort-by",
               "values": [
                 "id_ascending"
@@ -4116,14 +5230,32 @@
     },
     {
       "name": "utilization",
-      "about": "Fetch resource utilization for user's current silo"
+      "about": "Fetch resource utilization for user's current silo",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ]
     },
     {
       "name": "version",
-      "about": "Prints version information about the CLI."
+      "about": "Prints version information about the CLI.",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ]
     },
     {
       "name": "vpc",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands"
+        }
+      ],
       "subcommands": [
         {
           "name": "create",
@@ -4151,6 +5283,10 @@
               "long": "name"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             }
@@ -4160,6 +5296,10 @@
           "name": "delete",
           "about": "Delete VPC",
           "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
             {
               "long": "project",
               "help": "Name or ID of the project"
@@ -4172,6 +5312,12 @@
         },
         {
           "name": "firewall-rules",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "update",
@@ -4187,6 +5333,10 @@
                   "help": "XXX"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4200,6 +5350,10 @@
               "name": "view",
               "about": "List firewall rules",
               "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
                 {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
@@ -4221,6 +5375,10 @@
               "help": "Maximum number of items returned by a single call"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -4236,6 +5394,12 @@
         },
         {
           "name": "router",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "create",
@@ -4256,6 +5420,10 @@
                   "long": "name"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4269,6 +5437,10 @@
               "name": "delete",
               "about": "Delete router",
               "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
                 {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
@@ -4292,6 +5464,10 @@
                   "help": "Maximum number of items returned by a single call"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4311,6 +5487,12 @@
             },
             {
               "name": "route",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "create",
@@ -4331,6 +5513,10 @@
                       "long": "name"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "project",
                       "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                     },
@@ -4348,6 +5534,10 @@
                   "name": "delete",
                   "about": "Delete route",
                   "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
                     {
                       "long": "project",
                       "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
@@ -4374,6 +5564,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "project",
@@ -4416,6 +5610,10 @@
                       "long": "name"
                     },
                     {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
+                    {
                       "long": "project",
                       "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                     },
@@ -4437,6 +5635,10 @@
                   "name": "view",
                   "about": "Fetch route",
                   "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    },
                     {
                       "long": "project",
                       "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
@@ -4476,6 +5678,10 @@
                   "long": "name"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4494,6 +5700,10 @@
               "about": "Fetch router",
               "args": [
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4511,6 +5721,12 @@
         },
         {
           "name": "subnet",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            }
+          ],
           "subcommands": [
             {
               "name": "create",
@@ -4543,6 +5759,10 @@
                   "long": "name"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4556,6 +5776,10 @@
               "name": "delete",
               "about": "Delete subnet",
               "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
                 {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
@@ -4579,6 +5803,10 @@
                   "help": "Maximum number of items returned by a single call"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4598,6 +5826,12 @@
             },
             {
               "name": "nic",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "list",
@@ -4606,6 +5840,10 @@
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
                     },
                     {
                       "long": "project",
@@ -4654,6 +5892,10 @@
                   "long": "name"
                 },
                 {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
+                {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
                 },
@@ -4671,6 +5913,10 @@
               "name": "view",
               "about": "Fetch subnet",
               "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands"
+                },
                 {
                   "long": "project",
                   "help": "Name or ID of the project, only required if `vpc` is provided as a `Name`"
@@ -4709,6 +5955,10 @@
               "long": "name"
             },
             {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
+            {
               "long": "project",
               "help": "Name or ID of the project"
             },
@@ -4722,6 +5972,10 @@
           "name": "view",
           "about": "Fetch VPC",
           "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands"
+            },
             {
               "long": "project",
               "help": "Name or ID of the project"

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -27,7 +27,7 @@ struct OxideCli {
     pub debug: bool,
 
     /// Configuration profile to use for commands
-    #[clap(long)]
+    #[clap(long, global = true)]
     pub profile: Option<String>,
 
     /// Directory to use for configuration


### PR DESCRIPTION
The `profile` argument is associated with the top-level `oxide` command, meaning it must be applied before a subcommand is registered. It would be convenient to be able to specify this arg at any point in the command, such as when repeating the same command against different profiles.

Set `global` to `true` for `profile` to allow this behavior.