### PR TITLE
Allow user to select threads for image upload

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -554,6 +554,10 @@
             {
               "long": "snapshot",
               "help": "If supplied, create a snapshot with the given name"
+            },
+            {
+              "long": "thread-count",
+              "help": "The number of parallel threads to use during upload"
             }
           ],
           "subcommands": [

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -539,6 +539,10 @@
               "help": "The version of this image (e.g. 11, focal, a9e77e3a, 2023-04-06T14:23:34Z)"
             },
             {
+              "long": "parallelism",
+              "help": "The degree or parallelism to use during upload"
+            },
+            {
               "long": "path",
               "help": "Path to the file to import"
             },
@@ -554,10 +558,6 @@
             {
               "long": "snapshot",
               "help": "If supplied, create a snapshot with the given name"
-            },
-            {
-              "long": "thread-count",
-              "help": "The number of parallel threads to use during upload"
             }
           ],
           "subcommands": [

--- a/cli/src/cmd_disk.rs
+++ b/cli/src/cmd_disk.rs
@@ -76,6 +76,10 @@ pub struct CmdDiskImport {
     /// The version of this image (e.g. 11, focal, a9e77e3a, 2023-04-06T14:23:34Z)
     #[clap(long, requires_all = ["snapshot", "image", "image_description", "image_os"])]
     image_version: Option<String>,
+
+    /// The number of parallel threads to use during upload
+    #[clap(long, default_value = "8")]
+    thread_count: usize,
 }
 
 #[async_trait]
@@ -97,7 +101,7 @@ impl crate::AuthenticatedCmd for CmdDiskImport {
             .disk_import()
             .project(self.project.clone())
             .description(self.description.clone())
-            .upload_thread_ct(8)
+            .upload_thread_ct(self.thread_count)
             .disk(self.disk.clone())
             .disk_info(disk_info.clone());
 

--- a/cli/src/cmd_disk.rs
+++ b/cli/src/cmd_disk.rs
@@ -77,9 +77,9 @@ pub struct CmdDiskImport {
     #[clap(long, requires_all = ["snapshot", "image", "image_description", "image_os"])]
     image_version: Option<String>,
 
-    /// The number of parallel threads to use during upload
-    #[clap(long, default_value = "8")]
-    thread_count: usize,
+    /// The degree or parallelism to use during upload
+    #[clap(long, default_value = "8", hide = true)]
+    parallelism: usize,
 }
 
 #[async_trait]
@@ -101,7 +101,7 @@ impl crate::AuthenticatedCmd for CmdDiskImport {
             .disk_import()
             .project(self.project.clone())
             .description(self.description.clone())
-            .upload_thread_ct(self.thread_count)
+            .upload_thread_ct(self.parallelism)
             .disk(self.disk.clone())
             .disk_info(disk_info.clone());
 


### PR DESCRIPTION
Added an option, `thread-count` to the image upload that allows a user to choose how many threads to create.