### PR TITLE
Fix `--debug` flag

### DIFF
--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -229,9 +229,11 @@ impl<'a> NewCli<'a> {
             timeout,
         } = OxideCli::from_arg_matches(&matches).unwrap();
 
+        let mut log_builder = env_logger::builder();
         if debug {
-            env_logger::builder().filter_level(LevelFilter::Debug);
+            log_builder.filter_level(LevelFilter::Debug);
         }
+        log_builder.init();
 
         let mut client_config = ClientConfig::default();
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -98,8 +98,6 @@ pub fn make_cli() -> NewCli<'static> {
 
 #[tokio::main]
 async fn main() {
-    env_logger::init();
-
     let new_cli = make_cli();
 
     // Spawn a task so we get this potentially chunky Future off the

--- a/cli/tests/test_auth.rs
+++ b/cli/tests/test_auth.rs
@@ -568,3 +568,23 @@ fn test_cmd_auth_status_env() {
         ));
     oxide_mock.assert();
 }
+
+#[test]
+fn test_cmd_auth_debug_logging() {
+    let server = MockServer::start();
+    let bad_url = "sys.oxide.invalid";
+
+    // Validate debug logs are printed
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "oxide-token-bad")
+        .arg("--debug")
+        .arg("auth")
+        .arg("login")
+        .arg("--host")
+        .arg(bad_url)
+        .assert()
+        .failure()
+        .stderr(str::contains("DEBUG"));
+}

--- a/cli/tests/test_auth.rs
+++ b/cli/tests/test_auth.rs
@@ -571,14 +571,11 @@ fn test_cmd_auth_status_env() {
 
 #[test]
 fn test_cmd_auth_debug_logging() {
-    let server = MockServer::start();
     let bad_url = "sys.oxide.invalid";
 
     // Validate debug logs are printed
     Command::cargo_bin("oxide")
         .unwrap()
-        .env("OXIDE_HOST", server.url(""))
-        .env("OXIDE_TOKEN", "oxide-token-bad")
         .arg("--debug")
         .arg("auth")
         .arg("login")


### PR DESCRIPTION
Currently the `--debug` flag does not actually enable debug logging as
intended. We initialize `env_logger` immediately in `main`, then attempt
to change the log filtering level in `NewCli::run` if the `--debug` flag
is passed. This does not work, as `env_logger::builder` needs its `init`
method to be called to change the global logger. This is not an option,
as we've already called `env_logger::init`. The [internet suggests](https://github.com/rust-cli/env_logger/issues/228#issuecomment-1134753669)
that using `log::set_max_level` lets us change the level independently
of logger initialization, but this did not work when I tried it out.

Move logger initialization into `NewCli::run` so that we know the
desired log level ahead of calling `init`. This means that items logged
before we initialize the logger will be lost, but in practice we're not
missing anything.