### PR TITLE
`instance from-image` should set the disk as the boot disk

### DIFF
--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -267,7 +267,7 @@ impl crate::AuthenticatedCmd for CmdInstanceFromImage {
             .body_map(|body| {
                 body.name(self.name.clone())
                     .description(self.description.clone())
-                    .disks(vec![InstanceDiskAttachment::Create {
+                    .boot_disk(InstanceDiskAttachment::Create {
                         description: format!("{} disk", *self.name),
                         disk_source: DiskSource::Image {
                             image_id: image_view.id,
@@ -276,7 +276,7 @@ impl crate::AuthenticatedCmd for CmdInstanceFromImage {
                             .parse()
                             .expect("valid disk name"),
                         size: self.size.clone(),
-                    }])
+                    })
                     .external_ips(vec![ExternalIpCreate::Ephemeral { pool: None }])
                     .hostname(self.hostname.clone())
                     .memory(self.memory.clone())


### PR DESCRIPTION
As of https://github.com/oxidecomputer/omicron/pull/6585, we can set a boot disk at instance create time. Because `instance from-image` always creates exactly one disk, we simply move that disk attachment from the `disks` param to the `boot_disk` param.