### PR TITLE
dist: Install perl-IPC-Cmd

### DIFF
--- a/.github/manylinux.yml
+++ b/.github/manylinux.yml
@@ -1,3 +1,5 @@
 - name: Install perl-IPC-Cmd on manylinux
   if: contains(matrix.container.image, 'manylinux')
-  run: yum install -y perl-IPC-Cmd
+  run: |
+    yum install -y perl-IPC-Cmd
+    git config --global --add safe.directory /__w/oxide.rs/oxide.rs

--- a/.github/manylinux.yml
+++ b/.github/manylinux.yml
@@ -1,0 +1,3 @@
+- name: Install perl-IPC-Cmd on manylinux
+  if: contains(matrix.container.image, 'manylinux')
+  run: yum install -y perl-IPC-Cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,9 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Install perl-IPC-Cmd on manylinux"
+        if: "contains(matrix.container.image, 'manylinux')"
+        run: "yum install -y perl-IPC-Cmd"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,9 @@ jobs:
           fi
       - name: "Install perl-IPC-Cmd on manylinux"
         if: "contains(matrix.container.image, 'manylinux')"
-        run: "yum install -y perl-IPC-Cmd"
+        run: |
+          yum install -y perl-IPC-Cmd
+          git config --global --add safe.directory /__w/oxide.rs/oxide.rs
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,10 +130,6 @@ jobs:
         run: |
           yum install -y perl-IPC-Cmd
           git config --global --add safe.directory /__w/oxide.rs/oxide.rs
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,10 @@ jobs:
       - name: "Install perl-IPC-Cmd on manylinux"
         if: "contains(matrix.container.image, 'manylinux')"
         run: "yum install -y perl-IPC-Cmd"
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # Install `perl-IPC-Cmd` on manylinux
 github-build-setup = "../manylinux.yml"
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,7 +13,7 @@ installers = []
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
-# Install `perl-IPC-Cmd` on manylinux
+# Install `perl-IPC-Cmd` on manylinux as required to build OpenSSL
 github-build-setup = "../manylinux.yml"
 
 [dist.github-custom-runners.x86_64-unknown-linux-gnu]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "plan"
+pr-run-mode = "upload"
 # Install `perl-IPC-Cmd` on manylinux
 github-build-setup = "../manylinux.yml"
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,3 +13,8 @@ installers = []
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
+# Install `perl-IPC-Cmd` on manylinux
+github-build-setup = "../manylinux.yml"
+
+[dist.github-custom-runners.x86_64-unknown-linux-gnu]
+container = { image = "quay.io/pypa/manylinux_2_28_x86_64", host = "x86_64-unknown-linux-musl" }


### PR DESCRIPTION
To build `openssl` on the `manylinux` image we need to install the `perl-IPC-Cmd` package.
    
Add it as a dependency in our dist config.

Closes https://github.com/oxidecomputer/oxide.rs/issues/1025