### PR TITLE
Adapt to LLDP-related changes in link APIs

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -4434,6 +4434,16 @@
                   ]
                 },
                 {
+                  "name": "exported",
+                  "about": "Get BGP exported routes",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands"
+                    }
+                  ]
+                },
+                {
                   "name": "filter",
                   "about": "Add a filtering requirement to a BGP session.",
                   "long_about": "Add a filtering requirement to a BGP session.\n\nThe Oxide BGP implementation can filter prefixes received from peers\non import and filter prefixes sent to peers on export. This command\nprovides a way to specify import/export filtering. Filtering is a\nproperty of the BGP peering settings found in port settings configuration.\nThis command works by performing a read-modify-write on the port settings\nconfiguration identified by the specified rack/switch/port.",

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -480,6 +480,7 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         }
         CliCommand::NetworkingBgpAnnounceSetList => Some("system networking bgp announce-set list"),
         CliCommand::NetworkingBgpImportedRoutesIpv4 => Some("system networking bgp imported ipv4"),
+        CliCommand::NetworkingBgpExported => Some("system networking bgp exported"),
 
         // Subcommand: disk
         CliCommand::DiskList => Some("disk list"),

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -16,7 +16,7 @@ use oxide::{
     types::{
         Address, AddressConfig, BgpAnnounceSetCreate, BgpAnnouncementCreate, BgpPeer,
         BgpPeerConfig, BgpPeerStatus, ImportExportPolicy, IpNet, LinkConfigCreate, LinkFec,
-        LinkSpeed, LldpServiceConfigCreate, Name, NameOrId, Route, RouteConfig,
+        LinkSpeed, LldpLinkConfigCreate, Name, NameOrId, Route, RouteConfig,
         SwitchInterfaceConfigCreate, SwitchInterfaceKind, SwitchInterfaceKind2, SwitchLocation,
         SwitchPort, SwitchPortConfigCreate, SwitchPortGeometry, SwitchPortGeometry2,
         SwitchPortSettingsCreate,
@@ -116,10 +116,14 @@ impl AuthenticatedCmd for CmdLinkAdd {
             fec: self.fec,
             mtu: self.mtu,
             speed: self.speed,
-            //TODO not fully plumbed on the back end yet.
-            lldp: LldpServiceConfigCreate {
+            lldp: LldpLinkConfigCreate {
                 enabled: false,
-                lldp_config: None,
+                link_name: None,
+                link_description: None,
+                chassis_id: None,
+                system_name: None,
+                system_description: None,
+                management_ip: None,
             },
         };
         match settings.links.get(PHY0) {
@@ -1351,13 +1355,17 @@ async fn create_current(settings_id: Uuid, client: &Client) -> Result<SwitchPort
                 LinkConfigCreate {
                     autoneg: x.autoneg,
                     fec: x.fec,
-                    lldp: LldpServiceConfigCreate {
-                        //TODO
-                        enabled: false,
-                        lldp_config: None,
-                    },
                     mtu: x.mtu,
                     speed: x.speed,
+                    lldp: LldpLinkConfigCreate {
+                        enabled: false,
+                        link_name: None,
+                        link_description: None,
+                        chassis_id: None,
+                        system_name: None,
+                        system_description: None,
+                        management_ip: None,
+                    },
                 },
             )
         })
@@ -1379,6 +1387,7 @@ async fn create_current(settings_id: Uuid, client: &Client) -> Result<SwitchPort
                 dst: x.dst.clone(),
                 gw: x.gw.to_string().parse().unwrap(),
                 vid: x.vlan_id,
+                local_pref: None,
             })
             .collect(),
     };

--- a/cli/src/generated_cli.rs
+++ b/cli/src/generated_cli.rs
@@ -169,6 +169,7 @@ impl<T: CliConfig> Cli<T> {
             CliCommand::NetworkingBgpAnnounceSetDelete => {
                 Self::cli_networking_bgp_announce_set_delete()
             }
+            CliCommand::NetworkingBgpExported => Self::cli_networking_bgp_exported(),
             CliCommand::NetworkingBgpMessageHistory => Self::cli_networking_bgp_message_history(),
             CliCommand::NetworkingBgpImportedRoutesIpv4 => {
                 Self::cli_networking_bgp_imported_routes_ipv4()
@@ -4219,6 +4220,10 @@ impl<T: CliConfig> Cli<T> {
             .about("Delete BGP announce set")
     }
 
+    pub fn cli_networking_bgp_exported() -> clap::Command {
+        clap::Command::new("").about("Get BGP exported routes")
+    }
+
     pub fn cli_networking_bgp_message_history() -> clap::Command {
         clap::Command::new("")
             .arg(
@@ -6190,6 +6195,9 @@ impl<T: CliConfig> Cli<T> {
             CliCommand::NetworkingBgpAnnounceSetDelete => {
                 self.execute_networking_bgp_announce_set_delete(matches)
                     .await
+            }
+            CliCommand::NetworkingBgpExported => {
+                self.execute_networking_bgp_exported(matches).await
             }
             CliCommand::NetworkingBgpMessageHistory => {
                 self.execute_networking_bgp_message_history(matches).await
@@ -10822,6 +10830,26 @@ impl<T: CliConfig> Cli<T> {
         }
     }
 
+    pub async fn execute_networking_bgp_exported(
+        &self,
+        matches: &clap::ArgMatches,
+    ) -> anyhow::Result<()> {
+        let mut request = self.client.networking_bgp_exported();
+        self.config
+            .execute_networking_bgp_exported(matches, &mut request)?;
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                self.config.success_item(&r);
+                Ok(())
+            }
+            Err(r) => {
+                self.config.error(&r);
+                Err(anyhow::Error::new(r))
+            }
+        }
+    }
+
     pub async fn execute_networking_bgp_message_history(
         &self,
         matches: &clap::ArgMatches,
@@ -13902,6 +13930,14 @@ pub trait CliConfig {
         Ok(())
     }
 
+    fn execute_networking_bgp_exported(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::NetworkingBgpExported,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn execute_networking_bgp_message_history(
         &self,
         matches: &clap::ArgMatches,
@@ -14499,6 +14535,7 @@ pub enum CliCommand {
     NetworkingBgpAnnounceSetList,
     NetworkingBgpAnnounceSetUpdate,
     NetworkingBgpAnnounceSetDelete,
+    NetworkingBgpExported,
     NetworkingBgpMessageHistory,
     NetworkingBgpImportedRoutesIpv4,
     NetworkingBgpStatus,
@@ -14699,6 +14736,7 @@ impl CliCommand {
             CliCommand::NetworkingBgpAnnounceSetList,
             CliCommand::NetworkingBgpAnnounceSetUpdate,
             CliCommand::NetworkingBgpAnnounceSetDelete,
+            CliCommand::NetworkingBgpExported,
             CliCommand::NetworkingBgpMessageHistory,
             CliCommand::NetworkingBgpImportedRoutesIpv4,
             CliCommand::NetworkingBgpStatus,

--- a/cli/tests/test_net.rs
+++ b/cli/tests/test_net.rs
@@ -9,9 +9,10 @@ use chrono::prelude::*;
 use httpmock::MockServer;
 use oxide::types::{
     AddressLot, AddressLotBlock, AddressLotBlockResultsPage, AddressLotKind, AddressLotResultsPage,
-    BgpConfig, BgpConfigResultsPage, BgpPeer, ImportExportPolicy, LinkFec, LinkSpeed, NameOrId,
-    SwitchPort, SwitchPortAddressConfig, SwitchPortConfig, SwitchPortGeometry2,
-    SwitchPortLinkConfig, SwitchPortResultsPage, SwitchPortSettings, SwitchPortSettingsView,
+    BgpConfig, BgpConfigResultsPage, BgpPeer, ImportExportPolicy, LinkFec, LinkSpeed,
+    LldpLinkConfig, NameOrId, SwitchPort, SwitchPortAddressConfig, SwitchPortConfig,
+    SwitchPortGeometry2, SwitchPortLinkConfig, SwitchPortResultsPage, SwitchPortSettings,
+    SwitchPortSettingsView,
 };
 use oxide_httpmock::MockServerExt;
 use uuid::Uuid;
@@ -161,15 +162,24 @@ fn test_port_config() {
         ],
         groups: Vec::new(),
         interfaces: Vec::new(),
-        link_lldp: Vec::new(),
         links: vec![SwitchPortLinkConfig {
             autoneg: false,
             fec: LinkFec::None,
             link_name: String::from("phy0"),
-            lldp_service_config_id: Uuid::new_v4(),
+            lldp_link_config_id: Uuid::new_v4(),
             mtu: 1500,
             port_settings_id: switch1_qsfp0_settings_id,
             speed: LinkSpeed::Speed100G,
+        }],
+        link_lldp: vec![LldpLinkConfig {
+            id: Uuid::new_v4(),
+            enabled: false,
+            link_name: None,
+            link_description: None,
+            chassis_id: None,
+            system_name: None,
+            system_description: None,
+            management_ip: None,
         }],
         port: SwitchPortConfig {
             geometry: SwitchPortGeometry2::Qsfp28x1,
@@ -246,15 +256,24 @@ fn test_port_config() {
         ],
         groups: Vec::new(),
         interfaces: Vec::new(),
-        link_lldp: Vec::new(),
         links: vec![SwitchPortLinkConfig {
             autoneg: false,
             fec: LinkFec::None,
             link_name: String::from("phy0"),
-            lldp_service_config_id: Uuid::new_v4(),
+            lldp_link_config_id: Uuid::new_v4(),
             mtu: 1500,
             port_settings_id: switch1_qsfp0_settings_id,
             speed: LinkSpeed::Speed100G,
+        }],
+        link_lldp: vec![LldpLinkConfig {
+            id: Uuid::new_v4(),
+            enabled: false,
+            link_name: None,
+            link_description: None,
+            chassis_id: None,
+            system_name: None,
+            system_description: None,
+            management_ip: None,
         }],
         port: SwitchPortConfig {
             geometry: SwitchPortGeometry2::Qsfp28x1,

--- a/oxide.json
+++ b/oxide.json
@@ -6640,6 +6640,33 @@
         }
       }
     },
+    "/v1/system/networking/bgp-exported": {
+      "get": {
+        "tags": [
+          "system/networking"
+        ],
+        "summary": "Get BGP exported routes",
+        "operationId": "networking_bgp_exported",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BgpExported"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/system/networking/bgp-message-history": {
       "get": {
         "tags": [
@@ -10349,6 +10376,25 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "BgpExported": {
+        "description": "The current status of a BGP peer.",
+        "type": "object",
+        "properties": {
+          "exports": {
+            "description": "Exported routes indexed by peer address.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            }
+          }
+        },
+        "required": [
+          "exports"
         ]
       },
       "BgpImportedRouteIpv4": {
@@ -15980,7 +16026,7 @@
             "description": "The link-layer discovery protocol (LLDP) configuration for the link.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/LldpServiceConfigCreate"
+                "$ref": "#/components/schemas/LldpLinkConfigCreate"
               }
             ]
           },
@@ -16101,10 +16147,15 @@
           }
         ]
       },
-      "LldpServiceConfig": {
+      "LldpLinkConfig": {
         "description": "A link layer discovery protocol (LLDP) service configuration.",
         "type": "object",
         "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "The LLDP chassis identifier TLV.",
+            "type": "string"
+          },
           "enabled": {
             "description": "Whether or not the LLDP service is enabled.",
             "type": "boolean"
@@ -16114,11 +16165,34 @@
             "type": "string",
             "format": "uuid"
           },
-          "lldp_config_id": {
+          "link_description": {
             "nullable": true,
-            "description": "The link-layer discovery protocol configuration for this service.",
-            "type": "string",
-            "format": "uuid"
+            "description": "The LLDP link description TLV.",
+            "type": "string"
+          },
+          "link_name": {
+            "nullable": true,
+            "description": "The LLDP link name TLV.",
+            "type": "string"
+          },
+          "management_ip": {
+            "nullable": true,
+            "description": "The LLDP management IP TLV.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "The LLDP system description TLV.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "The LLDP system name TLV.",
+            "type": "string"
           }
         },
         "required": [
@@ -16126,22 +16200,44 @@
           "id"
         ]
       },
-      "LldpServiceConfigCreate": {
-        "description": "The LLDP configuration associated with a port. LLDP may be either enabled or disabled, if enabled, an LLDP configuration must be provided by name or id.",
+      "LldpLinkConfigCreate": {
+        "description": "The LLDP configuration associated with a port.",
         "type": "object",
         "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "The LLDP chassis identifier TLV.",
+            "type": "string"
+          },
           "enabled": {
             "description": "Whether or not LLDP is enabled.",
             "type": "boolean"
           },
-          "lldp_config": {
+          "link_description": {
             "nullable": true,
-            "description": "A reference to the LLDP configuration used. Must not be `None` when `enabled` is `true`.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/NameOrId"
-              }
-            ]
+            "description": "The LLDP link description TLV.",
+            "type": "string"
+          },
+          "link_name": {
+            "nullable": true,
+            "description": "The LLDP link name TLV.",
+            "type": "string"
+          },
+          "management_ip": {
+            "nullable": true,
+            "description": "The LLDP management IP TLV.",
+            "type": "string",
+            "format": "ip"
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "The LLDP system description TLV.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "The LLDP system name TLV.",
+            "type": "string"
           }
         },
         "required": [
@@ -17179,6 +17275,13 @@
             "description": "The route gateway.",
             "type": "string",
             "format": "ip"
+          },
+          "local_pref": {
+            "nullable": true,
+            "description": "Local preference for route. Higher preference indictes precedence within and across protocols.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
           },
           "vid": {
             "nullable": true,
@@ -19158,7 +19261,7 @@
             "description": "The name of this link.",
             "type": "string"
           },
-          "lldp_service_config_id": {
+          "lldp_link_config_id": {
             "description": "The link-layer discovery protocol service configuration id for this link.",
             "type": "string",
             "format": "uuid"
@@ -19187,7 +19290,7 @@
           "autoneg",
           "fec",
           "link_name",
-          "lldp_service_config_id",
+          "lldp_link_config_id",
           "mtu",
           "port_settings_id",
           "speed"
@@ -19237,6 +19340,13 @@
           "interface_name": {
             "description": "The interface name this route configuration is assigned to.",
             "type": "string"
+          },
+          "local_pref": {
+            "nullable": true,
+            "description": "Local preference indicating priority within and across protocols.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
           },
           "port_settings_id": {
             "description": "The port settings object this route configuration belongs to.",
@@ -19442,7 +19552,7 @@
             "description": "Link-layer discovery protocol (LLDP) settings.",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LldpServiceConfig"
+              "$ref": "#/components/schemas/LldpLinkConfig"
             }
           },
           "links": {

--- a/sdk-httpmock/src/generated_httpmock.rs
+++ b/sdk-httpmock/src/generated_httpmock.rs
@@ -10779,6 +10779,61 @@ pub mod operations {
         }
     }
 
+    pub struct NetworkingBgpExportedWhen(httpmock::When);
+    impl NetworkingBgpExportedWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner.method(httpmock::Method::GET).path_matches(
+                    regex::Regex::new("^/v1/system/networking/bgp-exported$").unwrap(),
+                ),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+    }
+
+    pub struct NetworkingBgpExportedThen(httpmock::Then);
+    impl NetworkingBgpExportedThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn ok(self, value: &types::BgpExported) -> Self {
+            Self(
+                self.0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
     pub struct NetworkingBgpMessageHistoryWhen(httpmock::When);
     impl NetworkingBgpMessageHistoryWhen {
         pub fn new(inner: httpmock::When) -> Self {
@@ -16091,6 +16146,9 @@ pub trait MockServerExt {
             operations::NetworkingBgpAnnounceSetDeleteWhen,
             operations::NetworkingBgpAnnounceSetDeleteThen,
         );
+    fn networking_bgp_exported<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBgpExportedWhen, operations::NetworkingBgpExportedThen);
     fn networking_bgp_message_history<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(
@@ -18031,6 +18089,18 @@ impl MockServerExt for httpmock::MockServer {
             config_fn(
                 operations::NetworkingBgpAnnounceSetDeleteWhen::new(when),
                 operations::NetworkingBgpAnnounceSetDeleteThen::new(then),
+            )
+        })
+    }
+
+    fn networking_bgp_exported<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::NetworkingBgpExportedWhen, operations::NetworkingBgpExportedThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::NetworkingBgpExportedWhen::new(when),
+                operations::NetworkingBgpExportedThen::new(then),
             )
         })
     }

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -2006,6 +2006,52 @@ pub mod types {
         }
     }
 
+    /// The current status of a BGP peer.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "The current status of a BGP peer.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "exports"
+    ///  ],
+    ///  "properties": {
+    ///    "exports": {
+    ///      "description": "Exported routes indexed by peer address.",
+    ///      "type": "object",
+    ///      "additionalProperties": {
+    ///        "type": "array",
+    ///        "items": {
+    ///          "$ref": "#/components/schemas/Ipv4Net"
+    ///        }
+    ///      }
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct BgpExported {
+        /// Exported routes indexed by peer address.
+        pub exports: ::std::collections::HashMap<String, Vec<Ipv4Net>>,
+    }
+
+    impl From<&BgpExported> for BgpExported {
+        fn from(value: &BgpExported) -> Self {
+            value.clone()
+        }
+    }
+
+    impl BgpExported {
+        pub fn builder() -> builder::BgpExported {
+            Default::default()
+        }
+    }
+
     /// A route imported from a BGP peer.
     ///
     /// <details><summary>JSON schema</summary>
@@ -13900,7 +13946,7 @@ pub mod types {
     /// configuration for the link.",
     ///      "allOf": [
     ///        {
-    ///          "$ref": "#/components/schemas/LldpServiceConfigCreate"
+    ///          "$ref": "#/components/schemas/LldpLinkConfigCreate"
     ///        }
     ///      ]
     ///    },
@@ -13931,7 +13977,7 @@ pub mod types {
         /// The forward error correction mode of the link.
         pub fec: LinkFec,
         /// The link-layer discovery protocol (LLDP) configuration for the link.
-        pub lldp: LldpServiceConfigCreate,
+        pub lldp: LldpLinkConfigCreate,
         /// Maximum transmission unit for the link.
         pub mtu: u16,
         /// The speed of the link.
@@ -14250,6 +14296,13 @@ pub mod types {
     ///    "id"
     ///  ],
     ///  "properties": {
+    ///    "chassis_id": {
+    ///      "description": "The LLDP chassis identifier TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
     ///    "enabled": {
     ///      "description": "Whether or not the LLDP service is enabled.",
     ///      "type": "boolean"
@@ -14259,71 +14312,40 @@ pub mod types {
     ///      "type": "string",
     ///      "format": "uuid"
     ///    },
-    ///    "lldp_config_id": {
-    ///      "description": "The link-layer discovery protocol configuration for
-    /// this service.",
+    ///    "link_description": {
+    ///      "description": "The LLDP link description TLV.",
     ///      "type": [
     ///        "string",
     ///        "null"
-    ///      ],
-    ///      "format": "uuid"
-    ///    }
-    ///  }
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
-    )]
-    pub struct LldpServiceConfig {
-        /// Whether or not the LLDP service is enabled.
-        pub enabled: bool,
-        /// The id of this LLDP service instance.
-        pub id: uuid::Uuid,
-        /// The link-layer discovery protocol configuration for this service.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub lldp_config_id: Option<uuid::Uuid>,
-    }
-
-    impl From<&LldpServiceConfig> for LldpServiceConfig {
-        fn from(value: &LldpServiceConfig) -> Self {
-            value.clone()
-        }
-    }
-
-    impl LldpServiceConfig {
-        pub fn builder() -> builder::LldpServiceConfig {
-            Default::default()
-        }
-    }
-
-    /// The LLDP configuration associated with a port. LLDP may be either
-    /// enabled or disabled, if enabled, an LLDP configuration must be provided
-    /// by name or id.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "The LLDP configuration associated with a port. LLDP may
-    /// be either enabled or disabled, if enabled, an LLDP configuration must be
-    /// provided by name or id.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "enabled"
-    ///  ],
-    ///  "properties": {
-    ///    "enabled": {
-    ///      "description": "Whether or not LLDP is enabled.",
-    ///      "type": "boolean"
+    ///      ]
     ///    },
-    ///    "lldp_config": {
-    ///      "description": "A reference to the LLDP configuration used. Must
-    /// not be `None` when `enabled` is `true`.",
+    ///    "link_name": {
+    ///      "description": "The LLDP link name TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "management_ip": {
+    ///      "description": "The LLDP management IP TLV.",
     ///      "allOf": [
     ///        {
-    ///          "$ref": "#/components/schemas/NameOrId"
+    ///          "$ref": "#/components/schemas/IpNet"
     ///        }
+    ///      ]
+    ///    },
+    ///    "system_description": {
+    ///      "description": "The LLDP system description TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "system_name": {
+    ///      "description": "The LLDP system name TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    }
     ///  }
@@ -14333,23 +14355,140 @@ pub mod types {
     #[derive(
         :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
     )]
-    pub struct LldpServiceConfigCreate {
-        /// Whether or not LLDP is enabled.
-        pub enabled: bool,
-        /// A reference to the LLDP configuration used. Must not be `None` when
-        /// `enabled` is `true`.
+    pub struct LldpLinkConfig {
+        /// The LLDP chassis identifier TLV.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub lldp_config: Option<NameOrId>,
+        pub chassis_id: Option<String>,
+        /// Whether or not the LLDP service is enabled.
+        pub enabled: bool,
+        /// The id of this LLDP service instance.
+        pub id: uuid::Uuid,
+        /// The LLDP link description TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub link_description: Option<String>,
+        /// The LLDP link name TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub link_name: Option<String>,
+        /// The LLDP management IP TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub management_ip: Option<IpNet>,
+        /// The LLDP system description TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub system_description: Option<String>,
+        /// The LLDP system name TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub system_name: Option<String>,
     }
 
-    impl From<&LldpServiceConfigCreate> for LldpServiceConfigCreate {
-        fn from(value: &LldpServiceConfigCreate) -> Self {
+    impl From<&LldpLinkConfig> for LldpLinkConfig {
+        fn from(value: &LldpLinkConfig) -> Self {
             value.clone()
         }
     }
 
-    impl LldpServiceConfigCreate {
-        pub fn builder() -> builder::LldpServiceConfigCreate {
+    impl LldpLinkConfig {
+        pub fn builder() -> builder::LldpLinkConfig {
+            Default::default()
+        }
+    }
+
+    /// The LLDP configuration associated with a port.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "The LLDP configuration associated with a port.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "enabled"
+    ///  ],
+    ///  "properties": {
+    ///    "chassis_id": {
+    ///      "description": "The LLDP chassis identifier TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "enabled": {
+    ///      "description": "Whether or not LLDP is enabled.",
+    ///      "type": "boolean"
+    ///    },
+    ///    "link_description": {
+    ///      "description": "The LLDP link description TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "link_name": {
+    ///      "description": "The LLDP link name TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "management_ip": {
+    ///      "description": "The LLDP management IP TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ],
+    ///      "format": "ip"
+    ///    },
+    ///    "system_description": {
+    ///      "description": "The LLDP system description TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "system_name": {
+    ///      "description": "The LLDP system name TLV.",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct LldpLinkConfigCreate {
+        /// The LLDP chassis identifier TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub chassis_id: Option<String>,
+        /// Whether or not LLDP is enabled.
+        pub enabled: bool,
+        /// The LLDP link description TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub link_description: Option<String>,
+        /// The LLDP link name TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub link_name: Option<String>,
+        /// The LLDP management IP TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub management_ip: Option<std::net::IpAddr>,
+        /// The LLDP system description TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub system_description: Option<String>,
+        /// The LLDP system name TLV.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub system_name: Option<String>,
+    }
+
+    impl From<&LldpLinkConfigCreate> for LldpLinkConfigCreate {
+        fn from(value: &LldpLinkConfigCreate) -> Self {
+            value.clone()
+        }
+    }
+
+    impl LldpLinkConfigCreate {
+        pub fn builder() -> builder::LldpLinkConfigCreate {
             Default::default()
         }
     }
@@ -17645,6 +17784,16 @@ pub mod types {
     ///      "type": "string",
     ///      "format": "ip"
     ///    },
+    ///    "local_pref": {
+    ///      "description": "Local preference for route. Higher preference
+    /// indictes precedence within and across protocols.",
+    ///      "type": [
+    ///        "integer",
+    ///        "null"
+    ///      ],
+    ///      "format": "uint32",
+    ///      "minimum": 0.0
+    ///    },
     ///    "vid": {
     ///      "description": "VLAN id the gateway is reachable over.",
     ///      "type": [
@@ -17666,6 +17815,10 @@ pub mod types {
         pub dst: IpNet,
         /// The route gateway.
         pub gw: std::net::IpAddr,
+        /// Local preference for route. Higher preference indictes precedence
+        /// within and across protocols.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub local_pref: Option<u32>,
         /// VLAN id the gateway is reachable over.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub vid: Option<u16>,
@@ -22348,7 +22501,7 @@ pub mod types {
     ///    "autoneg",
     ///    "fec",
     ///    "link_name",
-    ///    "lldp_service_config_id",
+    ///    "lldp_link_config_id",
     ///    "mtu",
     ///    "port_settings_id",
     ///    "speed"
@@ -22371,7 +22524,7 @@ pub mod types {
     ///      "description": "The name of this link.",
     ///      "type": "string"
     ///    },
-    ///    "lldp_service_config_id": {
+    ///    "lldp_link_config_id": {
     ///      "description": "The link-layer discovery protocol service
     /// configuration id for this link.",
     ///      "type": "string",
@@ -22413,7 +22566,7 @@ pub mod types {
         pub link_name: String,
         /// The link-layer discovery protocol service configuration id for this
         /// link.
-        pub lldp_service_config_id: uuid::Uuid,
+        pub lldp_link_config_id: uuid::Uuid,
         /// The maximum transmission unit for this link.
         pub mtu: u16,
         /// The port settings this link configuration belongs to.
@@ -22524,6 +22677,16 @@ pub mod types {
     /// assigned to.",
     ///      "type": "string"
     ///    },
+    ///    "local_pref": {
+    ///      "description": "Local preference indicating priority within and
+    /// across protocols.",
+    ///      "type": [
+    ///        "integer",
+    ///        "null"
+    ///      ],
+    ///      "format": "uint32",
+    ///      "minimum": 0.0
+    ///    },
     ///    "port_settings_id": {
     ///      "description": "The port settings object this route configuration
     /// belongs to.",
@@ -22554,6 +22717,9 @@ pub mod types {
         pub gw: IpNet,
         /// The interface name this route configuration is assigned to.
         pub interface_name: String,
+        /// Local preference indicating priority within and across protocols.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub local_pref: Option<u32>,
         /// The port settings object this route configuration belongs to.
         pub port_settings_id: uuid::Uuid,
         /// The VLAN identifier for the route. Use this if the gateway is
@@ -22939,7 +23105,7 @@ pub mod types {
     ///      "description": "Link-layer discovery protocol (LLDP) settings.",
     ///      "type": "array",
     ///      "items": {
-    ///        "$ref": "#/components/schemas/LldpServiceConfig"
+    ///        "$ref": "#/components/schemas/LldpLinkConfig"
     ///      }
     ///    },
     ///    "links": {
@@ -22997,7 +23163,7 @@ pub mod types {
         /// Layer 3 interface settings.
         pub interfaces: Vec<SwitchInterfaceConfig>,
         /// Link-layer discovery protocol (LLDP) settings.
-        pub link_lldp: Vec<LldpServiceConfig>,
+        pub link_lldp: Vec<LldpLinkConfig>,
         /// Layer 2 link settings.
         pub links: Vec<SwitchPortLinkConfig>,
         /// Layer 1 physical port settings.
@@ -28724,6 +28890,49 @@ pub mod types {
                 Self {
                     items: Ok(value.items),
                     next_page: Ok(value.next_page),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct BgpExported {
+            exports: Result<::std::collections::HashMap<String, Vec<super::Ipv4Net>>, String>,
+        }
+
+        impl Default for BgpExported {
+            fn default() -> Self {
+                Self {
+                    exports: Err("no value supplied for exports".to_string()),
+                }
+            }
+        }
+
+        impl BgpExported {
+            pub fn exports<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<::std::collections::HashMap<String, Vec<super::Ipv4Net>>>,
+                T::Error: std::fmt::Display,
+            {
+                self.exports = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for exports: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<BgpExported> for super::BgpExported {
+            type Error = super::error::ConversionError;
+            fn try_from(value: BgpExported) -> Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    exports: value.exports?,
+                })
+            }
+        }
+
+        impl From<super::BgpExported> for BgpExported {
+            fn from(value: super::BgpExported) -> Self {
+                Self {
+                    exports: Ok(value.exports),
                 }
             }
         }
@@ -36439,7 +36648,7 @@ pub mod types {
         pub struct LinkConfigCreate {
             autoneg: Result<bool, String>,
             fec: Result<super::LinkFec, String>,
-            lldp: Result<super::LldpServiceConfigCreate, String>,
+            lldp: Result<super::LldpLinkConfigCreate, String>,
             mtu: Result<u16, String>,
             speed: Result<super::LinkSpeed, String>,
         }
@@ -36479,7 +36688,7 @@ pub mod types {
             }
             pub fn lldp<T>(mut self, value: T) -> Self
             where
-                T: std::convert::TryInto<super::LldpServiceConfigCreate>,
+                T: std::convert::TryInto<super::LldpLinkConfigCreate>,
                 T::Error: std::fmt::Display,
             {
                 self.lldp = value
@@ -36535,23 +36744,43 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
-        pub struct LldpServiceConfig {
+        pub struct LldpLinkConfig {
+            chassis_id: Result<Option<String>, String>,
             enabled: Result<bool, String>,
             id: Result<uuid::Uuid, String>,
-            lldp_config_id: Result<Option<uuid::Uuid>, String>,
+            link_description: Result<Option<String>, String>,
+            link_name: Result<Option<String>, String>,
+            management_ip: Result<Option<super::IpNet>, String>,
+            system_description: Result<Option<String>, String>,
+            system_name: Result<Option<String>, String>,
         }
 
-        impl Default for LldpServiceConfig {
+        impl Default for LldpLinkConfig {
             fn default() -> Self {
                 Self {
+                    chassis_id: Ok(Default::default()),
                     enabled: Err("no value supplied for enabled".to_string()),
                     id: Err("no value supplied for id".to_string()),
-                    lldp_config_id: Ok(Default::default()),
+                    link_description: Ok(Default::default()),
+                    link_name: Ok(Default::default()),
+                    management_ip: Ok(Default::default()),
+                    system_description: Ok(Default::default()),
+                    system_name: Ok(Default::default()),
                 }
             }
         }
 
-        impl LldpServiceConfig {
+        impl LldpLinkConfig {
+            pub fn chassis_id<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.chassis_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for chassis_id: {}", e));
+                self
+            }
             pub fn enabled<T>(mut self, value: T) -> Self
             where
                 T: std::convert::TryInto<bool>,
@@ -36572,55 +36801,131 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for id: {}", e));
                 self
             }
-            pub fn lldp_config_id<T>(mut self, value: T) -> Self
+            pub fn link_description<T>(mut self, value: T) -> Self
             where
-                T: std::convert::TryInto<Option<uuid::Uuid>>,
+                T: std::convert::TryInto<Option<String>>,
                 T::Error: std::fmt::Display,
             {
-                self.lldp_config_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for lldp_config_id: {}", e)
+                self.link_description = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for link_description: {}",
+                        e
+                    )
                 });
+                self
+            }
+            pub fn link_name<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.link_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                self
+            }
+            pub fn management_ip<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<super::IpNet>>,
+                T::Error: std::fmt::Display,
+            {
+                self.management_ip = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for management_ip: {}", e)
+                });
+                self
+            }
+            pub fn system_description<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.system_description = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for system_description: {}",
+                        e
+                    )
+                });
+                self
+            }
+            pub fn system_name<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.system_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for system_name: {}", e));
                 self
             }
         }
 
-        impl std::convert::TryFrom<LldpServiceConfig> for super::LldpServiceConfig {
+        impl std::convert::TryFrom<LldpLinkConfig> for super::LldpLinkConfig {
             type Error = super::error::ConversionError;
-            fn try_from(value: LldpServiceConfig) -> Result<Self, super::error::ConversionError> {
+            fn try_from(value: LldpLinkConfig) -> Result<Self, super::error::ConversionError> {
                 Ok(Self {
+                    chassis_id: value.chassis_id?,
                     enabled: value.enabled?,
                     id: value.id?,
-                    lldp_config_id: value.lldp_config_id?,
+                    link_description: value.link_description?,
+                    link_name: value.link_name?,
+                    management_ip: value.management_ip?,
+                    system_description: value.system_description?,
+                    system_name: value.system_name?,
                 })
             }
         }
 
-        impl From<super::LldpServiceConfig> for LldpServiceConfig {
-            fn from(value: super::LldpServiceConfig) -> Self {
+        impl From<super::LldpLinkConfig> for LldpLinkConfig {
+            fn from(value: super::LldpLinkConfig) -> Self {
                 Self {
+                    chassis_id: Ok(value.chassis_id),
                     enabled: Ok(value.enabled),
                     id: Ok(value.id),
-                    lldp_config_id: Ok(value.lldp_config_id),
+                    link_description: Ok(value.link_description),
+                    link_name: Ok(value.link_name),
+                    management_ip: Ok(value.management_ip),
+                    system_description: Ok(value.system_description),
+                    system_name: Ok(value.system_name),
                 }
             }
         }
 
         #[derive(Clone, Debug)]
-        pub struct LldpServiceConfigCreate {
+        pub struct LldpLinkConfigCreate {
+            chassis_id: Result<Option<String>, String>,
             enabled: Result<bool, String>,
-            lldp_config: Result<Option<super::NameOrId>, String>,
+            link_description: Result<Option<String>, String>,
+            link_name: Result<Option<String>, String>,
+            management_ip: Result<Option<std::net::IpAddr>, String>,
+            system_description: Result<Option<String>, String>,
+            system_name: Result<Option<String>, String>,
         }
 
-        impl Default for LldpServiceConfigCreate {
+        impl Default for LldpLinkConfigCreate {
             fn default() -> Self {
                 Self {
+                    chassis_id: Ok(Default::default()),
                     enabled: Err("no value supplied for enabled".to_string()),
-                    lldp_config: Ok(Default::default()),
+                    link_description: Ok(Default::default()),
+                    link_name: Ok(Default::default()),
+                    management_ip: Ok(Default::default()),
+                    system_description: Ok(Default::default()),
+                    system_name: Ok(Default::default()),
                 }
             }
         }
 
-        impl LldpServiceConfigCreate {
+        impl LldpLinkConfigCreate {
+            pub fn chassis_id<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.chassis_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for chassis_id: {}", e));
+                self
+            }
             pub fn enabled<T>(mut self, value: T) -> Self
             where
                 T: std::convert::TryInto<bool>,
@@ -36631,35 +36936,91 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for enabled: {}", e));
                 self
             }
-            pub fn lldp_config<T>(mut self, value: T) -> Self
+            pub fn link_description<T>(mut self, value: T) -> Self
             where
-                T: std::convert::TryInto<Option<super::NameOrId>>,
+                T: std::convert::TryInto<Option<String>>,
                 T::Error: std::fmt::Display,
             {
-                self.lldp_config = value
+                self.link_description = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for link_description: {}",
+                        e
+                    )
+                });
+                self
+            }
+            pub fn link_name<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for lldp_config: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                self
+            }
+            pub fn management_ip<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<std::net::IpAddr>>,
+                T::Error: std::fmt::Display,
+            {
+                self.management_ip = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for management_ip: {}", e)
+                });
+                self
+            }
+            pub fn system_description<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.system_description = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for system_description: {}",
+                        e
+                    )
+                });
+                self
+            }
+            pub fn system_name<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.system_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for system_name: {}", e));
                 self
             }
         }
 
-        impl std::convert::TryFrom<LldpServiceConfigCreate> for super::LldpServiceConfigCreate {
+        impl std::convert::TryFrom<LldpLinkConfigCreate> for super::LldpLinkConfigCreate {
             type Error = super::error::ConversionError;
             fn try_from(
-                value: LldpServiceConfigCreate,
+                value: LldpLinkConfigCreate,
             ) -> Result<Self, super::error::ConversionError> {
                 Ok(Self {
+                    chassis_id: value.chassis_id?,
                     enabled: value.enabled?,
-                    lldp_config: value.lldp_config?,
+                    link_description: value.link_description?,
+                    link_name: value.link_name?,
+                    management_ip: value.management_ip?,
+                    system_description: value.system_description?,
+                    system_name: value.system_name?,
                 })
             }
         }
 
-        impl From<super::LldpServiceConfigCreate> for LldpServiceConfigCreate {
-            fn from(value: super::LldpServiceConfigCreate) -> Self {
+        impl From<super::LldpLinkConfigCreate> for LldpLinkConfigCreate {
+            fn from(value: super::LldpLinkConfigCreate) -> Self {
                 Self {
+                    chassis_id: Ok(value.chassis_id),
                     enabled: Ok(value.enabled),
-                    lldp_config: Ok(value.lldp_config),
+                    link_description: Ok(value.link_description),
+                    link_name: Ok(value.link_name),
+                    management_ip: Ok(value.management_ip),
+                    system_description: Ok(value.system_description),
+                    system_name: Ok(value.system_name),
                 }
             }
         }
@@ -38838,6 +39199,7 @@ pub mod types {
         pub struct Route {
             dst: Result<super::IpNet, String>,
             gw: Result<std::net::IpAddr, String>,
+            local_pref: Result<Option<u32>, String>,
             vid: Result<Option<u16>, String>,
         }
 
@@ -38846,6 +39208,7 @@ pub mod types {
                 Self {
                     dst: Err("no value supplied for dst".to_string()),
                     gw: Err("no value supplied for gw".to_string()),
+                    local_pref: Ok(Default::default()),
                     vid: Ok(Default::default()),
                 }
             }
@@ -38872,6 +39235,16 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for gw: {}", e));
                 self
             }
+            pub fn local_pref<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<u32>>,
+                T::Error: std::fmt::Display,
+            {
+                self.local_pref = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for local_pref: {}", e));
+                self
+            }
             pub fn vid<T>(mut self, value: T) -> Self
             where
                 T: std::convert::TryInto<Option<u16>>,
@@ -38890,6 +39263,7 @@ pub mod types {
                 Ok(Self {
                     dst: value.dst?,
                     gw: value.gw?,
+                    local_pref: value.local_pref?,
                     vid: value.vid?,
                 })
             }
@@ -38900,6 +39274,7 @@ pub mod types {
                 Self {
                     dst: Ok(value.dst),
                     gw: Ok(value.gw),
+                    local_pref: Ok(value.local_pref),
                     vid: Ok(value.vid),
                 }
             }
@@ -42633,7 +43008,7 @@ pub mod types {
             autoneg: Result<bool, String>,
             fec: Result<super::LinkFec, String>,
             link_name: Result<String, String>,
-            lldp_service_config_id: Result<uuid::Uuid, String>,
+            lldp_link_config_id: Result<uuid::Uuid, String>,
             mtu: Result<u16, String>,
             port_settings_id: Result<uuid::Uuid, String>,
             speed: Result<super::LinkSpeed, String>,
@@ -42645,8 +43020,8 @@ pub mod types {
                     autoneg: Err("no value supplied for autoneg".to_string()),
                     fec: Err("no value supplied for fec".to_string()),
                     link_name: Err("no value supplied for link_name".to_string()),
-                    lldp_service_config_id: Err(
-                        "no value supplied for lldp_service_config_id".to_string()
+                    lldp_link_config_id: Err(
+                        "no value supplied for lldp_link_config_id".to_string()
                     ),
                     mtu: Err("no value supplied for mtu".to_string()),
                     port_settings_id: Err("no value supplied for port_settings_id".to_string()),
@@ -42686,14 +43061,14 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for link_name: {}", e));
                 self
             }
-            pub fn lldp_service_config_id<T>(mut self, value: T) -> Self
+            pub fn lldp_link_config_id<T>(mut self, value: T) -> Self
             where
                 T: std::convert::TryInto<uuid::Uuid>,
                 T::Error: std::fmt::Display,
             {
-                self.lldp_service_config_id = value.try_into().map_err(|e| {
+                self.lldp_link_config_id = value.try_into().map_err(|e| {
                     format!(
-                        "error converting supplied value for lldp_service_config_id: {}",
+                        "error converting supplied value for lldp_link_config_id: {}",
                         e
                     )
                 });
@@ -42743,7 +43118,7 @@ pub mod types {
                     autoneg: value.autoneg?,
                     fec: value.fec?,
                     link_name: value.link_name?,
-                    lldp_service_config_id: value.lldp_service_config_id?,
+                    lldp_link_config_id: value.lldp_link_config_id?,
                     mtu: value.mtu?,
                     port_settings_id: value.port_settings_id?,
                     speed: value.speed?,
@@ -42757,7 +43132,7 @@ pub mod types {
                     autoneg: Ok(value.autoneg),
                     fec: Ok(value.fec),
                     link_name: Ok(value.link_name),
-                    lldp_service_config_id: Ok(value.lldp_service_config_id),
+                    lldp_link_config_id: Ok(value.lldp_link_config_id),
                     mtu: Ok(value.mtu),
                     port_settings_id: Ok(value.port_settings_id),
                     speed: Ok(value.speed),
@@ -42829,6 +43204,7 @@ pub mod types {
             dst: Result<super::IpNet, String>,
             gw: Result<super::IpNet, String>,
             interface_name: Result<String, String>,
+            local_pref: Result<Option<u32>, String>,
             port_settings_id: Result<uuid::Uuid, String>,
             vlan_id: Result<Option<u16>, String>,
         }
@@ -42839,6 +43215,7 @@ pub mod types {
                     dst: Err("no value supplied for dst".to_string()),
                     gw: Err("no value supplied for gw".to_string()),
                     interface_name: Err("no value supplied for interface_name".to_string()),
+                    local_pref: Ok(Default::default()),
                     port_settings_id: Err("no value supplied for port_settings_id".to_string()),
                     vlan_id: Ok(Default::default()),
                 }
@@ -42876,6 +43253,16 @@ pub mod types {
                 });
                 self
             }
+            pub fn local_pref<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<u32>>,
+                T::Error: std::fmt::Display,
+            {
+                self.local_pref = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for local_pref: {}", e));
+                self
+            }
             pub fn port_settings_id<T>(mut self, value: T) -> Self
             where
                 T: std::convert::TryInto<uuid::Uuid>,
@@ -42910,6 +43297,7 @@ pub mod types {
                     dst: value.dst?,
                     gw: value.gw?,
                     interface_name: value.interface_name?,
+                    local_pref: value.local_pref?,
                     port_settings_id: value.port_settings_id?,
                     vlan_id: value.vlan_id?,
                 })
@@ -42922,6 +43310,7 @@ pub mod types {
                     dst: Ok(value.dst),
                     gw: Ok(value.gw),
                     interface_name: Ok(value.interface_name),
+                    local_pref: Ok(value.local_pref),
                     port_settings_id: Ok(value.port_settings_id),
                     vlan_id: Ok(value.vlan_id),
                 }
@@ -43323,7 +43712,7 @@ pub mod types {
             bgp_peers: Result<Vec<super::BgpPeer>, String>,
             groups: Result<Vec<super::SwitchPortSettingsGroups>, String>,
             interfaces: Result<Vec<super::SwitchInterfaceConfig>, String>,
-            link_lldp: Result<Vec<super::LldpServiceConfig>, String>,
+            link_lldp: Result<Vec<super::LldpLinkConfig>, String>,
             links: Result<Vec<super::SwitchPortLinkConfig>, String>,
             port: Result<super::SwitchPortConfig, String>,
             routes: Result<Vec<super::SwitchPortRouteConfig>, String>,
@@ -43391,7 +43780,7 @@ pub mod types {
             }
             pub fn link_lldp<T>(mut self, value: T) -> Self
             where
-                T: std::convert::TryInto<Vec<super::LldpServiceConfig>>,
+                T: std::convert::TryInto<Vec<super::LldpLinkConfig>>,
                 T::Error: std::fmt::Display,
             {
                 self.link_lldp = value
@@ -49207,6 +49596,16 @@ pub trait ClientSystemNetworkingExt {
     ///    .await;
     /// ```
     fn networking_bgp_announce_set_delete(&self) -> builder::NetworkingBgpAnnounceSetDelete;
+    /// Get BGP exported routes
+    ///
+    /// Sends a `GET` request to `/v1/system/networking/bgp-exported`
+    ///
+    /// ```ignore
+    /// let response = client.networking_bgp_exported()
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn networking_bgp_exported(&self) -> builder::NetworkingBgpExported;
     /// Get BGP router message history
     ///
     /// Sends a `GET` request to `/v1/system/networking/bgp-message-history`
@@ -49488,6 +49887,10 @@ impl ClientSystemNetworkingExt for Client {
 
     fn networking_bgp_announce_set_delete(&self) -> builder::NetworkingBgpAnnounceSetDelete {
         builder::NetworkingBgpAnnounceSetDelete::new(self)
+    }
+
+    fn networking_bgp_exported(&self) -> builder::NetworkingBgpExported {
+        builder::NetworkingBgpExported::new(self)
     }
 
     fn networking_bgp_message_history(&self) -> builder::NetworkingBgpMessageHistory {
@@ -64425,6 +64828,47 @@ pub mod builder {
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    /// Builder for [`ClientSystemNetworkingExt::networking_bgp_exported`]
+    ///
+    /// [`ClientSystemNetworkingExt::networking_bgp_exported`]: super::ClientSystemNetworkingExt::networking_bgp_exported
+    #[derive(Debug, Clone)]
+    pub struct NetworkingBgpExported<'a> {
+        client: &'a super::Client,
+    }
+
+    impl<'a> NetworkingBgpExported<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self { client: client }
+        }
+
+        /// Sends a `GET` request to `/v1/system/networking/bgp-exported`
+        pub async fn send(self) -> Result<ResponseValue<types::BgpExported>, Error<types::Error>> {
+            let Self { client } = self;
+            let url = format!("{}/v1/system/networking/bgp-exported", client.baseurl,);
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),


### PR DESCRIPTION
The external `omicron` APIs related to link creation changed recently, breaking the CLI.  This PR just adapts to those changes to restore the previous functionality, but does not add and LLDP-related functionality.

Since the last CLI update, a BGP-related API was also added.  I _think_ I've got that plumbed in as well.

The link-related changed were tested by @elaine-oxide in a4x2.

I've added Ry as a reviewer to verify the BGP-related stuff, and Will because he's been by far the most active contributor recently.  If there is somebody else I should pull in, please let me know.