### PR TITLE
Change to system networking bgp exported ipv4

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -4764,12 +4764,24 @@
                 },
                 {
                   "name": "exported",
-                  "about": "Get BGP exported routes",
                   "args": [
                     {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
+                    }
+                  ],
+                  "subcommands": [
+                    {
+                      "name": "ipv4",
+                      "about": "Get BGP exported routes",
+                      "args": [
+                        {
+                          "long": "profile",
+                          "help": "Configuration profile to use for commands",
+                          "global": true
+                        }
+                      ]
                     }
                   ]
                 },

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -4788,7 +4788,7 @@
                 {
                   "name": "filter",
                   "about": "Add a filtering requirement to a BGP session.",
-                  "long_about": "Add a filtering requirement to a BGP session.\n\nThe Oxide BGP implementation can filter prefixes received from peers\non import and filter prefixes sent to peers on export. This command\nprovides a way to specify import/export filtering. Filtering is a\nproperty of the BGP peering settings found in port settings configuration.\nThis command works by performing a read-modify-write on the port settings\nconfiguration identified by the specified rack/switch/port.",
+                  "long_about": "Add a filtering requirement to a BGP session.\n\nThe Oxide BGP implementation can filter prefixes received from peers\non import and filter prefixes sent to peers on export. This command\nprovides a way to specify import/export filtering. Filtering is a\nproperty of the BGP peering settings found in the port settings configuration.\nThis command works by performing a read-modify-write on the port settings\nconfiguration identified by the specified rack/switch/port.",
                   "args": [
                     {
                       "long": "allowed",

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -482,7 +482,7 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::NetworkingBgpAnnouncementList => {
             Some("system networking bgp announcement list")
         }
-        CliCommand::NetworkingBgpExported => Some("system networking bgp exported"),
+        CliCommand::NetworkingBgpExported => Some("system networking bgp exported ipv4"),
         CliCommand::NetworkingBgpImportedRoutesIpv4 => Some("system networking bgp imported ipv4"),
 
         // Subcommand: disk

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -356,7 +356,7 @@ enum FilterDirection {
 /// The Oxide BGP implementation can filter prefixes received from peers
 /// on import and filter prefixes sent to peers on export. This command
 /// provides a way to specify import/export filtering. Filtering is a
-/// property of the BGP peering settings found in port settings configuration.
+/// property of the BGP peering settings found in the port settings configuration.
 /// This command works by performing a read-modify-write on the port settings
 /// configuration identified by the specified rack/switch/port.
 #[derive(Parser, Debug, Clone)]


### PR DESCRIPTION
- Change to `oxide system networking bgp exported ipv4` so that it matches `oxide system networking bgp imported ipv4`
- Fix grammar in `oxide system networking bgp filter --help`