### PR TITLE
disk import: Prioritize returning upload errors

### DIFF
--- a/cli/tests/test_disk_import.rs
+++ b/cli/tests/test_disk_import.rs
@@ -573,8 +573,7 @@ fn test_disk_write_import_fail() {
     });
 
     let test_file = Testfile::new_random(CHUNK_SIZE * 2).unwrap();
-    let output = "upload task(s) failed:
-  task 0: Error Response: status: 503 Service Unavailable;";
+    let output = "upload task failed: Error Response: status: 503 Service Unavailable;";
 
     Command::cargo_bin("oxide")
         .unwrap()

--- a/cli/tests/test_disk_import.rs
+++ b/cli/tests/test_disk_import.rs
@@ -573,7 +573,7 @@ fn test_disk_write_import_fail() {
     });
 
     let test_file = Testfile::new_random(CHUNK_SIZE * 2).unwrap();
-    let output = "upload task failed: Error Response: status: 503 Service Unavailable;";
+    let output = r#"(?m)\AErrors while uploading the disk image:\n \* Error Response: status: 503 Service Unavailable;.*$\n \* Error Response: status: 503 Service Unavailable;.*"#;
 
     Command::cargo_bin("oxide")
         .unwrap()
@@ -590,16 +590,16 @@ fn test_disk_write_import_fail() {
         .arg(test_file.path())
         .arg("--disk")
         .arg("test-disk-import-bulk-import-start-fail")
-        .arg("--parallelism") // Ensure only one write request is sent.
-        .arg("1")
+        .arg("--parallelism")
+        .arg("2")
         .assert()
         .failure()
-        .stderr(predicate::str::starts_with(output));
+        .stderr(predicate::str::is_match(output).unwrap());
 
     disk_view_mock.assert_hits(2);
     disk_create_mock.assert();
     start_bulk_write_mock.assert();
-    disk_bulk_write_mock.assert();
+    disk_bulk_write_mock.assert_hits(2);
 }
 
 // Test for required parameters being supplied

--- a/sdk/src/extras/disk.rs
+++ b/sdk/src/extras/disk.rs
@@ -431,18 +431,18 @@ pub mod types {
             match errors.len() {
                 1 => {
                     return Err(DiskImportError::context(
-                        "upload task failed",
+                        "Error while uploading the disk image",
                         errors.remove(0),
                     ))
                 }
                 2.. => {
-                    let mut msg = String::from("upload tasks failed:");
+                    let mut msg = String::from("Errors while uploading the disk image:");
                     for err in errors {
                         msg += &format!("\n * {err}");
                     }
                     return Err(DiskImportError::Other(msg.into()));
                 }
-                _ => {}
+                0 => {}
             }
 
             // Stop the bulk write process

--- a/sdk/src/extras/disk.rs
+++ b/sdk/src/extras/disk.rs
@@ -416,9 +416,11 @@ pub mod types {
                 drop(tx);
             }
 
-            read_result?;
-
             let mut errors = Vec::new();
+            if let Err(e) = read_result {
+                errors.push(e);
+            }
+
             for handle in handles {
                 let result = handle.await.map_err(DiskImportError::other)?;
                 if let Err(err) = result {

--- a/sdk/src/extras/disk.rs
+++ b/sdk/src/extras/disk.rs
@@ -436,7 +436,7 @@ pub mod types {
                 2.. => {
                     let mut msg = String::from("upload tasks failed:");
                     for err in errors {
-                        msg += &format!("\n{err}");
+                        msg += &format!("\n * {err}");
                     }
                     return Err(DiskImportError::Other(msg.into()));
                 }


### PR DESCRIPTION
When sending chunks of the file to upload tasks, we return an error if the channel to that task is closed. This situation will happen if the upload task has panicked or already returned due to an error. However, we check for an error from the sending task first, and the `failed to send chunks` error will be surfaced to the user, rather than the true problem that occurred in the upload task.

In the inverse situation, where the reader fails, the uploaders will return gracefully when their channels are closed, so we do not need to worry about a problem reading the file showing up as an upload error.

Update our error handling to check for an error from the upload tasks, then the reader if those returned cleanly.