### PR TITLE
Generate docs for positional args

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -80,6 +80,10 @@
           "long": "raw-field",
           "short": "f",
           "help": "Add a string parameter in key=value format"
+        },
+        {
+          "name": "endpoint",
+          "help": "The endpoint to request"
         }
       ]
     },
@@ -924,6 +928,10 @@
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
+                },
+                {
+                  "name": "query",
+                  "help": "The timeseries query to display in the dashboard"
                 }
               ]
             },

--- a/cli/src/cmd_docs.rs
+++ b/cli/src/cmd_docs.rs
@@ -23,6 +23,8 @@ pub struct CmdDocs;
 #[derive(Serialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct JsonArg {
     #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     long: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     short: Option<String>,
@@ -64,8 +66,9 @@ fn to_json(cmd: &Command) -> JsonDoc {
     let mut args = cmd
         .get_arguments()
         .filter(|arg| arg.get_long() != Some("help"))
-        .filter(|arg| arg.get_short().is_some() || arg.get_long().is_some())
         .map(|arg| JsonArg {
+            name: (arg.get_long().is_none() && arg.get_short().is_none())
+                .then_some(arg.get_id().to_string()),
             short: arg.get_short().map(|char| char.to_string()),
             long: arg.get_long().map(ToString::to_string),
             values: arg


### PR DESCRIPTION
Currently we only generate docs for args that have a `long` or `short` attribute. Positional args will not have these items, and so are undocumented on our web docs.

Add a new `name` field to `JsonArg` which will only be serialized when neither `long` nor `short` are present.