### PR TITLE
Add unit help to all ByteCount fields

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -474,7 +474,7 @@
             },
             {
               "long": "size",
-              "help": "The total size of the Disk. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
+              "help": "The total size of the Disk; unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib"
             }
           ]
         },
@@ -520,7 +520,7 @@
             },
             {
               "long": "disk-size",
-              "help": "The size of the disk to create. If unspecified, the size of the file will be used, rounded up to the nearest GB. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
+              "help": "The size of the disk to create. If unspecified, the size of the file will be used, rounded up to the nearest GB; unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib"
             },
             {
               "long": "image",
@@ -1425,7 +1425,7 @@
             },
             {
               "long": "memory",
-              "help": "The amount of RAM to be allocated to the instance. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
+              "help": "The amount of RAM to be allocated to the instance; unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib"
             },
             {
               "long": "name"
@@ -1680,7 +1680,7 @@
             },
             {
               "long": "memory",
-              "help": "Amount of RAM to be allocated to the instance. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
+              "help": "Amount of RAM to be allocated to the instance; unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib"
             },
             {
               "long": "name",
@@ -1701,7 +1701,7 @@
             },
             {
               "long": "size",
-              "help": "Boot disk size. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
+              "help": "Boot disk size; unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib"
             },
             {
               "long": "start",
@@ -3726,7 +3726,7 @@
                 },
                 {
                   "long": "memory",
-                  "help": "The amount of RAM available for running instances in the Silo. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
+                  "help": "The amount of RAM available for running instances in the Silo; unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib"
                 },
                 {
                   "long": "profile",
@@ -3739,7 +3739,7 @@
                 },
                 {
                   "long": "storage",
-                  "help": "The amount of storage available for disks or snapshots. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
+                  "help": "The amount of storage available for disks or snapshots; unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib"
                 }
               ]
             },

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -474,7 +474,7 @@
             },
             {
               "long": "size",
-              "help": "The total size of the Disk (in bytes)"
+              "help": "The total size of the Disk. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
             }
           ]
         },
@@ -520,7 +520,7 @@
             },
             {
               "long": "disk-size",
-              "help": "The size of the disk to create. If unspecified, the size of the file will be used, rounded up to the nearest GB"
+              "help": "The size of the disk to create. If unspecified, the size of the file will be used, rounded up to the nearest GB. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
             },
             {
               "long": "image",
@@ -1425,7 +1425,7 @@
             },
             {
               "long": "memory",
-              "help": "The amount of RAM (in bytes) to be allocated to the instance"
+              "help": "The amount of RAM to be allocated to the instance. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
             },
             {
               "long": "name"
@@ -1668,11 +1668,11 @@
           "args": [
             {
               "long": "description",
-              "help": "Description of the instance to create"
+              "help": "Description of the instance"
             },
             {
               "long": "hostname",
-              "help": "Hostname of the instance to create"
+              "help": "The hostname to be assigned to the instance"
             },
             {
               "long": "image",
@@ -1680,7 +1680,7 @@
             },
             {
               "long": "memory",
-              "help": "Instance memory e.g 32M. Suffix can be k,m,g,t"
+              "help": "Amount of RAM to be allocated to the instance. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
             },
             {
               "long": "name",
@@ -1688,7 +1688,7 @@
             },
             {
               "long": "ncpus",
-              "help": "Instance CPU count"
+              "help": "Number of vCPUs to be allocated to the instance"
             },
             {
               "long": "profile",
@@ -1701,7 +1701,7 @@
             },
             {
               "long": "size",
-              "help": "Boot disk size e.g. 512G. Suffix can be k,m,g,t"
+              "help": "Boot disk size. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
             },
             {
               "long": "start",
@@ -3726,7 +3726,7 @@
                 },
                 {
                   "long": "memory",
-                  "help": "The amount of RAM (in bytes) available for running instances in the Silo"
+                  "help": "The amount of RAM available for running instances in the Silo. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
                 },
                 {
                   "long": "profile",
@@ -3739,7 +3739,7 @@
                 },
                 {
                   "long": "storage",
-                  "help": "The amount of storage (in bytes) available for disks or snapshots"
+                  "help": "The amount of storage available for disks or snapshots. Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib)."
                 }
               ]
             },

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -640,7 +640,7 @@ impl CommandExt for Command {
 /// For Args that take a `ByteCount`, append a message on the unit formatting accepted and remove
 /// any reference to the field taking bytes as an argument.
 fn update_byte_count_help(arg: Arg) -> Arg {
-    const UNIT_HINT: &str = "Units are in powers of two (e.g., 1k = 1024 bytes); use suffixes like k, KiB (e.g., 6GiB, 512k, 2048mib).";
+    const UNIT_HINT: &str = "unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib
 
     let parser = arg.get_value_parser();
     if parser.type_id() == TypeId::of::<ByteCount>() {

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -650,7 +650,7 @@ fn update_byte_count_help(arg: Arg) -> Arg {
             .map(|h| h.to_string().replace(" (in bytes)", ""));
 
         arg.help(match old_help {
-            Some(old) => format!("{old}. {UNIT_HINT}"),
+            Some(old) => format!("{old}; {UNIT_HINT}"),
             None => UNIT_HINT.to_string(),
         })
     } else {

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -640,7 +640,8 @@ impl CommandExt for Command {
 /// For Args that take a `ByteCount`, append a message on the unit formatting accepted and remove
 /// any reference to the field taking bytes as an argument.
 fn update_byte_count_help(arg: Arg) -> Arg {
-    const UNIT_HINT: &str = "unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib
+    const UNIT_HINT: &str =
+        "unit suffixes are in powers of two (1k = 1024 bytes) for example: 6GiB, 512k, 2048mib";
 
     let parser = arg.get_value_parser();
     if parser.type_id() == TypeId::of::<ByteCount>() {

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -221,19 +221,19 @@ pub struct CmdInstanceFromImage {
     #[clap(long)]
     project: NameOrId,
 
-    /// Description of the instance to create
+    /// Description of the instance
     #[clap(long)]
     description: String,
 
-    /// Hostname of the instance to create
+    /// The hostname to be assigned to the instance
     #[clap(long)]
     hostname: String,
 
-    /// Instance memory e.g 32M. Suffix can be k,m,g,t
+    /// Amount of RAM to be allocated to the instance
     #[clap(long)]
     memory: ByteCount,
 
-    /// Instance CPU count
+    /// Number of vCPUs to be allocated to the instance
     #[clap(long)]
     ncpus: InstanceCpuCount,
 
@@ -241,7 +241,7 @@ pub struct CmdInstanceFromImage {
     #[clap(long)]
     image: NameOrId,
 
-    /// Boot disk size e.g. 512G. Suffix can be k,m,g,t
+    /// Boot disk size
     #[clap(long)]
     size: ByteCount,
 


### PR DESCRIPTION
The help strings for API fields accepting a `ByteCount` have a dilemma. For users directly consuming the API, or via the SDK, we need to make it clear that they should use bytes as the type name suggests. For CLI, however, we want to encourage users to pass unit suffixes for ease of use. Help text that emphasizes bytes will lead users to write out values in bytes, an annoying and error-prone process.

With https://github.com/oxidecomputer/omicron/pull/6737 we have updated the doc strings on all external API `ByteCount` fields to include the string "(in bytes)". Add a function to update all CLI `ByteCount` args and remove that string, appending a help message explaining the units we accept. While we're at it, also harmonize all CLI-specific `ByteCount` doc strings.

Closes https://github.com/oxidecomputer/oxide.rs/issues/854