### PR TITLE
Update progen client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d385da3c602d29036d2f70beed71c36604df7570be17fed4c5b839616785bf"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom",
  "http 1.2.0",
@@ -2509,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec6f204bec21b7165004e0973327631e4976e690c6b91686ee3f0a700d9f5bd"
+checksum = "fdae8df95f0b2a7d6159a9c43b7380016b8d3b0fc1ece46871ecd2e0087cfaf6"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2996,18 +2996,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4134,7 +4134,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ oxnet = { git = "https://github.com/oxidecomputer/oxnet" }
 predicates = "3.1.3"
 pretty_assertions = "1.4.1"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", default-features = false }
-progenitor-client = "0.9.0"
+progenitor-client = "0.9.1"
 rand = "0.8.5"
 ratatui = "0.26.3"
 rcgen = "0.10.0"

--- a/cli/tests/test_projects.rs
+++ b/cli/tests/test_projects.rs
@@ -33,6 +33,8 @@ fn test_project_simple_list() {
         .env("OXIDE_TOKEN", "fake-token")
         .arg("project")
         .arg("list")
+        .arg("--sort-by")
+        .arg("name_ascending")
         .assert()
         .success()
         .stdout(expectorate::eq_file_or_panic(


### PR DESCRIPTION
First commit fails like this:

```
---- test_project_simple_list stdout ----
thread 'test_project_simple_list' panicked at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:250:5:
Unexpected failure.
code=1
stderr=``````
WARNING: 644 permissions on \"/Users/ahl/.config/oxide/credentials.toml\" may allow other users to access your login credentials.
Communication Error: builder error: builder error: top-level serializer supports only maps and structs
\```
\```
command=`OXIDE_HOST="http://127.0.0.1:61116" OXIDE_TOKEN="fake-token" RUST_BACKTRACE="1" "/Users/ahl/src/oxide.rs/target/debug/oxide" "project" "list" "--sort-by" "name_ascending"`
code=1
stdout="[]\n"
stderr=```
WARNING: 644 permissions on \"/Users/ahl/.config/oxide/credentials.toml\" may allow other users to access your login credentials.
Communication Error: builder error: builder error: top-level serializer supports only maps and structs
\```
```