### PR TITLE
Bump toolchain to Rust 1.80

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76"
+channel = "1.80"
 profile = "default"


### PR DESCRIPTION
Just in time for the v1.81 release, update to 1.80.