### PR TITLE
Update doc comment for insecure auth to Oxide silo.

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -95,7 +95,7 @@
         {
           "name": "login",
           "about": "Authenticate with an Oxide Silo",
-          "long_about": "Authenticate with an Oxide Silo\n\n    # authenticate with a specific Oxide silo\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide silo (not recommended)\n    $ oxide auth login --host http://oxide.internal",
+          "long_about": "Authenticate with an Oxide Silo\n\n    # authenticate with a specific Oxide silo\n    $ oxide auth login --host oxide.internal\n\n    # authenticate with an insecure Oxide silo (not recommended)\n    $ oxide --insecure auth login --host oxide.internal",
           "args": [
             {
               "long": "browser",

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -128,7 +128,7 @@ fn yes(prompt: impl Into<String>) -> Result<bool> {
 ///     $ oxide auth login --host oxide.internal
 ///
 ///     # authenticate with an insecure Oxide silo (not recommended)
-///     $ oxide auth login --host http://oxide.internal
+///     $ oxide --insecure auth login --host oxide.internal
 #[derive(Parser, Debug, Clone)]
 #[command(verbatim_doc_comment)]
 pub struct CmdAuthLogin {


### PR DESCRIPTION
It seems more likely (and preferred) that users not have a non-HTTPS endpoint for the rack available, so the recommendation here should be to used the `insecure` flag instead.