### PR TITLE
Add convenience wrapper for disk uploads to SDK

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ log = { workspace = true }
 md5 = { workspace = true }
 oauth2 = { workspace = true }
 open = { workspace = true }
-oxide = { workspace = true }
+oxide = { workspace = true, features = ["clap"] }
 oxnet = { workspace = true }
 predicates = { workspace = true }
 ratatui = { workspace = true }

--- a/cli/src/cmd_disk.rs
+++ b/cli/src/cmd_disk.rs
@@ -6,33 +6,18 @@
 
 use crate::{eprintln_nopipe, println_nopipe};
 
-use anyhow::bail;
 use anyhow::Result;
 use async_trait::async_trait;
-use base64::Engine;
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
-use oxide::types::BlockSize;
-use oxide::types::ByteCount;
-use oxide::types::DiskCreate;
-use oxide::types::DiskSource;
-use oxide::types::FinalizeDisk;
-use oxide::types::ImageCreate;
-use oxide::types::ImageSource;
-use oxide::types::ImportBlocksBulkWrite;
-use oxide::types::Name;
-use oxide::types::NameOrId;
+use oxide::extras::disk::types::{DiskImportHandle, DiskInfo, ImageInfo};
+use oxide::extras::ClientExtraDiskExt;
+use oxide::types::{BlockSize, ByteCount, Name, NameOrId};
 use oxide::Client;
-use oxide::ClientDisksExt;
-use oxide::ClientImagesExt;
-use oxide::ClientSnapshotsExt;
-use oxide::ResponseValue;
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::sync::mpsc;
+use std::process;
+use tokio::signal;
+use tokio::sync::watch;
 
 /// Create a disk from a file upload
 ///
@@ -93,461 +78,112 @@ pub struct CmdDiskImport {
     image_version: Option<String>,
 }
 
-/// Return a disk size that Nexus will accept for the path and size arguments
-fn get_disk_size(path: &PathBuf, size: Option<u64>) -> Result<u64> {
-    const ONE_GB: u64 = 1024 * 1024 * 1024;
-
-    let disk_size = if let Some(size) = size {
-        size
-    } else {
-        std::fs::metadata(path)?.len()
-    };
-
-    // Nexus' disk size minimum is 1 GB, and Nexus only supports disks whose
-    // size is a multiple of 1 GB
-    let disk_size = if disk_size % ONE_GB != 0 {
-        let rounded_down_gb: u64 = disk_size - disk_size % ONE_GB;
-        assert_eq!(rounded_down_gb % ONE_GB, 0);
-        rounded_down_gb + ONE_GB
-    } else {
-        disk_size
-    };
-
-    Ok(disk_size)
-}
-
-#[test]
-fn test_get_disk_size() {
-    let path = PathBuf::from("not relevant because we're supplying a size");
-
-    // test rounding up
-    assert_eq!(get_disk_size(&path, Some(1)).unwrap(), 1024 * 1024 * 1024,);
-
-    assert_eq!(
-        get_disk_size(&path, Some(1024 * 1024 * 1024 - 1)).unwrap(),
-        1024 * 1024 * 1024,
-    );
-
-    // test even multiples of GB
-    assert_eq!(
-        get_disk_size(&path, Some(1024 * 1024 * 1024)).unwrap(),
-        1024 * 1024 * 1024,
-    );
-
-    assert_eq!(
-        get_disk_size(&path, Some(2 * 1024 * 1024 * 1024)).unwrap(),
-        2 * 1024 * 1024 * 1024,
-    );
-
-    // test non-even multiples of GB
-    assert_eq!(
-        get_disk_size(&path, Some(2 * 1024 * 1024 * 1024 + 1)).unwrap(),
-        3 * 1024 * 1024 * 1024,
-    );
-
-    assert_eq!(
-        get_disk_size(&path, Some(3 * 1024 * 1024 * 1024 - 1)).unwrap(),
-        3 * 1024 * 1024 * 1024,
-    );
-}
-
-fn err_if_object_exists<T>(
-    error_msg: String,
-    send_response: Result<ResponseValue<T>, oxide::Error<oxide::types::Error>>,
-) -> Result<()> {
-    match send_response {
-        Ok(_) => {
-            bail!(error_msg);
-        }
-
-        Err(e) => {
-            match &e {
-                // Match against 404
-                oxide::Error::ErrorResponse(response_value) => {
-                    if response_value.status() == 404 {
-                        // ok
-                    } else {
-                        bail!(e);
-                    }
-                }
-
-                // Bail on any other error
-                _ => bail!(e),
-            }
-        }
-    }
-    Ok(())
-}
-
-// Upload to Nexus in 512k byte chunks
-const CHUNK_SIZE: u64 = 512 * 1024;
-
-impl CmdDiskImport {
-    async fn unwind_disk_delete(&self, client: &Client) -> Result<()> {
-        let response = client
-            .disk_delete()
-            .project(&self.project)
-            .disk(self.disk.clone())
-            .send()
-            .await;
-
-        if let Err(e) = response {
-            eprintln_nopipe!(
-                "trying to unwind, deleting {:?} failed with {:?}",
-                self.disk,
-                e
-            );
-            return Err(e.into());
-        }
-
-        Ok(())
-    }
-
-    async fn unwind_disk_finalize(&self, client: &Client) -> Result<()> {
-        let response = client
-            .disk_finalize_import()
-            .project(&self.project)
-            .disk(self.disk.clone())
-            .send()
-            .await;
-
-        // If this fails, then the disk will remain in state "import-ready"
-        if let Err(e) = response {
-            eprintln_nopipe!(
-                "trying to unwind, finalizing {:?} failed with {:?}",
-                self.disk,
-                e
-            );
-            return Err(e.into());
-        }
-
-        Ok(())
-    }
-
-    async fn unwind_disk_bulk_write_stop(&self, client: &Client) -> Result<()> {
-        let response = client
-            .disk_bulk_write_import_stop()
-            .project(&self.project)
-            .disk(self.disk.clone())
-            .send()
-            .await;
-
-        // If this fails, then the disk will remain in state
-        // "importing-from-bulk-writes"
-        if let Err(e) = response {
-            eprintln_nopipe!(
-                "trying to unwind, stopping the bulk write process for {:?} failed with {:?}",
-                self.disk,
-                e
-            );
-            return Err(e.into());
-        }
-
-        Ok(())
-    }
-}
-
 #[async_trait]
 impl crate::AuthenticatedCmd for CmdDiskImport {
     fn is_subtree() -> bool {
         false
     }
-    async fn run(&self, client: &Client) -> Result<()> {
-        if !Path::new(&self.path).exists() {
-            bail!("path {} does not exist", self.path.to_string_lossy());
-        }
 
-        // validate that objects don't exist already
-        err_if_object_exists(
-            format!("disk {:?} exists already", &self.disk),
-            client
-                .disk_view()
-                .project(&self.project)
-                .disk(NameOrId::Name(self.disk.clone()))
-                .send()
-                .await,
+    async fn run(&self, client: &Client) -> Result<()> {
+        let disk_info = DiskInfo::calculate(
+            self.path.clone(),
+            self.disk_size.as_ref(),
+            self.disk_block_size.as_ref(),
         )?;
 
-        // snapshot
-        if let Some(snapshot_name) = &self.snapshot {
-            err_if_object_exists(
-                format!("snapshot {:?} exists already", &snapshot_name),
-                client
-                    .snapshot_view()
-                    .project(&self.project)
-                    .snapshot(NameOrId::Name(snapshot_name.clone()))
-                    .send()
-                    .await,
-            )?;
-        }
-
-        // image
-        if let Some(image_name) = &self.image {
-            err_if_object_exists(
-                format!("image {:?} exists already", &image_name),
-                client
-                    .image_view()
-                    .project(&self.project)
-                    .image(NameOrId::Name(image_name.clone()))
-                    .send()
-                    .await,
-            )?;
-        }
-
-        let file_size = std::fs::metadata(&self.path)?.len();
-        let disk_size = get_disk_size(&self.path, self.disk_size.as_ref().map(|x| **x))?;
-
-        let disk_block_size = match &self.disk_block_size {
-            Some(v) => v.clone(),
-            None => BlockSize::try_from(512).unwrap(),
-        };
-
-        if (file_size % *disk_block_size as u64) != 0 {
-            bail!(
-                "file size {} is not divisible by block size{}!",
-                file_size,
-                *disk_block_size
-            );
-        }
-
-        // Use 8 upload tasks - this evenly divides all block sizes, and we know
-        // that the file size is evenly divided by the selected block size due
-        // to the above check.
-        const UPLOAD_TASKS: usize = 8;
-
-        // Create the disk in state "importing blocks"
-        client
-            .disk_create()
-            .project(&self.project)
-            .body(DiskCreate {
-                name: self.disk.clone(),
-                description: self.description.clone(),
-                disk_source: DiskSource::ImportingBlocks {
-                    block_size: disk_block_size.clone(),
-                },
-                size: disk_size.into(),
-            })
-            .send()
-            .await?;
-
-        // Start the bulk write process
-        let start_bulk_write_response = client
-            .disk_bulk_write_import_start()
-            .project(&self.project)
+        // Default to 8 upload tasks - this evenly divides all block sizes, and we know
+        // that the file size is evenly divided by the selected block size.
+        let mut builder = client
+            .disk_import()
+            .project(self.project.clone())
+            .description(self.description.clone())
+            .upload_thread_ct(8)
             .disk(self.disk.clone())
-            .send()
-            .await;
+            .disk_info(disk_info.clone());
 
-        if let Err(e) = start_bulk_write_response {
-            eprintln_nopipe!("starting the bulk write process failed with {:?}", e);
-
-            // If this fails, the disk is in state import-ready. Finalize it so
-            // it can be deleted.
-            self.unwind_disk_finalize(client).await?;
-
-            // The finalize succeeded, so delete the disk.
-            self.unwind_disk_delete(client).await?;
-
-            // Finalizing and deleting the disk succeeded, so return the
-            // original error.
-            return Err(e.into());
-        }
-
-        // Create one tokio task for each thread that will upload file chunks
-        let mut handles: Vec<tokio::task::JoinHandle<Result<()>>> =
-            Vec::with_capacity(UPLOAD_TASKS);
-        let mut senders = Vec::with_capacity(UPLOAD_TASKS);
-
-        let pb = Arc::new(ProgressBar::new(file_size));
-        pb.set_style(ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] [{wide_bar:.green}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")?
-        );
-        pb.set_position(0);
-
-        for _i in 0..UPLOAD_TASKS {
-            let (tx, mut rx) = mpsc::channel(100);
-
-            let client = client.clone();
-            let disk_name = self.disk.clone();
-            let project = self.project.clone();
-
-            let pb = pb.clone();
-
-            handles.push(tokio::spawn(async move {
-                while let Some((offset, base64_encoded_data, data_len)) = rx.recv().await {
-                    client
-                        .disk_bulk_write_import()
-                        .disk(disk_name.clone())
-                        .project(project.clone())
-                        .body(ImportBlocksBulkWrite {
-                            offset,
-                            base64_encoded_data,
-                        })
-                        .send()
-                        .await?;
-
-                    pb.inc(data_len as u64);
-                }
-
-                Ok(())
-            }));
-
-            senders.push(tx);
-        }
-
-        // Read chunks from the file in the file system and send them to the
-        // upload threads.
-        let mut file = File::open(&self.path)?;
-        let mut i = 0;
-        let mut offset = 0;
-
-        let read_result: Result<()> = loop {
-            let mut chunk = Vec::with_capacity(CHUNK_SIZE as usize);
-
-            let n = match file.by_ref().take(CHUNK_SIZE).read_to_end(&mut chunk) {
-                Ok(n) => n,
-                Err(e) => {
-                    eprintln_nopipe!(
-                        "reading from {} failed with {:?}",
-                        self.path.to_string_lossy(),
-                        e,
-                    );
-                    break Err(e.into());
-                }
-            };
-
-            if n == 0 {
-                break Ok(());
-            }
-
-            // If the chunk we just read is all zeroes, don't POST it.
-            if !chunk.iter().all(|x| *x == 0) {
-                let encoded = base64::engine::general_purpose::STANDARD.encode(&chunk[0..n]);
-
-                if let Err(e) = senders[i % UPLOAD_TASKS].send((offset, encoded, n)).await {
-                    eprintln_nopipe!("sending chunk to thread failed with {:?}", e);
-                    break Err(e.into());
-                }
-            } else {
-                // Bump the progress bar here to make it consistent
-                pb.inc(n as u64);
-            }
-
-            offset += CHUNK_SIZE;
-            i += 1;
-        };
-
-        for tx in senders {
-            drop(tx);
-        }
-
-        if let Err(e) = read_result {
-            // some part of reading from the disk and sending to the upload
-            // threads failed, so unwind. stop the bulk write process, finalize
-            // the disk, then delete it.
-            self.unwind_disk_bulk_write_stop(client).await?;
-            self.unwind_disk_finalize(client).await?;
-            self.unwind_disk_delete(client).await?;
-
-            // return the original error
-            return Err(e);
-        }
-
-        let mut results = Vec::with_capacity(handles.len());
-        for handle in handles {
-            let result = handle.await?;
-            results.push(result);
-        }
-
-        if results.iter().any(|x| x.is_err()) {
-            // If any of the upload threads returned an error, unwind the disk.
-            eprintln_nopipe!("one of the upload threads failed");
-            self.unwind_disk_bulk_write_stop(client).await?;
-            self.unwind_disk_finalize(client).await?;
-            self.unwind_disk_delete(client).await?;
-            bail!("one of the upload threads failed");
-        }
-
-        // wait for upload threads to complete, then finish the progress bar
-        pb.finish();
-
-        // Stop the bulk write process
-        let stop_bulk_write_response = client
-            .disk_bulk_write_import_stop()
-            .project(&self.project)
-            .disk(self.disk.clone())
-            .send()
-            .await;
-
-        if let Err(e) = stop_bulk_write_response {
-            eprintln_nopipe!("stopping the bulk write process failed with {:?}", e);
-
-            // Attempt to unwind the disk, although it will probably fail - the
-            // first step is to stop the bulk write process!
-            self.unwind_disk_bulk_write_stop(client).await?;
-            self.unwind_disk_finalize(client).await?;
-            self.unwind_disk_delete(client).await?;
-
-            return Err(e.into());
-        }
-
-        // Finalize the disk, optionally making a snapshot
-        let request = client
-            .disk_finalize_import()
-            .project(&self.project)
-            .disk(self.disk.clone())
-            .body(FinalizeDisk {
-                snapshot_name: self.snapshot.clone(),
+        if self.snapshot.is_some() {
+            // Clap enforces that all of these are present when snapshot is.
+            builder = builder.image_info(ImageInfo {
+                snapshot: self.snapshot.clone().unwrap(),
+                image: self.image.clone().unwrap(),
+                image_description: self.image_description.clone().unwrap(),
+                image_os: self.image_os.clone().unwrap(),
+                image_version: self.image_version.clone().unwrap(),
             });
-
-        let finalize_response = request.send().await;
-
-        if let Err(e) = finalize_response {
-            eprintln_nopipe!("finalizing the disk failed with {:?}", e);
-
-            // Attempt to unwind the disk, although it will probably fail - the
-            // first step is to finalize the disk!
-            self.unwind_disk_finalize(client).await?;
-            self.unwind_disk_delete(client).await?;
-
-            return Err(e.into());
         }
 
-        // optionally, make an image out of that snapshot
-        if let Some(image_name) = &self.image {
-            let snapshot_name = self.snapshot.as_ref().unwrap();
-            let image_description = self.image_description.as_ref().unwrap();
-            let image_os = self.image_os.as_ref().unwrap();
-            let image_version = self.image_version.as_ref().unwrap();
+        let (import_future, handle) = builder.execute_with_control()?;
 
-            // at this point, unwinding is not as important as before. the user
-            // has uploaded their file to a disk and finalized that disk, making
-            // a snapshot out of it. if this step fails, they can always
-            // manually make an image out of the snapshot later and be sure that
-            // the snapshot's contents are the same.
-            let snapshot = client
-                .snapshot_view()
-                .project(&self.project)
-                .snapshot(NameOrId::Name(snapshot_name.clone()))
-                .send()
-                .await?;
+        let pb = ProgressBar::new(disk_info.file_size);
+        pb.set_style(ProgressStyle::default_bar().template(
+            "[{elapsed_precise}] [{wide_bar:.green}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta}",
+        )?);
+        pb.println(format!("Creating disk \"{}\"", &*self.disk));
+        let pb = start_progress_bar(handle.progress(), disk_info.file_size, &self.disk)?;
+        watch_for_ctrl_c(handle, pb);
 
-            client
-                .image_create()
-                .project(&self.project)
-                .body(ImageCreate {
-                    name: image_name.clone(),
-                    description: image_description.clone(),
-                    os: image_os.clone(),
-                    version: image_version.clone(),
-                    source: ImageSource::Snapshot(snapshot.id),
-                })
-                .send()
-                .await?;
-        }
+        import_future.await?;
 
-        println_nopipe!("done!");
-
+        println_nopipe!("Done!");
         Ok(())
     }
+}
+
+fn start_progress_bar(
+    mut progress_rx: watch::Receiver<u64>,
+    file_size: u64,
+    disk_name: &str,
+) -> Result<ProgressBar> {
+    let pb = ProgressBar::new(file_size);
+    pb.set_style(ProgressStyle::default_bar().template(
+        "[{elapsed_precise}] [{wide_bar:.green}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta}",
+    )?);
+    pb.set_position(0);
+    pb.println(format!("Creating disk \"{disk_name}\""));
+    let pb_updater = pb.clone();
+
+    tokio::spawn(async move {
+        loop {
+            match progress_rx.changed().await {
+                Ok(_) => {
+                    let p = *progress_rx.borrow();
+                    pb_updater.set_position(p);
+
+                    if p >= file_size {
+                        pb_updater.finish();
+                        return;
+                    }
+                }
+                Err(_) => return, // Sender has dropped.
+            }
+        }
+    });
+
+    Ok(pb)
+}
+
+fn watch_for_ctrl_c(handle: DiskImportHandle, pb: ProgressBar) {
+    tokio::spawn(async move {
+        let mut force_shutdown = false;
+        let mut handle = Some(handle);
+
+        loop {
+            signal::ctrl_c().await.expect("Failed to listen for CTRL+C");
+
+            if force_shutdown {
+                eprintln_nopipe!("Shutting down immediately.\nSee https://docs.oxide.computer/guides/troubleshooting#_cant_delete_disk_after_canceled_image_import for instructions on removing the disk.");
+
+                // Match exit code used by Bash on Unix, 128 + 2 (SIGINT).
+                process::exit(130);
+            }
+            force_shutdown = true;
+
+            pb.finish_and_clear();
+            pb.println("Cleaning up disk. Press CTRL+C again to exit immediately.");
+
+            if let Some(handle) = handle.take() {
+                handle.cancel();
+            }
+        }
+    });
 }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
 thiserror =  { workspace = true }
+tokio = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 uuid = { workspace = true }
@@ -29,6 +30,6 @@ uuid = { workspace = true }
 tokio = { workspace = true }
 
 [features]
-# TODO disable clap by default:
-default = ["clap"]
+default = []
 clap = ["dep:clap"]
+extras = []

--- a/sdk/src/extras/disk.rs
+++ b/sdk/src/extras/disk.rs
@@ -1,0 +1,807 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+use super::ClientExtraDiskExt;
+use crate::Client;
+
+impl ClientExtraDiskExt for Client {
+    fn disk_import(&self) -> builder::DiskImport {
+        builder::DiskImport::new(self)
+    }
+}
+
+pub mod builder {
+    use crate::extras::disk::types::{DiskImportError, DiskImportHandle, DiskInfo, ImageInfo};
+    use crate::types::{Name, NameOrId};
+    use crate::{Client, Error};
+
+    use std::future::Future;
+    use std::sync::atomic::{AtomicBool, AtomicU64};
+    use std::sync::Arc;
+    use tokio::sync::{oneshot, watch};
+
+    /// Builder for [`ClientExtraDiskExt::disk_import`]
+    ///
+    /// [`ClientExtraDiskExt::disk_import`]: super::ClientExtraDiskExt::disk_import
+    pub struct DiskImport<'a> {
+        client: &'a Client,
+        project: Result<NameOrId, String>,
+        description: Result<String, String>,
+        upload_thread_ct: Result<usize, String>,
+        disk: Result<Name, String>,
+        disk_info: Result<DiskInfo, String>,
+        image_info: Result<Option<ImageInfo>, String>,
+    }
+
+    impl<'a> DiskImport<'a> {
+        pub fn new(client: &'a Client) -> Self {
+            Self {
+                client,
+                project: Err("project was not initialized".to_string()),
+                description: Err("description was not initialized".to_string()),
+                upload_thread_ct: Err("upload_thread_ct was not initialized".to_string()),
+                disk: Err("disk was not initialized".to_string()),
+                disk_info: Err("disk_info was not initialized".to_string()),
+                image_info: Ok(None),
+            }
+        }
+
+        pub fn project<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<NameOrId>,
+        {
+            self.project = value
+                .try_into()
+                .map_err(|_| "conversion to `NameOrId` for project failed".to_string());
+            self
+        }
+
+        pub fn description<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.description = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for description failed".to_string());
+            self
+        }
+
+        pub fn upload_thread_ct<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<usize>,
+        {
+            self.upload_thread_ct = value
+                .try_into()
+                .map_err(|_| "conversion to `usize` for upload_thread_ct failed".to_string());
+            self
+        }
+
+        pub fn disk<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<Name>,
+        {
+            self.disk = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for disk failed".to_string());
+            self
+        }
+
+        pub fn disk_info(mut self, value: DiskInfo) -> Self {
+            self.disk_info = Ok(value);
+            self
+        }
+
+        pub fn image_info(mut self, value: ImageInfo) -> Self {
+            self.image_info = Ok(Some(value));
+            self
+        }
+
+        /// Return a `Future` for the disk creation and a `DiskImportHandle` which
+        /// can be used to track upload progress and cancel the job.
+        pub fn execute(
+            self,
+        ) -> Result<
+            impl Future<Output = Result<(), DiskImportError>> + 'a,
+            Error<crate::types::Error>,
+        > {
+            Ok(self.execute_with_control()?.0)
+        }
+
+        /// Return a `Future` for the disk creation and a `DiskImportHandle` which
+        /// can be used to track upload progress and cancel the import.
+        pub fn execute_with_control(
+            self,
+        ) -> Result<
+            (
+                impl Future<Output = Result<(), DiskImportError>> + 'a,
+                DiskImportHandle,
+            ),
+            Error<crate::types::Error>,
+        > {
+            let (progress_tx, progress_rx) = watch::channel(0);
+            let (cancel_tx, cancel_rx) = oneshot::channel();
+
+            let importer = super::types::DiskImport::try_from((self, progress_tx))?;
+            let handle = DiskImportHandle {
+                progress_rx,
+                cancel_tx,
+            };
+
+            Ok((importer.run_with_cancel(cancel_rx), handle))
+        }
+    }
+
+    impl<'a> TryFrom<(DiskImport<'a>, watch::Sender<u64>)> for super::types::DiskImport<'a> {
+        type Error = Error<crate::types::Error>;
+
+        fn try_from(input: (DiskImport<'a>, watch::Sender<u64>)) -> Result<Self, Self::Error> {
+            let (builder, progress_tx) = input;
+
+            let project = builder.project.map_err(Error::InvalidRequest)?;
+            let description = builder.description.map_err(Error::InvalidRequest)?;
+            let upload_thread_ct = builder.upload_thread_ct.map_err(Error::InvalidRequest)?;
+            let disk = builder.disk.map_err(Error::InvalidRequest)?;
+            let disk_info = builder.disk_info.map_err(Error::InvalidRequest)?;
+            let image_info = builder.image_info.map_err(Error::InvalidRequest)?;
+
+            let upload_progress = Arc::new(AtomicU64::new(0));
+
+            Ok(Self {
+                client: builder.client,
+                project,
+                description,
+                upload_thread_ct,
+                disk,
+                disk_info,
+                image_info,
+                upload_progress,
+                progress_tx,
+                cleanup_started: AtomicBool::new(false),
+            })
+        }
+    }
+}
+
+pub mod types {
+    use crate::types::{
+        self, BlockSize, ByteCount, DiskCreate, DiskSource, DiskState, FinalizeDisk, ImageCreate,
+        ImageSource, ImportBlocksBulkWrite, Name, NameOrId,
+    };
+    use crate::{
+        Client, ClientDisksExt, ClientImagesExt, ClientSnapshotsExt, Error, ResponseValue,
+    };
+
+    use base64::Engine;
+    use std::fs::{self, File};
+    use std::io::{self, Read};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::{mpsc, oneshot, watch};
+
+    // Upload to Nexus in 512k byte chunks
+    const CHUNK_SIZE: u64 = 512 * 1024;
+
+    #[derive(thiserror::Error, Debug)]
+    pub enum DiskImportError {
+        #[error("{err}")]
+        Wrapped {
+            err: Box<dyn std::error::Error + Send + Sync>,
+            source: Box<DiskImportError>,
+        },
+        #[error("{0}")]
+        Other(Box<dyn std::error::Error + Send + Sync>),
+        #[error(transparent)]
+        Api(#[from] crate::Error<types::Error>),
+        #[error(transparent)]
+        Conversion(#[from] types::error::ConversionError),
+        #[error(transparent)]
+        Io(#[from] io::Error),
+    }
+
+    impl DiskImportError {
+        pub fn context(
+            err: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+            source: impl Into<DiskImportError>,
+        ) -> Self {
+            DiskImportError::Wrapped {
+                err: err.into(),
+                source: Box::new(source.into()),
+            }
+        }
+
+        pub fn other(err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+            DiskImportError::Other(err.into())
+        }
+    }
+
+    /// Provides access to upload progress and cancellation for
+    /// a disk import.
+    #[derive(Debug)]
+    pub struct DiskImportHandle {
+        pub(super) progress_rx: watch::Receiver<u64>,
+        pub(super) cancel_tx: oneshot::Sender<()>,
+    }
+
+    impl DiskImportHandle {
+        /// Returns `tokio::sync::watch::Receiver` that reports the current number of bytes uploaded.
+        /// For use with progress reports.
+        pub fn progress(&self) -> watch::Receiver<u64> {
+            self.progress_rx.clone()
+        }
+
+        /// Attempt to cancel the disk upload. If the upload has completed and the disk is
+        /// finalized then this will not remove the disk.
+        pub fn cancel(self) {
+            // Err indicates DiskImport has dropped and request has completed, nothing to do.
+            let _ = self.cancel_tx.send(());
+        }
+    }
+
+    #[derive(Debug)]
+    pub(super) struct DiskImport<'a> {
+        pub client: &'a Client,
+        pub project: NameOrId,
+        pub description: String,
+        pub upload_thread_ct: usize,
+        pub disk: Name,
+        pub disk_info: DiskInfo,
+        pub image_info: Option<ImageInfo>,
+        pub upload_progress: Arc<AtomicU64>,
+        pub progress_tx: watch::Sender<u64>,
+        pub cleanup_started: AtomicBool,
+    }
+
+    impl<'a> DiskImport<'a> {
+        pub async fn run_with_cancel(
+            self,
+            cancel_rx: oneshot::Receiver<()>,
+        ) -> Result<(), DiskImportError> {
+            let result = tokio::select! {
+                biased; // Prioritize cancellation.
+                _ = cancel_rx => {
+                    Err(DiskImportError::other("Disk import canceled"))
+                }
+                result = self.do_disk_import() => result,
+            };
+
+            if let Err(e) = result {
+                if let Err(cleanup_err) = self.cleanup().await {
+                    return Err(DiskImportError::Wrapped {
+                        err: cleanup_err.into(),
+                        source: e.into(),
+                    });
+                }
+                return Err(e);
+            }
+
+            Ok(())
+        }
+
+        async fn do_disk_import(&self) -> Result<(), DiskImportError> {
+            self.check_for_existing_disk().await?;
+
+            // Create the disk in state "importing blocks"
+            self.client
+                .disk_create()
+                .project(self.project.clone())
+                .body(DiskCreate {
+                    name: self.disk.clone(),
+                    description: self.description.clone(),
+                    disk_source: DiskSource::ImportingBlocks {
+                        block_size: self.disk_info.disk_block_size.clone(),
+                    },
+                    size: self.disk_info.disk_size.clone(),
+                })
+                .send()
+                .await
+                .map_err(|e| DiskImportError::context("creating the disk failed", e))?;
+
+            // Start the bulk write process
+            self.client
+                .disk_bulk_write_import_start()
+                .project(self.project.clone())
+                .disk(self.disk.clone())
+                .send()
+                .await
+                .map_err(|e| {
+                    DiskImportError::context("starting the build write process failed", e)
+                })?;
+
+            // Create one tokio task for each thread that will upload file chunks
+            let mut handles: Vec<tokio::task::JoinHandle<Result<(), DiskImportError>>> =
+                Vec::with_capacity(self.upload_thread_ct);
+            let mut senders = Vec::with_capacity(self.upload_thread_ct);
+
+            for _ in 0..self.upload_thread_ct {
+                let (tx, mut rx) = mpsc::channel(100);
+
+                let client = self.client.clone();
+                let project = self.project.clone();
+                let disk = self.disk.clone();
+                let upload_progress = self.upload_progress.clone();
+                let progress_tx = self.progress_tx.clone();
+
+                handles.push(tokio::spawn(async move {
+                    while let Some((offset, base64_encoded_data, data_len)) = rx.recv().await {
+                        client
+                            .disk_bulk_write_import()
+                            .disk(disk.clone())
+                            .project(project.clone())
+                            .body(ImportBlocksBulkWrite {
+                                offset,
+                                base64_encoded_data,
+                            })
+                            .send()
+                            .await?;
+
+                        upload_progress.fetch_add(data_len, Ordering::Relaxed);
+                        progress_tx.send_replace(upload_progress.load(Ordering::Relaxed));
+                    }
+
+                    Ok(())
+                }));
+
+                senders.push(tx);
+            }
+
+            // Read chunks from the file in the file system and send them to the
+            // upload threads.
+            let mut file = File::open(&self.disk_info.file_path)?;
+            let mut i = 0;
+            let mut offset = 0;
+
+            let read_result: Result<(), DiskImportError> = loop {
+                let mut chunk = Vec::with_capacity(CHUNK_SIZE as usize);
+
+                let n = match file.by_ref().take(CHUNK_SIZE).read_to_end(&mut chunk) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        break Err(DiskImportError::context(
+                            format!("reading from {} failed", self.disk_info.file_path.display()),
+                            e,
+                        ));
+                    }
+                };
+
+                if n == 0 {
+                    break Ok(());
+                }
+
+                // If the chunk we just read is all zeroes, don't POST it.
+                if !chunk.iter().all(|x| *x == 0) {
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&chunk[0..n]);
+
+                    if let Err(e) = senders[i % self.upload_thread_ct]
+                        .send((offset, encoded, n as u64))
+                        .await
+                    {
+                        break Err(DiskImportError::other(format!(
+                            "sending chunk to thread failed: {e}"
+                        )));
+                    }
+                } else {
+                    // Bump the progress bar here to make it consistent
+                    self.upload_progress.fetch_add(n as u64, Ordering::Relaxed);
+                    self.progress_tx
+                        .send_replace(self.upload_progress.load(Ordering::Relaxed));
+                }
+
+                offset += CHUNK_SIZE;
+                i += 1;
+            };
+
+            for tx in senders {
+                drop(tx);
+            }
+
+            read_result?;
+
+            let mut results = Vec::with_capacity(handles.len());
+            for handle in handles {
+                let result = handle.await.map_err(DiskImportError::other)?;
+                results.push(result);
+            }
+
+            if results.iter().any(|x| x.is_err()) {
+                return Err(DiskImportError::other("one of the upload threads failed"));
+            }
+
+            // Stop the bulk write process
+            self.client
+                .disk_bulk_write_import_stop()
+                .project(self.project.clone())
+                .disk(self.disk.clone())
+                .send()
+                .await
+                .map_err(|e| {
+                    DiskImportError::context("stopping the bulk write process failed", e)
+                })?;
+
+            // Finalize the disk, optionally making a snapshot
+            self.client
+                .disk_finalize_import()
+                .project(self.project.clone())
+                .disk(self.disk.clone())
+                .body(FinalizeDisk {
+                    snapshot_name: self.image_info.as_ref().map(|ii| ii.snapshot.clone()),
+                })
+                .send()
+                .await
+                .map_err(|e| DiskImportError::context("finalizing the disk failed", e))?;
+
+            if self.image_info.is_some() {
+                self.create_image().await?;
+            }
+
+            Ok(())
+        }
+
+        async fn create_image(&self) -> Result<(), DiskImportError> {
+            let Some(image_info) = &self.image_info else {
+                return Err(DiskImportError::other("no snapshot provided"));
+            };
+
+            // At this point, unwinding is not as important as before. the user
+            // has uploaded their file to a disk and finalized that disk, making
+            // a snapshot out of it. if this step fails, they can always
+            // manually make an image out of the snapshot later and be sure that
+            // the snapshot's contents are the same.
+            let snapshot_id = self
+                .client
+                .snapshot_view()
+                .project(&self.project)
+                .snapshot(image_info.snapshot.clone())
+                .send()
+                .await
+                .map_err(|e| DiskImportError::context("failed to fetch snapshot", e))?;
+
+            self.client
+                .image_create()
+                .project(&self.project)
+                .body(ImageCreate {
+                    name: image_info.image.clone(),
+                    description: image_info.image_description.clone(),
+                    os: image_info.image_os.clone(),
+                    version: image_info.image_version.clone(),
+                    source: ImageSource::Snapshot(snapshot_id.id),
+                })
+                .send()
+                .await
+                .map_err(|e| DiskImportError::context("failed to create image", e))?;
+
+            Ok(())
+        }
+
+        async fn cleanup(&self) -> Result<(), DiskImportError> {
+            if self
+                .cleanup_started
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                return Ok(());
+            }
+
+            let disk_state = match self.wait_for_disk().await {
+                Ok(state) => state,
+                Err(e) => match e {
+                    // No disk, no problem.
+                    Error::ErrorResponse(rv) if rv.status() == 404 => return Ok(()),
+                    _ => Err(e)?,
+                },
+            };
+
+            // Disk is not partially imported, no cleanup needed.
+            if !matches!(
+                disk_state,
+                DiskState::ImportReady
+                    | DiskState::ImportingFromBulkWrites
+                    | DiskState::ImportingFromUrl
+                    | DiskState::Finalizing
+            ) {
+                return Ok(());
+            }
+
+            if matches!(disk_state, DiskState::ImportingFromBulkWrites) {
+                self.unwind_disk_bulk_write_stop().await?;
+            }
+
+            self.unwind_disk_finalize().await?;
+            self.unwind_disk_delete().await
+        }
+
+        async fn check_for_existing_disk(&self) -> Result<(), DiskImportError> {
+            err_if_object_exists(
+                format!("disk \"{}\" exists already", &*self.disk),
+                self.client
+                    .disk_view()
+                    .project(&self.project)
+                    .disk(self.disk.clone())
+                    .send()
+                    .await,
+            )?;
+
+            if let Some(image_info) = &self.image_info {
+                err_if_object_exists(
+                    format!("snapshot \"{}\" exists already", &*image_info.snapshot),
+                    self.client
+                        .snapshot_view()
+                        .project(&self.project)
+                        .snapshot(image_info.snapshot.clone())
+                        .send()
+                        .await,
+                )?;
+
+                err_if_object_exists(
+                    format!("image \"{}\" exists already", &*image_info.image),
+                    self.client
+                        .image_view()
+                        .project(&self.project)
+                        .image(image_info.image.clone())
+                        .send()
+                        .await,
+                )?;
+            }
+
+            Ok(())
+        }
+
+        async fn get_disk_state(&self) -> Result<DiskState, Error<types::Error>> {
+            let response = self
+                .client
+                .disk_view()
+                .project(&self.project)
+                .disk(self.disk.clone())
+                .send()
+                .await?;
+
+            Ok(response.into_inner().state)
+        }
+
+        /// A shutdown may race with the newly created disk transitioning from Created
+        /// to ImportReady state. Wait until the disk has moved past Created before
+        /// attempting tear it down.
+        async fn wait_for_disk(&self) -> Result<DiskState, Error<types::Error>> {
+            const RETRY_CT: usize = 10;
+            const RETRY_DELAY: Duration = Duration::from_millis(500);
+
+            let mut disk_state = self.get_disk_state().await?;
+
+            for _ in 0..RETRY_CT {
+                if !matches!(disk_state, DiskState::Creating) {
+                    return Ok(disk_state);
+                }
+
+                tokio::time::sleep(RETRY_DELAY).await;
+                disk_state = self.get_disk_state().await?;
+            }
+
+            Err(Error::InvalidRequest(
+                "disk remained in \"Creating\" state for more than 5 seconds".to_string(),
+            ))
+        }
+
+        async fn unwind_disk_delete(&self) -> Result<(), DiskImportError> {
+            self.client
+                .disk_delete()
+                .project(&self.project)
+                .disk(self.disk.clone())
+                .send()
+                .await
+                .map_err(|e| {
+                    DiskImportError::context(
+                        format!("trying to unwind, deleting \"{}\" failed", &*self.disk),
+                        e,
+                    )
+                })?;
+
+            Ok(())
+        }
+
+        async fn unwind_disk_finalize(&self) -> Result<(), DiskImportError> {
+            self.client
+                .disk_finalize_import()
+                .project(&self.project)
+                .disk(self.disk.clone())
+                .send()
+                .await
+                .map_err(|e| {
+                    DiskImportError::context(
+                        format!("trying to unwind, finalizing \"{}\" failed", &*self.disk),
+                        e,
+                    )
+                })?;
+
+            Ok(())
+        }
+
+        async fn unwind_disk_bulk_write_stop(&self) -> Result<(), DiskImportError> {
+            self.client
+                .disk_bulk_write_import_stop()
+                .project(&self.project)
+                .disk(self.disk.clone())
+                .send()
+                .await
+                .map_err(|e| {
+                    DiskImportError::context(
+                        format!(
+                            "trying to unwind, stopping the bulk write process for \"{}\"",
+                            &*self.disk
+                        ),
+                        e,
+                    )
+                })?;
+
+            Ok(())
+        }
+    }
+
+    /// The information required to create a `Disk`.
+    #[derive(Clone, Debug)]
+    pub struct DiskInfo {
+        /// The path to the file
+        pub file_path: PathBuf,
+
+        /// The size of the file in bytes
+        pub file_size: u64,
+
+        /// The size of the disk in bytes
+        pub disk_size: ByteCount,
+
+        /// The block size of the disk
+        pub disk_block_size: BlockSize,
+    }
+
+    impl DiskInfo {
+        /// Determine the `DiskInfo` for an image file.
+        pub fn calculate(
+            file_path: PathBuf,
+            requested_disk_size: Option<&ByteCount>,
+            requested_disk_block_size: Option<&BlockSize>,
+        ) -> Result<DiskInfo, DiskImportError> {
+            if !Path::new(&file_path).exists() {
+                return Err(DiskImportError::other(format!(
+                    "path {} does not exist",
+                    file_path.display()
+                )));
+            }
+
+            let file_size = fs::metadata(&file_path)?.len();
+            let disk_size = Self::get_disk_size(file_size, requested_disk_size.map(|x| **x)).into();
+
+            let disk_block_size = match requested_disk_block_size {
+                Some(v) => v.clone(),
+                None => BlockSize::try_from(512)?,
+            };
+
+            if (file_size % *disk_block_size as u64) != 0 {
+                return Err(DiskImportError::other(format!(
+                    "file size {file_size} is not divisible by block size {}!",
+                    *disk_block_size
+                )));
+            }
+
+            Ok(DiskInfo {
+                file_path,
+                file_size,
+                disk_size,
+                disk_block_size,
+            })
+        }
+
+        /// Return a disk size that Nexus will accept for the path and size arguments
+        fn get_disk_size(file_size: u64, size: Option<u64>) -> u64 {
+            const ONE_GB: u64 = 1024 * 1024 * 1024;
+
+            let disk_size = if let Some(size) = size {
+                size
+            } else {
+                file_size
+            };
+
+            // Nexus' disk size minimum is 1 GB, and Nexus only supports disks whose
+            // size is a multiple of 1 GB
+            if disk_size % ONE_GB != 0 {
+                let rounded_down_gb: u64 = disk_size - disk_size % ONE_GB;
+                assert_eq!(rounded_down_gb % ONE_GB, 0);
+                rounded_down_gb + ONE_GB
+            } else {
+                disk_size
+            }
+        }
+    }
+
+    fn err_if_object_exists<T>(
+        error_msg: String,
+        send_response: Result<ResponseValue<T>, Error<types::Error>>,
+    ) -> Result<(), crate::Error<crate::types::Error>> {
+        match send_response {
+            Ok(_) => {
+                return Err(Error::InvalidRequest(error_msg));
+            }
+
+            Err(e) => {
+                match &e {
+                    // Match against 404
+                    crate::Error::ErrorResponse(response_value) => {
+                        if response_value.status() == 404 {
+                            // ok
+                        } else {
+                            Err(e)?
+                        }
+                    }
+
+                    // Bail on any other error
+                    _ => Err(e)?,
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The information required to create an `Image`.
+    #[derive(Clone, Debug)]
+    pub struct ImageInfo {
+        /// The name of the snapshot
+        pub snapshot: Name,
+
+        /// The name of the image
+        pub image: Name,
+
+        /// Human-readable free-form text about the image
+        pub image_description: String,
+
+        /// The name of the image's operating system
+        pub image_os: String,
+
+        /// The version of the image's operating system
+        pub image_version: String,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_get_disk_size() {
+            let file_size = 1; //"not relevant because we're supplying a size.
+
+            // test rounding up
+            assert_eq!(
+                DiskInfo::get_disk_size(file_size, Some(1)),
+                1024 * 1024 * 1024,
+            );
+
+            assert_eq!(
+                DiskInfo::get_disk_size(file_size, Some(1024 * 1024 * 1024 - 1)),
+                1024 * 1024 * 1024,
+            );
+
+            // test even multiples of GB
+            assert_eq!(
+                DiskInfo::get_disk_size(file_size, Some(1024 * 1024 * 1024)),
+                1024 * 1024 * 1024,
+            );
+
+            assert_eq!(
+                DiskInfo::get_disk_size(file_size, Some(2 * 1024 * 1024 * 1024)),
+                2 * 1024 * 1024 * 1024,
+            );
+
+            // test non-even multiples of GB
+            assert_eq!(
+                DiskInfo::get_disk_size(file_size, Some(2 * 1024 * 1024 * 1024 + 1)),
+                3 * 1024 * 1024 * 1024,
+            );
+
+            assert_eq!(
+                DiskInfo::get_disk_size(file_size, Some(3 * 1024 * 1024 * 1024 - 1)),
+                3 * 1024 * 1024 * 1024,
+            );
+        }
+    }
+}

--- a/sdk/src/extras/mod.rs
+++ b/sdk/src/extras/mod.rs
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+//! The `extra` feature adds additional, non-generated, compound interfaces to
+//! the [`Client`](super::generated_sdk::Client). It is intended for methods
+//! that are functional rather than for those that offer enhanced output or a
+//! simplified interface. (This is why the the CLI uses a disk import interface
+//! from here, but has a number of custom network subcommands that pretty-print
+//! or provide a simpler user interface for common use cases.)
+//!
+//! These interfaces operate very similarly to the generated interfaces.
+
+pub mod disk;
+
+pub trait ClientExtraDiskExt {
+    /// A convenience wrapper around the SDK to simplify disk creation.
+    /// Create a disk, optionally with a snapshot and image. The standard
+    /// disk import methods in the SDK will frequently leave the partially
+    /// imported disks when interrupted or an error occurs. This extension
+    /// will attempt to cleanup the disk.
+    ///
+    /// Arguments:
+    /// - `project`: Name or ID of the project
+    /// - `description`: Human-readable free-form text about the disk
+    /// - `upload_thread_ct`: The number of threads used to upload the disk
+    /// - `disk`: Name of the disk
+    /// - `disk_info`: Information needed to construct the disk
+    /// - `image_info`: Information needed to construct a snapshot and image, optional
+    ///
+    /// The [`execute`](disk::builder::DiskImport::execute) method is equivalent to the
+    /// `send` method used in standard SDK actions.
+    /// ```ignore
+    /// client.disk_import()
+    ///    .project(project)
+    ///    .description(description)
+    ///    .upload_thread_ct(upload_thread_ct)
+    ///    .disk(disk)
+    ///    .disk_info(disk_info)
+    ///    .image_info(image_info)
+    ///    .execute()?.await?;
+    /// ```
+    ///
+    /// The [`execute_with_control`](disk::builder::DiskImport::execute_with_control)
+    /// method returns a future for the import and a [`DiskImportHandle`](disk::types::DiskImportHandle).
+    /// The handle exposes a [`progress`](disk::types::DiskImportHandle::progress) method
+    /// to check the current number of bytes uploaded, and a
+    /// [`cancel`](disk::types::DiskImportHandle::cancel) method that will stop the
+    /// import and remove the new disk.
+    /// ```ignore
+    /// let (import_future, handle) = client.disk_import()
+    ///    .project(project)
+    ///    .description(description)
+    ///    .upload_thread_ct(upload_thread_ct)
+    ///    .disk(disk)
+    ///    .disk_info(disk_info)
+    ///    .image_info(image_info)
+    ///    .execute_with_control()?;
+    ///
+    /// let pb = ProgressBar::new();
+    /// let progress_rx = handler.progress();
+    /// tokio::spawn(async move {
+    ///     loop {
+    ///         _ = tokio::signal::ctrl_c() => {
+    ///            handle.cancel();
+    ///         }
+    ///         _ = progress_rx.changed() => {
+    ///             pb.set_position(*progress_rs.borrow());
+    ///         }
+    ///     }
+    /// });
+    ///
+    /// import_future.await?;
+    /// ```
+    fn disk_import(&self) -> disk::builder::DiskImport;
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,10 +12,10 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 mod auth;
-mod generated_sdk;
-
 #[cfg(feature = "clap")]
 mod clap_feature;
+pub mod extras;
+mod generated_sdk;
 
 pub use auth::*;
 pub use generated_sdk::*;


### PR DESCRIPTION
From a user perspective uploading a disk is a single operation, but doing so via the SDK is a very involved process, involving stringing together multiple API calls with any interruption leaving the disk in a state that cannot be directly removed.

Add a new `extras` module to the SDK that will contain convenience wrappers around actions that functions that are overly complicated. Create a `disk_import` function in `extras` that will perform a disk upload as a single step, and attempts to cleanup partially imported disks on failure. We make the `disk upload` CLI command a thin wrapper around the new SDK function, responsible only for cancellation and progress. We manually recreate the builder interface, as creating a procmacro to do this would require creating a new crate. If/when `extras` continues to grow we should reconsider this.

`disk_import` also give callers access to a `DiskImportHandle` with a `watch` channel with the current number of bytes uploaded for use in progress tracking, and provides a `cancel` function that allows users to gracefully stop the disk upload. A disk that has been successfully created will not be removed, only those that are partially imported.

The `cancel` function uses `tokio::select` to cancel the `Future` of the upload task. This should be safe in our in our case no locks are held across `await` points. No operations need to be safe to restart as we only call `tokio::select` a single time, they will be dropped immediately and losing a message is not a problem.

We are forced to remove tests `test_disk_import_bulk_import_start_fail` and `test_disk_import_bulk_write_import_fail` as we now poll for disks in `Created` state, which may happen if a user immediately cancels a new request. This state is not eligible to be finalized, so we need to wait for the disk to progress to the next state, but `HttpMock` does not provide a way to programatically delete or update a mock after sending `n` responses. This means that the disk will always be returned as non-existing when querying, and cleanup will be skipped. I have opened https://github.com/alexliesenfeld/httpmock/pull/108 to add a `delete_after_n` method, but this seems unlikely to be merged. We may want to consider moving to `wiremock` in the long term, which provides this functionality.