### PR TITLE
test_disk_write_import_fail reads local config

### DIFF
--- a/cli/tests/test_disk_import.rs
+++ b/cli/tests/test_disk_import.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use anyhow::Result;
 use assert_cmd::Command;
@@ -573,13 +573,21 @@ fn test_disk_write_import_fail() {
     });
 
     let test_file = Testfile::new_random(CHUNK_SIZE * 2).unwrap();
-    let output = r#"(?m)\AError while uploading the disk image:\n \* Error Response: status: 503 Service Unavailable;.*$"#;
+    let output = format!(
+        "{}\n {}",
+        r#"(?m)\AError while uploading the disk image:"#,
+        r#"\* Error Response: status: 503 Service Unavailable;.*$"#
+    );
+
+    let temp_dir = tempfile::tempdir().unwrap().into_path();
 
     Command::cargo_bin("oxide")
         .unwrap()
         .env("RUST_BACKTRACE", "1")
         .env("OXIDE_HOST", server.url(""))
         .env("OXIDE_TOKEN", "test_disk_import_bulk_import_start_fail")
+        .arg("--config-dir")
+        .arg(temp_dir.as_os_str())
         .arg("disk")
         .arg("import")
         .arg("--project")

--- a/cli/tests/test_disk_import.rs
+++ b/cli/tests/test_disk_import.rs
@@ -573,9 +573,8 @@ fn test_disk_write_import_fail() {
     });
 
     let test_file = Testfile::new_random(CHUNK_SIZE * 2).unwrap();
-    let output = format!(
-        "{}\n {}",
-        r#"(?m)\AError while uploading the disk image:"#,
+    let output = concat!(
+        r#"(?m)\AError while uploading the disk image:\n "#,
         r#"\* Error Response: status: 503 Service Unavailable;.*$"#
     );
 


### PR DESCRIPTION
Fails due to output mismatch

```
WARNING: 644 permissions on \"/Users/ahl/.config/oxide/credentials.toml\" may allow other users to access your login credentials.
Error while uploading the disk image:
 * Error Response: status: 503 Service Unavailable; headers: {\"content-type\": \"application/json\", \"content-length\": \"86\", \"date\": \"Fri, 14 Feb 2025 17:05:03 GMT\"}; value: Error { error_code: None, message: \"I can\'t do that Dave\", request_id: \"f59ead8e-b7d1-60d8-4782-8b1c5ad46ca3\" }
```

I've left my .config/oxide/credentials.toml with the wrong permissions to catch tests that read from the local config.