### PR TITLE
Expand permitted ByteCount formatting

### DIFF
--- a/sdk/src/clap_feature.rs
+++ b/sdk/src/clap_feature.rs
@@ -39,9 +39,9 @@ impl clap::builder::TypedValueParser for ByteCountParser {
                 .unwrap_or(value.len());
 
             let number = &value[..ii];
-            let suffix = &value[ii..];
+            let suffix = value[ii..].trim_ascii_start().to_lowercase();
 
-            let multiple = match suffix {
+            let multiple = match suffix.as_ref() {
                 "kib" | "k" => 1024,
                 "mib" | "m" => 1024 * 1024,
                 "gib" | "g" => 1024 * 1024 * 1024,
@@ -196,6 +196,16 @@ mod tests {
         struct Cmd {
             x: ByteCount,
         }
+
+        let Ok(cmd) = Cmd::try_parse_from(vec!["", "1 k"]) else {
+            panic!()
+        };
+        assert_eq!(cmd.x.0, 1024);
+
+        let Ok(cmd) = Cmd::try_parse_from(vec!["", "1GiB"]) else {
+            panic!()
+        };
+        assert_eq!(cmd.x.0, 1024 * 1024 * 1024);
 
         let Err(err) = Cmd::try_parse_from(vec!["", "1.21jiggabytes"]) else {
             panic!()


### PR DESCRIPTION
Currently we require size suffixes to `ByteCount` arguments to be lowercase and directly after the numerals. Users may expect to pass an argument with upper case suffixes, e.g., GiB, or with a space before the unit, e.g., `oxide instance create --memory '1 gib'.

Update the `TypedValueParser` for `ByteCount` to ignore case and permit spaces within the argument.