### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76"
+channel = "nightly"
 profile = "default"


### PR DESCRIPTION
I found I needed to change to nightly to get oxide.rs to compile