### PR TITLE
Update CLI code for `name_or_id` renamed to `announce_set`

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -4475,7 +4475,7 @@
                 {
                   "name": "announce",
                   "about": "Announce a prefix over BGP.",
-                  "long_about": "Announce a prefix over BGP.\n\nThis command adds the provided prefix to the specified announce set. It is\nrequired that the prefix be available in the given address lot. The add is\nperformed as a read-modify-write on the specified address lot.",
+                  "long_about": "Announce a prefix over BGP.\n\nThis command adds the provided prefix to the specified announce set. It is\nrequired that the prefix be available in the given address lot. The add is\nperformed as a read-modify-write on the announce set.",
                   "args": [
                     {
                       "long": "address-lot",
@@ -5213,7 +5213,7 @@
                 {
                   "name": "withdraw",
                   "about": "Withdraw a prefix over BGP.",
-                  "long_about": "Withdraw a prefix over BGP.\n\nThis command removes the provided prefix to the specified announce set.\nThe remove is performed as a read-modify-write on the specified address lot.",
+                  "long_about": "Withdraw a prefix over BGP.\n\nThis command removes the provided prefix from the specified announce set.\nThe remove is performed as a read-modify-write on the announce set.",
                   "args": [
                     {
                       "long": "announce-set",

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -4514,8 +4514,8 @@
                       "about": "Delete BGP announce set",
                       "args": [
                         {
-                          "long": "name-or-id",
-                          "help": "A name or id to use when selecting BGP port settings"
+                          "long": "announce-set",
+                          "help": "Name or ID of the announce set"
                         },
                         {
                           "long": "profile",
@@ -4531,10 +4531,6 @@
                         {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
-                        },
-                        {
-                          "long": "name-or-id",
-                          "help": "A name or id to use when s electing BGP port settings"
                         },
                         {
                           "long": "page-token",
@@ -4598,8 +4594,8 @@
                       "about": "Get originated routes for a specified BGP announce set",
                       "args": [
                         {
-                          "long": "name-or-id",
-                          "help": "A name or id to use when selecting BGP port settings"
+                          "long": "announce-set",
+                          "help": "Name or ID of the announce set"
                         },
                         {
                           "long": "profile",
@@ -4748,10 +4744,6 @@
                         {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
-                        },
-                        {
-                          "long": "name-or-id",
-                          "help": "A name or id to use when selecting BGP config."
                         },
                         {
                           "long": "profile",

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -247,7 +247,7 @@ enum BgpSubCommand {
 ///
 /// This command adds the provided prefix to the specified announce set. It is
 /// required that the prefix be available in the given address lot. The add is
-/// performed as a read-modify-write on the specified address lot.
+/// performed as a read-modify-write on the announce set.
 #[derive(Parser, Debug, Clone)]
 #[command(verbatim_doc_comment)]
 #[command(name = "announce")]
@@ -305,8 +305,8 @@ impl AuthenticatedCmd for CmdBgpAnnounce {
 
 /// Withdraw a prefix over BGP.
 ///
-/// This command removes the provided prefix to the specified announce set.
-/// The remove is performed as a read-modify-write on the specified address lot.
+/// This command removes the provided prefix from the specified announce set.
+/// The remove is performed as a read-modify-write on the announce set.
 #[derive(Parser, Debug, Clone)]
 #[command(verbatim_doc_comment)]
 #[command(name = "withdraw")]

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -273,7 +273,7 @@ impl AuthenticatedCmd for CmdBgpAnnounce {
     async fn run(&self, client: &Client) -> Result<()> {
         let mut current: Vec<BgpAnnouncementCreate> = client
             .networking_bgp_announcement_list()
-            .name_or_id(NameOrId::Name(self.announce_set.clone()))
+            .announce_set(NameOrId::Name(self.announce_set.clone()))
             .send()
             .await?
             .into_inner()
@@ -325,7 +325,7 @@ impl AuthenticatedCmd for CmdBgpWithdraw {
     async fn run(&self, client: &Client) -> Result<()> {
         let mut current: Vec<BgpAnnouncementCreate> = client
             .networking_bgp_announcement_list()
-            .name_or_id(NameOrId::Name(self.announce_set.clone()))
+            .announce_set(NameOrId::Name(self.announce_set.clone()))
             .send()
             .await?
             .into_inner()


### PR DESCRIPTION
This is on top of the `integration` branch. I actually don't know how this sort of thing is done in this repo, but in any case here is the fix that needs to be done when the latest schema changes are brought into main so the CLI will compile.