### PR TITLE
Handle empty credentials.toml files

### DIFF
--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -29,14 +29,7 @@ pub struct ConfigFile {
 
 fn read_or_default<T: DeserializeOwned + Default>(path: PathBuf) -> Result<T> {
     match std::fs::read_to_string(path) {
-        Ok(contents) => {
-            // Empty `credentials.toml` files cannot be parsed.
-            if contents.trim().is_empty() {
-                Ok(T::default())
-            } else {
-                Ok(toml::from_str(&contents)?)
-            }
-        }
+        Ok(contents) => Ok(toml::from_str(&contents)?),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(T::default()),
         Err(e) => Err(e.into()),
     }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -29,7 +29,14 @@ pub struct ConfigFile {
 
 fn read_or_default<T: DeserializeOwned + Default>(path: PathBuf) -> Result<T> {
     match std::fs::read_to_string(path) {
-        Ok(contents) => Ok(toml::from_str(&contents)?),
+        Ok(contents) => {
+            // Empty `credentials.toml` files cannot be parsed.
+            if contents.trim().is_empty() {
+                Ok(T::default())
+            } else {
+                Ok(toml::from_str(&contents)?)
+            }
+        }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(T::default()),
         Err(e) => Err(e.into()),
     }

--- a/cli/tests/test_auth.rs
+++ b/cli/tests/test_auth.rs
@@ -14,6 +14,7 @@ use expectorate::assert_contents;
 use httpmock::{Method::POST, Mock, MockServer};
 use oxide::types::CurrentUser;
 use oxide_httpmock::MockServerExt;
+use predicates::str;
 use serde_json::json;
 
 fn scrub_server(raw: String, server: String) -> String {
@@ -376,16 +377,15 @@ fn test_cmd_auth_status() {
     );
 
     // Validate empty `credentials.toml` does not error.
-    let empty_cmd = Command::cargo_bin("oxide")
+    Command::cargo_bin("oxide")
         .unwrap()
         .arg("--config-dir")
         .arg(empty_creds_dir.as_os_str())
         .arg("auth")
         .arg("status")
         .assert()
-        .success();
-    let empty_stdout = String::from_utf8_lossy(&empty_cmd.get_output().stdout);
-    assert!(empty_stdout.is_empty());
+        .success()
+        .stdout(str::is_empty());
 
     ok.assert_hits(2);
     bad.assert();

--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -130,6 +130,7 @@ impl ClientConfig {
 }
 
 #[derive(Deserialize, Debug, Default)]
+#[serde(default)]
 pub struct CredentialsFile {
     pub profile: BTreeMap<String, ProfileCredentials>,
 }


### PR DESCRIPTION
After logging out of all profiles we write an empty `credentials.toml` file to the user's config directory. However, when loading that file we will fail to parse the contents as a TOML table.

Only parse `credentials.toml` if it is not empty, falling back on the default value otherwise.

Closes https://github.com/oxidecomputer/oxide.rs/issues/797