### PR TITLE
Enable help menu wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -3391,6 +3392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.34",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.81"
 base64 = "0.22.1"
 built = { version = "0.7.4", features = ["git2"] }
 chrono = { version = "0.4.38", features = ["serde"] }
-clap = { version = "4.5.16", features = ["derive", "string", "env"] }
+clap = { version = "4.5.16", features = ["derive", "string", "env", "wrap_help"] }
 clap_complete = "4.5.23"
 colored = "2.1.0"
 crossterm = { version = "0.27.0", features = [ "event-stream" ] }


### PR DESCRIPTION
Turns this

```
$ oxide floating-ip create --help
Create floating IP

Usage: oxide floating-ip create [OPTIONS] --project <project>

Options:
      --description <description>
      --ip <ip>                    An IP address to reserve for use as a floating IP. This field is
 optional: when not set, an address will be automatically chosen from `pool`. If set, then the IP m
ust be available in the resolved `pool`.
      --profile <PROFILE>          Configuration profile to use for commands
      --name <name>
      --pool <pool>                The parent IP pool that a floating IP is pulled from. If unset, 
the default pool is selected.
      --project <project>          Name or ID of the project
      --json-body <JSON-FILE>      Path to a file that contains the full json body.
      --json-body-template         XXX
  -h, --help                       Print help
ry@ryair:~/src/oxide.rs$
```

into this

```
$ oxide floating-ip create --help
Create floating IP

Usage: oxide floating-ip create [OPTIONS] --project <project>

Options:
      --description <description>
      --ip <ip>                    An IP address to reserve for use as a floating IP. This field is
                                   optional: when not set, an address will be automatically chosen
                                   from `pool`. If set, then the IP must be available in the
                                   resolved `pool`.
      --profile <PROFILE>          Configuration profile to use for commands
      --name <name>
      --pool <pool>                The parent IP pool that a floating IP is pulled from. If unset,
                                   the default pool is selected.
      --project <project>          Name or ID of the project
      --json-body <JSON-FILE>      Path to a file that contains the full json body.
      --json-body-template         XXX
  -h, --help                       Print help
```

This clap feature detects the user's terminal width and wraps accordingly.