### PR TITLE
Default to current_thread tokio runtime

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -96,16 +96,10 @@ pub fn make_cli() -> NewCli<'static> {
         .add_custom::<cmd_net::CmdStaticRoute>("system networking route")
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let new_cli = make_cli();
 
-    // Spawn a task so we get this potentially chunky Future off the
-    // main thread's stack.
-    let result = tokio::spawn(async move { new_cli.run().await })
-        .await
-        .unwrap();
-    if let Err(e) = result {
+    if let Err(e) = new_cli.run() {
         if let Some(io_err) = e.downcast_ref::<io::Error>() {
             if io_err.kind() == io::ErrorKind::BrokenPipe {
                 return;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -96,10 +96,11 @@ pub fn make_cli() -> NewCli<'static> {
         .add_custom::<cmd_net::CmdStaticRoute>("system networking route")
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let new_cli = make_cli();
 
-    if let Err(e) = new_cli.run() {
+    if let Err(e) = new_cli.run().await {
         if let Some(io_err) = e.downcast_ref::<io::Error>() {
             if io_err.kind() == io::ErrorKind::BrokenPipe {
                 return;


### PR DESCRIPTION
The vast majority operations in the CLI perform a single task, and we suspect that they do not benefit from the scalability offered by the multi-threaded runtime tokio defaults to.

Benchmarking the runtimes, `oxide version` unsurprisingly shows a significant improvement in performance with `current_thread`:

```
  $ hyperfine -L oxide './oxide-st, ./oxide-mt' -w3 '{oxide} version'
  Benchmark 1: ./oxide-st version
    Time (mean ± σ):      14.5 ms ±   0.6 ms    [User: 9.2 ms, System: 5.3 ms]
    Range (min … max):    13.3 ms …  17.9 ms    187 runs

  Benchmark 2:  ./oxide-mt version
    Time (mean ± σ):      22.1 ms ±   1.0 ms    [User: 11.6 ms, System: 13.3 ms]
    Range (min … max):    20.2 ms …  26.4 ms    127 runs

  Summary
    ./oxide-st version ran
      1.52 ± 0.10 times faster than  ./oxide-mt version
```

Of more relevance to actual use, a simple command that hits the network shows a smaller benefit to using `current_thread`:

```
  $ hyperfine -L oxide './oxide-st,./oxide-mt' '{oxide} instance list --project=will'
  Benchmark 1: ./oxide-st instance list --project=will
    Time (mean ± σ):     156.4 ms ±   5.8 ms    [User: 12.8 ms, System: 7.8 ms]
    Range (min … max):   149.4 ms … 174.7 ms    18 runs

  Benchmark 2:  ./oxide-mt instance list --project=will
    Time (mean ± σ):     163.6 ms ±   8.6 ms    [User: 14.9 ms, System: 17.5 ms]
    Range (min … max):   153.5 ms … 191.6 ms    18 runs

  Summary
    ./oxide-st instance list --project=will ran
      1.05 ± 0.07 times faster than  ./oxide-mt instance list --project=will
```

However, this mostly washes out when run from my more distant home network, though CPU usage remains slightly lower:

```
  $ hyperfine -M5 -L oxide './oxide-st,./oxide-mt' '{oxide} instance list --project=will'
  Benchmark 1: ./oxide-st instance list --project=will
    Time (mean ± σ):     541.2 ms ±  15.3 ms    [User: 13.9 ms, System: 13.8 ms]
    Range (min … max):   515.1 ms … 554.2 ms    5 runs

  Benchmark 2: ./oxide-mt instance list --project=will
    Time (mean ± σ):     544.5 ms ±   3.4 ms    [User: 16.4 ms, System: 19.7 ms]
    Range (min … max):   541.0 ms … 549.6 ms    5 runs

  Summary
    ./oxide-st instance list --project=will ran
      1.01 ± 0.03 times faster than ./oxide-mt instance list --project=will
```

With disk imports, which are highly parallel, we see higher variance with `current_thread`, but in human terms the results are essentially the same:

```
  $ hyperfine -L oxide './oxide-st,./oxide-mt' 'bash -c "{oxide} disk import --project will --description BenchRTs --path ~/alpine.raw --disk bench-$(date +%s%N) --disk-block-size 512"'
  Benchmark 1: bash -c "./oxide-st disk import --project will --description BenchRTs --path ~/alpine.raw --disk bench-$(date +%s%N) --disk-block-size 512"
    Time (mean ± σ):      6.817 s ±  1.341 s    [User: 0.545 s, System: 1.144 s]
    Range (min … max):    5.196 s …  8.928 s    10 runs

  Benchmark 2: bash -c "./oxide-mt disk import --project will --description BenchRTs --path ~/alpine.raw --disk bench-$(date +%s%N) --disk-block-size 512"
    Time (mean ± σ):      6.375 s ±  0.982 s    [User: 0.615 s, System: 1.113 s]
    Range (min … max):    4.975 s …  8.027 s    10 runs

  Summary
    bash -c "./oxide-mt disk import --project will --description BenchRTs --path ~/alpine.raw --disk bench-$(date +%s%N) --disk-block-size 512" ran
      1.07 ± 0.27 times faster than bash -c "./oxide-st disk import --project will --description BenchRTs --path ~/alpine.raw --disk bench-$(date +%s%N) --disk-block-size 512"
```

Update the CLI to use the `current_thread` runtime.

While we're at it, replace a few unwraps with errors.