### PR TITLE
Add debug logging for all Oxide API requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -935,19 +935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1837,7 +1824,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1851,7 +1838,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -1957,6 +1944,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "md5"
@@ -2071,6 +2067,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -2214,6 +2220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "oxide"
 version = "0.10.0+20250212.0.0"
 dependencies = [
@@ -2236,6 +2248,7 @@ dependencies = [
  "tokio",
  "toml",
  "toml_edit",
+ "tracing",
  "uuid",
 ]
 
@@ -2256,14 +2269,12 @@ dependencies = [
  "dialoguer",
  "dirs",
  "dropshot",
- "env_logger",
  "expectorate",
  "futures",
  "httpmock",
  "humantime",
  "indicatif",
  "libc",
- "log",
  "md5",
  "oauth2",
  "open",
@@ -2286,6 +2297,8 @@ dependencies = [
  "tokio",
  "toml",
  "toml_edit",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -2613,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2710,8 +2723,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2722,8 +2744,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3143,6 +3171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,15 +3498,6 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -3808,7 +3836,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3818,6 +3858,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3993,6 +4076,12 @@ dependencies = [
  "getrandom 0.3.1",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -4444,6 +4533,7 @@ dependencies = [
  "clap",
  "newline-converter",
  "progenitor",
+ "quote",
  "regex",
  "rustfmt-wrapper",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { version = "1.44.0", features = ["full"] }
 toml = "0.8.20"
 toml_edit = "0.22.24"
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter","json"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 url = "2.5.4"
 uuid = { version = "1.15.1", features = ["serde", "v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ crossterm = { version = "0.27.0", features = [ "event-stream" ] }
 dialoguer = "0.10.4"
 dirs = "4.0.0"
 dropshot = "0.13.0"
-env_logger = "0.10.2"
 expectorate = { version = "1.1.0", features = ["predicates"] }
 flume = "0.11.1"
 futures = "0.3.31"
@@ -31,7 +30,6 @@ httpmock = "0.7.0"
 humantime = "2"
 indicatif = "0.17"
 libc = "0.2.170"
-log = "0.4.26"
 md5 = "0.7.0"
 newline-converter = "0.3.0"
 oauth2 = "5.0.0"
@@ -43,6 +41,7 @@ predicates = "3.1.3"
 pretty_assertions = "1.4.1"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", default-features = false }
 progenitor-client = "0.9.1"
+quote = "1.0.40"
 rand = "0.8.5"
 ratatui = "0.26.3"
 rcgen = "0.10.0"
@@ -62,6 +61,8 @@ thouart = { git = "https://github.com/oxidecomputer/thouart" }
 tokio = { version = "1.44.0", features = ["full"] }
 toml = "0.8.20"
 toml_edit = "0.22.24"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter","json"] }
 url = "2.5.4"
 uuid = { version = "1.15.1", features = ["serde", "v4"] }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,11 +28,9 @@ colored = { workspace = true }
 crossterm = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
-env_logger = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 indicatif = { workspace = true }
-log = { workspace = true }
 md5 = { workspace = true }
 oauth2 = { workspace = true }
 open = { workspace = true }
@@ -49,6 +47,8 @@ thouart = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -2,14 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::{any::TypeId, collections::BTreeMap, marker::PhantomData, net::IpAddr, path::PathBuf};
 
 use anyhow::{bail, Result};
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command, CommandFactory, FromArgMatches};
-use log::LevelFilter;
+use tracing_subscriber::EnvFilter;
 
 use crate::{
     context::Context,
@@ -229,11 +229,20 @@ impl<'a> NewCli<'a> {
             timeout,
         } = OxideCli::from_arg_matches(&matches).expect("failed to parse OxideCli from args");
 
-        let mut log_builder = env_logger::builder();
-        if debug {
-            log_builder.filter_level(LevelFilter::Debug);
-        }
-        log_builder.init();
+        let env_filter = if debug {
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"))
+        } else {
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+        };
+
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_writer(std::io::stderr)
+            .json()
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(false)
+            .init();
 
         let mut client_config = ClientConfig::default();
 

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -230,7 +230,7 @@ impl<'a> NewCli<'a> {
         } = OxideCli::from_arg_matches(&matches).expect("failed to parse OxideCli from args");
 
         let env_filter = if debug {
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"))
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("oxide=debug"))
         } else {
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
         };

--- a/cli/src/cmd_auth.rs
+++ b/cli/src/cmd_auth.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::error::Error;
 use std::fs::{File, OpenOptions};
@@ -465,11 +465,11 @@ impl CmdAuthStatus {
 
             match result {
                 Ok(user) => {
-                    log::debug!("success response for {} (env): {:?}", host_env, user);
+                    tracing::debug!("success response for {} (env): {:?}", host_env, user);
                     println_nopipe!("Logged in to {} as {}", host_env, user.id)
                 }
                 Err(e) => {
-                    log::debug!("error response for {} (env): {:#}", host_env, e);
+                    tracing::debug!("error response for {} (env): {:#}", host_env, e);
                     println_nopipe!("{}: {}", host_env, Self::error_msg(&e))
                 }
             };
@@ -490,11 +490,11 @@ impl CmdAuthStatus {
 
                 let status = match result {
                     Ok(v) => {
-                        log::debug!("success response for {}: {:?}", profile_info.host, v);
+                        tracing::debug!("success response for {}: {:?}", profile_info.host, v);
                         "Authenticated".to_string()
                     }
                     Err(e) => {
-                        log::debug!("error response for {}: {:#}", profile_info.host, e);
+                        tracing::debug!("error response for {}: {:#}", profile_info.host, e);
                         Self::error_msg(&e)
                     }
                 };

--- a/cli/src/cmd_version.rs
+++ b/cli/src/cmd_version.rs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
-use oxide::Client;
+use oxide::{Client, LogCtx};
 
 use crate::println_nopipe;
 use crate::{context::Context, RunnableCmd};
@@ -26,7 +26,7 @@ pub struct CmdVersion;
 impl RunnableCmd for CmdVersion {
     async fn run(&self, _ctx: &Context) -> Result<()> {
         let cli_version = built_info::PKG_VERSION;
-        let api_version = Client::new("").api_version();
+        let api_version = Client::new("", LogCtx::new()).api_version();
 
         println_nopipe!("Oxide CLI {}", cli_version);
 
@@ -52,7 +52,7 @@ fn version_success() {
 
     let mut cmd = Command::cargo_bin("oxide").unwrap();
     let cli_version = built_info::PKG_VERSION;
-    let api_version = Client::new("").api_version();
+    let api_version = Client::new("", oxide::LogCtx::new()).api_version();
 
     cmd.arg("version");
     cmd.assert().success().stdout(format!(

--- a/cli/tests/test_auth.rs
+++ b/cli/tests/test_auth.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::{
     fs::{read_to_string, write, File},
@@ -14,6 +14,7 @@ use expectorate::assert_contents;
 use httpmock::{Method::POST, Mock, MockServer};
 use oxide::types::CurrentUser;
 use oxide_httpmock::MockServerExt;
+use predicates::prelude::*;
 use predicates::str;
 use serde_json::json;
 
@@ -572,17 +573,58 @@ fn test_cmd_auth_status_env() {
 
 #[test]
 fn test_cmd_auth_debug_logging() {
-    let bad_url = "sys.oxide.invalid";
+    let server = MockServer::start();
 
-    // Validate debug logs are printed
-    Command::cargo_bin("oxide")
+    let oxide_mock = server.current_user_view(|when, then| {
+        when.into_inner()
+            .header("authorization", "Bearer oxide-token-good");
+
+        then.ok(&oxide::types::CurrentUser {
+            display_name: "privileged".to_string(),
+            id: "001de000-05e4-4000-8000-000000004007".parse().unwrap(),
+            silo_id: "d1bb398f-872c-438c-a4c6-2211e2042526".parse().unwrap(),
+            silo_name: "funky-town".parse().unwrap(),
+        });
+    });
+
+    let cmd = Command::cargo_bin("oxide")
         .unwrap()
-        .arg("--debug")
         .arg("auth")
-        .arg("login")
-        .arg("--host")
-        .arg(bad_url)
+        .arg("status")
+        .env("RUST_LOG", "oxide=debug")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "oxide-token-good")
         .assert()
-        .failure()
-        .stderr(str::contains("DEBUG"));
+        .success();
+
+    let stderr_str = std::str::from_utf8(&cmd.get_output().stderr).unwrap();
+    assert!(str::is_match(r#""level":"DEBUG""#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""message":"request succeeded""#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""url":"http://127.0.0.1:\d+/v1/me""#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""path":"/v1/me""#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""remote_addr":"127.0.0.1:\d+""#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""http.request.method":"GET""#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""http.response.content_length":\d+"#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""http.response.status_code":200"#)
+        .unwrap()
+        .eval(stderr_str));
+    assert!(str::is_match(r#""duration_ms":\d+"#)
+        .unwrap()
+        .eval(stderr_str));
+
+    oxide_mock.assert();
 }

--- a/cli/tests/test_auth.rs
+++ b/cli/tests/test_auth.rs
@@ -589,9 +589,9 @@ fn test_cmd_auth_debug_logging() {
 
     let cmd = Command::cargo_bin("oxide")
         .unwrap()
+        .arg("--debug")
         .arg("auth")
         .arg("status")
-        .env("RUST_LOG", "oxide=debug")
         .env("OXIDE_HOST", server.url(""))
         .env("OXIDE_TOKEN", "oxide-token-good")
         .assert()

--- a/cli/tests/test_net.rs
+++ b/cli/tests/test_net.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use assert_cmd::Command;
 use chrono::prelude::*;
@@ -295,7 +295,7 @@ fn test_port_config() {
             then.ok(&switch1_qsfp0_view);
         });
 
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     Command::cargo_bin("oxide")
         .unwrap()

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -25,6 +25,7 @@ thiserror =  { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::{
     collections::BTreeMap,
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{Client, OxideAuthError};
+use crate::{Client, LogCtx, OxideAuthError};
 use reqwest::ClientBuilder;
 use serde::Deserialize;
 
@@ -178,6 +178,7 @@ impl Client {
             client_builder
                 .build()
                 .expect("failure to construct underlying client object"),
+            LogCtx::new(),
         ))
     }
 }

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -54128,6 +54128,7 @@ pub mod types {
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
+    pub(crate) inner: crate::LogCtx,
 }
 
 impl Client {
@@ -54136,7 +54137,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
-    pub fn new(baseurl: &str) -> Self {
+    pub fn new(baseurl: &str, inner: crate::LogCtx) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
             let dur = std::time::Duration::from_secs(15);
@@ -54146,7 +54147,7 @@ impl Client {
         };
         #[cfg(target_arch = "wasm32")]
         let client = reqwest::ClientBuilder::new();
-        Self::new_with_client(baseurl, client.build().unwrap())
+        Self::new_with_client(baseurl, client.build().unwrap(), inner)
     }
 
     /// Construct a new client with an existing `reqwest::Client`,
@@ -54155,10 +54156,11 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client, inner: crate::LogCtx) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
+            inner,
         }
     }
 
@@ -54178,6 +54180,11 @@ impl Client {
     /// document and may be in any format the API selects.
     pub fn api_version(&self) -> &'static str {
         "20250212.0.0"
+    }
+
+    /// Return a reference to the inner type stored in `self`.
+    pub fn inner(&self) -> &crate::LogCtx {
+        &self.inner
     }
 }
 
@@ -59435,7 +59442,9 @@ pub mod builder {
             let url = format!("{}/device/auth", client.baseurl,);
             #[allow(unused_mut)]
             let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -59500,7 +59509,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -59567,7 +59578,9 @@ pub mod builder {
             let url = format!("{}/device/token", client.baseurl,);
             #[allow(unused_mut)]
             let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -59673,7 +59686,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -59807,7 +59822,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -59885,7 +59902,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -59963,7 +59982,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -60060,7 +60081,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -60150,7 +60173,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -60216,7 +60241,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -60280,7 +60307,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -60337,7 +60366,9 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -60388,7 +60419,9 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.head(url).build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -60455,7 +60488,9 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -60522,7 +60557,9 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.head(url).build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -60573,7 +60610,9 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -60660,7 +60699,9 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -60772,7 +60813,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -60910,7 +60953,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -60991,7 +61036,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -61101,7 +61148,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -61180,7 +61229,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -61312,7 +61363,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -61458,7 +61511,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -61555,7 +61610,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -61650,7 +61707,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -61763,7 +61822,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -61906,7 +61967,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -61988,7 +62051,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -62103,7 +62168,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -62183,7 +62250,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -62315,7 +62384,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -62463,7 +62534,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -62562,7 +62635,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -62659,7 +62734,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -62755,7 +62832,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -62872,7 +62951,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -62935,7 +63016,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -62998,7 +63081,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -63110,7 +63195,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -63244,7 +63331,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -63323,7 +63412,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -63402,7 +63493,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -63512,7 +63605,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -63591,7 +63686,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -63670,7 +63767,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -63776,7 +63875,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -63958,7 +64059,9 @@ pub mod builder {
                     &start_time,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -64119,7 +64222,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -64255,7 +64360,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -64334,7 +64441,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -64442,7 +64551,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -64521,7 +64632,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -64629,7 +64742,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -64708,7 +64823,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -64804,7 +64921,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -64910,7 +65029,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -65022,7 +65143,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -65157,7 +65280,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -65236,7 +65361,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -65315,7 +65442,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -65393,7 +65522,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -65472,7 +65603,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -65584,7 +65717,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -65718,7 +65853,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -65797,7 +65934,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -65903,7 +66042,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -65982,7 +66123,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -66112,7 +66255,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -66265,7 +66410,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -66371,7 +66518,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -66452,7 +66601,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -66561,7 +66712,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -66641,7 +66794,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -66720,7 +66875,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -66855,7 +67012,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -66962,7 +67121,9 @@ pub mod builder {
                     ),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -67087,7 +67248,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -67213,7 +67376,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -67292,7 +67457,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -67437,7 +67604,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -67615,7 +67784,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -67743,7 +67914,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -67888,7 +68061,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -68066,7 +68241,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -68193,7 +68370,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -68321,7 +68500,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -68478,7 +68659,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -68575,7 +68758,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -68686,7 +68871,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -68782,7 +68969,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -68888,7 +69077,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -68985,7 +69176,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -69026,7 +69219,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -69067,7 +69262,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -69163,7 +69360,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -69305,7 +69504,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -69420,7 +69621,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -69480,7 +69683,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -69540,7 +69745,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -69707,7 +69914,9 @@ pub mod builder {
                     &start_time,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -69885,7 +70094,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70046,7 +70257,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("instance", &instance))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -70143,7 +70356,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("instance", &instance))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70274,7 +70489,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("instance", &instance))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70369,7 +70586,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("instance", &instance))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -70410,7 +70629,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70453,7 +70674,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70524,7 +70747,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70620,7 +70845,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70735,7 +70962,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -70795,7 +71024,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70885,7 +71116,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -70945,7 +71178,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -71007,7 +71242,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -71101,7 +71338,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -71213,7 +71452,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -71347,7 +71588,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -71426,7 +71669,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -71505,7 +71750,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -71601,7 +71848,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -71707,7 +71956,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -71854,7 +72105,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -71998,7 +72251,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -72104,7 +72359,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -72200,7 +72457,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -72317,7 +72576,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -72377,7 +72638,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -72491,7 +72754,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -72653,7 +72918,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -72801,7 +73068,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -72882,7 +73151,9 @@ pub mod builder {
                     &page_token,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -73042,7 +73313,9 @@ pub mod builder {
                     &switch_port_id,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -73189,7 +73462,9 @@ pub mod builder {
                     &switch_location,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -73314,7 +73589,9 @@ pub mod builder {
                     &switch_location,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -73445,7 +73722,9 @@ pub mod builder {
                     &switch_location,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -73543,7 +73822,9 @@ pub mod builder {
                     &switch_location,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -73642,7 +73923,9 @@ pub mod builder {
                     &switch_location,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -73738,7 +74021,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -73844,7 +74129,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -73957,7 +74244,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -74091,7 +74380,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -74170,7 +74461,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -74264,7 +74557,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -74356,7 +74651,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -74437,7 +74734,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -74533,7 +74832,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -74648,7 +74949,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -74708,7 +75011,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -74794,7 +75099,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -74854,7 +75161,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -74952,7 +75261,9 @@ pub mod builder {
                     &page_token,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -75071,7 +75382,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -75145,7 +75458,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -75259,7 +75574,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -75393,7 +75710,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -75502,7 +75821,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -75577,7 +75898,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -75639,7 +75962,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -75680,7 +76005,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -75760,7 +76087,9 @@ pub mod builder {
                     &page_token,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -75862,7 +76191,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -75923,7 +76254,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -76090,7 +76423,9 @@ pub mod builder {
                     &start_time,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -76235,7 +76570,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -76354,7 +76691,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -76418,7 +76757,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -76534,7 +76875,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -76622,7 +76965,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -76691,7 +77036,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -76762,7 +77109,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -76833,7 +77182,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -76876,7 +77227,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -76972,7 +77325,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77087,7 +77442,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -77147,7 +77504,9 @@ pub mod builder {
                     &name_or_id,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -77245,7 +77604,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77321,7 +77682,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -77386,7 +77749,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -77454,7 +77819,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77495,7 +77862,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77558,7 +77927,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("asn", &asn))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77619,7 +77990,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("asn", &asn))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77663,7 +78036,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77760,7 +78135,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -77882,7 +78259,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -77993,7 +78372,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -78114,7 +78495,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -78245,7 +78628,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -78314,7 +78699,9 @@ pub mod builder {
                     &port_settings,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -78378,7 +78765,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -78421,7 +78810,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -78492,7 +78883,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -78572,7 +78965,9 @@ pub mod builder {
                     &page_token,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -78677,7 +79072,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -78773,7 +79170,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -78915,7 +79314,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79030,7 +79431,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -79090,7 +79493,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79150,7 +79555,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -79264,7 +79671,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79372,7 +79781,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79460,7 +79871,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79520,7 +79933,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79608,7 +80023,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79679,7 +80096,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79760,7 +80179,9 @@ pub mod builder {
                     &page_token,
                 ))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79848,7 +80269,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -79923,7 +80346,9 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -80035,7 +80460,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80160,7 +80587,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("silo", &silo))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80256,7 +80685,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80362,7 +80793,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80458,7 +80891,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80566,7 +81001,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80655,7 +81092,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80767,7 +81206,9 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80855,7 +81296,9 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -80933,7 +81376,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -81045,7 +81490,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -81189,7 +81636,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -81359,7 +81808,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("router", &router))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -81469,7 +81920,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("router", &router))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -81609,7 +82062,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("router", &router))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -81720,7 +82175,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("router", &router))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -81848,7 +82305,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -81999,7 +82458,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -82094,7 +82555,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -82216,7 +82679,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -82311,7 +82776,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -82439,7 +82906,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -82590,7 +83059,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -82685,7 +83156,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -82807,7 +83280,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -82902,7 +83377,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -83050,7 +83527,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .query(&progenitor_client::QueryParam::new("vpc", &vpc))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -83212,7 +83691,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -83346,7 +83827,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -83425,7 +83908,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -83531,7 +84016,9 @@ pub mod builder {
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -83610,7 +84097,9 @@ pub mod builder {
                 )
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
+            (crate::tracing::on_request_start)(&client.inner, &request);
             let result = client.client.execute(request).await;
+            (crate::tracing::on_request_end)(&client.inner, &result);
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
@@ -16,9 +16,11 @@ mod auth;
 mod clap_feature;
 pub mod extras;
 mod generated_sdk;
+pub mod tracing;
 
 pub use auth::*;
 pub use generated_sdk::*;
+pub use tracing::LogCtx;
 
 /// Errors for interfaces related to authentication
 #[derive(Error, Debug)]

--- a/sdk/src/tracing.rs
+++ b/sdk/src/tracing.rs
@@ -1,0 +1,200 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2025 Oxide Computer Company
+
+use chrono::{DateTime, Utc};
+use reqwest::{Method, Request, Response, Url};
+use tokio::task::Id;
+use tracing::{Level, Span};
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+#[derive(Clone, Debug)]
+struct StartDetails {
+    url: Url,
+    method: Method,
+    start_time: SystemTime,
+    body: Option<String>,
+    span: Span,
+}
+
+/// Store Oxide API request metadata during execution so a unified log entry can
+/// be generated.
+#[derive(Clone, Debug)]
+pub struct LogCtx(Arc<Mutex<HashMap<Id, StartDetails>>>);
+
+impl LogCtx {
+    pub fn new() -> Self {
+        Self(Arc::new(Mutex::new(HashMap::new())))
+    }
+}
+
+impl Default for LogCtx {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn on_request_start(ctx: &LogCtx, request: &Request) {
+    let url = request.url();
+    let span = tracing::debug_span!("oxide", request = format!("{} {}", request.method(), url));
+
+    let mut details = StartDetails {
+        url: url.clone(),
+        method: request.method().clone(),
+        body: None,
+        start_time: SystemTime::now(),
+        span,
+    };
+
+    // Log up to the first KiB of the request body. Avoid performing this relatively
+    // expensive operation unless the log level is DEBUG or above.
+    if tracing::enabled!(target: "oxide", Level::DEBUG) {
+        let body_bytes = request.body().and_then(|b| b.as_bytes());
+        let body = body_bytes.map(|b| {
+            let len = b.len().min(1024);
+            let mut out = String::from_utf8_lossy(&b[..len]).into_owned();
+            if b.len() > 1024 {
+                out.push_str("...");
+            }
+            out
+        });
+
+        if let Some(b) = body {
+            details.body = Some(b);
+        }
+    }
+
+    // Try to store the request details for retrieval when the requests finishes.
+    // If we're not in a tokio Task this is not possible, instead log separate
+    // events for start and finish.
+    let Some(task_id) = tokio::task::try_id() else {
+        tracing::debug!(
+            url = %url,
+            path = url.path(),
+            http.request.method = %request.method(),
+            http.request.body = details.body,
+        );
+        return;
+    };
+
+    let Ok(mut ctx_map) = ctx.0.lock() else {
+        tracing::warn!(task_id = ?task_id, "failed to take LogCtx lock");
+        return;
+    };
+
+    ctx_map.insert(task_id, details);
+}
+
+pub fn on_request_end(ctx: &LogCtx, outcome: &Result<Response, reqwest::Error>) {
+    let Some(task_id) = tokio::task::try_id() else {
+        log_uncorrelated_response(outcome);
+        return;
+    };
+
+    let Ok(mut ctx_map) = ctx.0.lock() else {
+        tracing::warn!(task_id = ?task_id, "failed to take LogCtx lock");
+        return;
+    };
+
+    let Some(details) = ctx_map.remove(&task_id) else {
+        tracing::warn!(task_id = ?task_id, response = ?outcome, "no LogCtx entry found for task");
+        log_uncorrelated_response(outcome);
+        return;
+    };
+
+    // Don't hold the lock any longer than necessary.
+    drop(ctx_map);
+
+    // Convert to a u64 so this can be logged as a JSON number.
+    let duration_ms: u64 = SystemTime::now()
+        .duration_since(details.start_time)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+
+    let _enter = details.span.enter();
+    match outcome {
+        Ok(resp) => {
+            tracing::debug!(
+                url = %details.url,
+                path = details.url.path(),
+                remote_addr = resp.remote_addr().map(|a| a.to_string()),
+                http.request.method = %details.method,
+                http.request.body = details.body,
+                http.response.content_length = resp.content_length(),
+                http.response.status_code = resp.status().as_u16(),
+                start_time = format_time(details.start_time),
+                duration_ms,
+                oxide.request_id = get_request_id(resp),
+                "request succeeded",
+            );
+        }
+        Err(e) => {
+            tracing::debug!(
+                url = %details.url,
+                path = details.url.path(),
+                http.request.method = %details.method,
+                http.request.body = details.body,
+                http.response.status_code = ?e.status(),
+                start_time = format_time(details.start_time),
+                duration_ms,
+                error.message = e.to_string(),
+                error.cause = ?e.source(),
+                "request failed",
+            );
+        }
+    }
+}
+
+fn log_uncorrelated_response(outcome: &Result<Response, reqwest::Error>) {
+    match outcome {
+        Ok(resp) => {
+            let url = resp.url();
+            tracing::debug!(
+                url = %url,
+                path = url.path(),
+                remote_addr = resp.remote_addr().map(|a| a.to_string()),
+                http.response.content_length = resp.content_length(),
+                http.response.status_code = resp.status().as_u16(),
+                oxide.request_id = get_request_id(resp),
+                "request succeeded",
+            );
+        }
+        Err(e) => {
+            tracing::debug!(
+                url = ?e.url(),
+                path = ?e.url().map(|u| u.path()),
+                http.response.status_code = ?e.status().map(|s| s.as_u16()),
+                error.message = e.to_string(),
+                error.cause = ?e.source(),
+                "request failed",
+            );
+        }
+    }
+}
+
+fn get_request_id(response: &Response) -> Option<&str> {
+    response
+        .headers()
+        .get("x-request-id")
+        .and_then(|id| id.to_str().ok())
+        .map(|id| id.trim_matches('"'))
+}
+
+fn format_time(time: SystemTime) -> String {
+    let datetime = time
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| DateTime::from_timestamp(d.as_secs() as i64, d.subsec_nanos()))
+        .ok()
+        .flatten()
+        .unwrap_or_else(Utc::now);
+
+    datetime.format("%Y-%m-%dT%H:%M:%S.%6fZ").to_string()
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 clap = { workspace = true }
 newline-converter = { workspace = true }
 progenitor = { workspace = true, default-features = false }
+quote = { workspace = true }
 regex = { workspace = true }
 rustfmt-wrapper = { workspace = true }
 serde_json = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 #![forbid(unsafe_code)]
 
@@ -11,6 +11,7 @@ use std::{fs::File, io::Write, path::PathBuf, time::Instant};
 use clap::Parser;
 use newline_converter::dos2unix;
 use progenitor::{GenerationSettings, Generator, TagStyle};
+use quote::quote;
 use similar::{Algorithm, ChangeTag, TextDiff};
 
 #[derive(Parser)]
@@ -72,7 +73,14 @@ fn generate(
         GenerationSettings::default()
             .with_interface(progenitor::InterfaceStyle::Builder)
             .with_tag(TagStyle::Separate)
-            .with_derive("schemars::JsonSchema"),
+            .with_derive("schemars::JsonSchema")
+            .with_inner_type(quote! { crate::LogCtx })
+            .with_pre_hook(quote! {
+                crate::tracing::on_request_start
+            })
+            .with_post_hook(quote! {
+                crate::tracing::on_request_end
+            }),
     );
 
     let mut error = false;


### PR DESCRIPTION
Currently only the `auth` CLI subcommand will log any request details when debug logging is enabled. Adding debug logging for all requests will enable users to troubleshoot issues on any API endpoint.

To do this, we add add pre and post-request hooks via Progenitor. However, this does not lend itself to tracking the duration of the request, or creating a single log event with the details from the the `Request` and `Response`.

We add a `LogCtx` inner type to the client to act as a store while requests are in flight, but need something to associate the start and end. We could inject a header into the request, but on failure this will not be available to us.

Instead, we use the tokio `task::Id` as an identifier, which is unique within a given runtime. This raises the possibility of a client shared between runtimes associating the wrong start with a finished request. We do not have a way to detect which runtime a task is associated with, `runtime::Id` is an unstable feature, but we will log a warning if we find a response without a corresponding request, along with the response details. Should a request be run outside of a task, we fall back to logging separate events for start and end.

We also create a `Span` that includes the log event. This is ignored by the CLI, but may be useful for other consumers of the SDK that want to integrate it with their monitoring infrastructure.

An example event:

```
  {
    "timestamp": "2025-03-12T15:25:58.487790Z",
    "level": "DEBUG",
    "message": "request succeeded",
    "url": "https://oxide.sys.r3.oxide-preview.com/v1/disks?project=will",
    "path": "/v1/disks",
    "remote_addr": "45.154.216.35:443",
    "http.request.method": "GET",
    "http.response.content_length": 998,
    "http.response.status_code": 200,
    "start_time": "2025-03-12T15:25:58.048984Z",
    "duration_ms": 438,
    "oxide.request_id": "5d738e7a-ad78-4938-b682-c43f7b2a84be",
    "target": "oxide::tracing"
  }
```

Closes https://github.com/oxidecomputer/oxide.rs/issues/1014