### PR TITLE
Print extended error information in debug logs

### DIFF
--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -469,7 +469,7 @@ impl CmdAuthStatus {
                     println_nopipe!("Logged in to {} as {}", host_env, user.id)
                 }
                 Err(e) => {
-                    log::debug!("error response for {} (env): {}", host_env, e);
+                    log::debug!("error response for {} (env): {:#}", host_env, e);
                     println_nopipe!("{}: {}", host_env, Self::error_msg(&e))
                 }
             };
@@ -494,7 +494,7 @@ impl CmdAuthStatus {
                         "Authenticated".to_string()
                     }
                     Err(e) => {
-                        log::debug!("error response for {}: {}", profile_info.host, e);
+                        log::debug!("error response for {}: {:#}", profile_info.host, e);
                         Self::error_msg(&e)
                     }
                 };


### PR DESCRIPTION
With https://github.com/oxidecomputer/progenitor/pull/949 Progenitor now prints the full error chain when the alternate format option `{:#}` is used, like `anyhow` does.

Update our debug logs to use alternate formatting to ensure they contain the maximum amount of detail available.