### PR TITLE
Place global options under a separate help heading

### DIFF
--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -27,7 +27,7 @@ struct OxideCli {
     pub debug: bool,
 
     /// Configuration profile to use for commands
-    #[clap(long, global = true)]
+    #[clap(long, global = true, help_heading = "Global Options")]
     pub profile: Option<String>,
 
     /// Directory to use for configuration


### PR DESCRIPTION
With #815 we set the stage for our web docs to list global options under a separate header. It would be useful for CLI help output to also make it clear that `--profile` is globally accepted.

Add a separate "Global Options" `help_heading` for it.

Updated help output:

```sh
$ oxide disk create -h
Create a disk

Usage: oxide disk create [OPTIONS] --project <project> --json-body <JSON-FILE>

Options:
      --description <description>
      --name <name>
      --project <project>          Name or ID of the project
      --size <size>                total size of the Disk in bytes
      --json-body <JSON-FILE>      Path to a file that contains the full json body.
      --json-body-template         XXX
  -h, --help                       Print help

Global Options:
      --profile <PROFILE>  Configuration profile to use for commands
```