### PR TITLE
Add rename-profile subcommand to auth

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -157,11 +157,11 @@
               "global": true
             },
             {
-              "name": "current_profile_name",
+              "name": "current_name",
               "help": "The current name of the profile to be renamed"
             },
             {
-              "name": "new_profile_name",
+              "name": "new_name",
               "help": "The new name of the profile to be renamed"
             }
           ]

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -147,6 +147,26 @@
           ]
         },
         {
+          "name": "rename-profile",
+          "about": "Rename a profile.",
+          "long_about": "Rename a profile.\n\nThis command does not modify the profile credentials. If\nthe profile being renamed is your `default-profile` that\nwill be updated as well.",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands",
+              "global": true
+            },
+            {
+              "name": "current_profile_name",
+              "help": "The current name of the profile to be renamed"
+            },
+            {
+              "name": "new_profile_name",
+              "help": "The new name of the profile to be renamed"
+            }
+          ]
+        },
+        {
           "name": "status",
           "about": "Verifies and displays information about your authentication state.",
           "long_about": "Verifies and displays information about your authentication state.\n\nThis command validates the authentication state for each profile in the\ncurrent configuration.",

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -528,10 +528,10 @@ impl CmdAuthStatus {
 #[command(verbatim_doc_comment)]
 pub struct CmdAuthRenameProfile {
     /// The current name of the profile to be renamed.
-    current_profile_name: String,
+    current_name: String,
 
     /// The new name of the profile to be renamed.
-    new_profile_name: String,
+    new_name: String,
 }
 
 impl CmdAuthRenameProfile {
@@ -544,14 +544,14 @@ impl CmdAuthRenameProfile {
                 .unwrap();
             if let Some(profiles) = credentials.get_mut("profile") {
                 let profiles = profiles.as_table_mut().unwrap();
-                let Some(profile) = profiles.remove(&self.current_profile_name) else {
+                let Some(profile) = profiles.remove(&self.current_name) else {
                     bail!(
                         "No profile named \"{}\" found in {}",
-                        self.current_profile_name,
+                        self.current_name,
                         credentials_path.display()
                     );
                 };
-                profiles.insert(&self.new_profile_name, profile);
+                profiles.insert(&self.new_name, profile);
             }
 
             write_configuration_file(&credentials_path, &credentials.to_string())?;
@@ -562,11 +562,8 @@ impl CmdAuthRenameProfile {
             let mut config = config_contents.parse::<toml_edit::DocumentMut>()?;
 
             if let Some(old_default) = config.remove("default-profile") {
-                if Some(self.current_profile_name.as_str()) == old_default.as_str() {
-                    config.insert(
-                        "default-profile",
-                        Item::Value(self.new_profile_name.clone().into()),
-                    );
+                if Some(self.current_name.as_str()) == old_default.as_str() {
+                    config.insert("default-profile", Item::Value(self.new_name.clone().into()));
                     write_configuration_file(&config_path, &config.to_string())?;
                 }
             }
@@ -575,8 +572,8 @@ impl CmdAuthRenameProfile {
         writeln!(
             io::stdout(),
             "Renamed profile \"{}\" to \"{}\"",
-            self.current_profile_name,
-            self.new_profile_name,
+            self.current_name,
+            self.new_name,
         )?;
         Ok(())
     }

--- a/cli/tests/data/test_cmd_auth_rename_profile_renamed_credentials.toml
+++ b/cli/tests/data/test_cmd_auth_rename_profile_renamed_credentials.toml
@@ -1,0 +1,5 @@
+[profile.new-profile]
+host = "https://oxide.internal"
+token = "***-***-***"
+user = "00000000-0000-0000-0000-000000000000"
+

--- a/cli/tests/test_auth.rs
+++ b/cli/tests/test_auth.rs
@@ -510,8 +510,8 @@ fn test_cmd_auth_rename_profile() {
         .assert()
         .failure()
         .stderr(format!(
-            "No profile named \"non-existent-profile\" found in {}/credentials.toml\n",
-            temp_dir.display()
+            "No profile named \"non-existent-profile\" found in {}\n",
+            temp_dir.join("credentials.toml").display()
         ));
 
     let cfg_only_temp_dir = tempfile::tempdir().unwrap().into_path();


### PR DESCRIPTION
Currently we name the profile associated with a silo based on the silo URL. Users who want a more descriptive name must manually edit the `credentials.toml` and `config.toml` files to update the profile name. These files are thinly documented and subject to change, a programmatic way to perform this change would be helpful, particularly for non-technical users.

Add a new `rename-profile` subcommand to `auth` to update the profile name and default-profile (when needed).

Demo:
https://github.com/user-attachments/assets/1b876273-ea76-4eff-b8c1-ec081a7c0199

