### PR TITLE
allow initializing port settings with a link

### DIFF
--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -109,8 +109,21 @@ pub struct CmdLinkAdd {
 #[async_trait]
 impl AuthenticatedCmd for CmdLinkAdd {
     async fn run(&self, client: &Client) -> Result<()> {
-        let mut settings =
-            current_port_settings(client, &self.rack, &self.switch, &self.port).await?;
+        let mut settings = current_port_settings(client, &self.rack, &self.switch, &self.port)
+            .await
+            .unwrap_or(SwitchPortSettingsCreate {
+                addresses: HashMap::new(),
+                bgp_peers: HashMap::new(),
+                description: String::new(),
+                groups: Vec::new(),
+                interfaces: HashMap::new(),
+                links: HashMap::new(),
+                name: format!("{}-{}", self.switch, self.port).parse().unwrap(),
+                port_config: SwitchPortConfigCreate {
+                    geometry: SwitchPortGeometry::Qsfp28x1,
+                },
+                routes: HashMap::new(),
+            });
         let link = LinkConfigCreate {
             autoneg: self.autoneg,
             fec: self.fec.into(),

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -112,17 +112,17 @@ impl AuthenticatedCmd for CmdLinkAdd {
         let mut settings = current_port_settings(client, &self.rack, &self.switch, &self.port)
             .await
             .unwrap_or(SwitchPortSettingsCreate {
-                addresses: HashMap::new(),
-                bgp_peers: HashMap::new(),
-                description: String::new(),
-                groups: Vec::new(),
-                interfaces: HashMap::new(),
-                links: HashMap::new(),
+                addresses: HashMap::default(),
+                bgp_peers: HashMap::default(),
+                description: String::default(),
+                groups: Vec::default(),
+                interfaces: HashMap::default(),
+                links: HashMap::default(),
                 name: format!("{}-{}", self.switch, self.port).parse().unwrap(),
                 port_config: SwitchPortConfigCreate {
                     geometry: SwitchPortGeometry::Qsfp28x1,
                 },
-                routes: HashMap::new(),
+                routes: HashMap::default(),
             });
         let link = LinkConfigCreate {
             autoneg: self.autoneg,


### PR DESCRIPTION
When a user tries to make a change to a port settings object that does not exist, we tell them to create a link to initialize the port. However, when they do just that, we tell them to create a link to initialize the port. A bit of a jerk move. This fix allows port settings to be initialized via link creation.