### PR TITLE
Bump stack size on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,12 @@
 [alias]
 xtask = "run --package xtask --"
+
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+    "-C", "link-args=/STACK:8388608",
+]
+
+[target.x86_64-pc-windows-gnu]
+rustflags = [
+    "-C", "link-arg=-Wl,--stack,8388608"
+]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -100,12 +100,7 @@ pub fn make_cli() -> NewCli<'static> {
 async fn main() {
     let new_cli = make_cli();
 
-    // Spawn a task so we get this potentially chunky Future off the
-    // main thread's stack.
-    let result = tokio::spawn(async move { new_cli.run().await })
-        .await
-        .unwrap();
-    if let Err(e) = result {
+    if let Err(e) = new_cli.run().await {
         if let Some(io_err) = e.downcast_ref::<io::Error>() {
             if io_err.kind() == io::ErrorKind::BrokenPipe {
                 return;


### PR DESCRIPTION
With https://github.com/oxidecomputer/oxide.rs/pull/1004 we converted the CLI to use the `current_thread` tokio executor. We had seen stack overflows on Windows in the past, which defaults to a 1 MiB stack. While this problem is not currently present, a PR that increases the depth of our call stack is [encountering it in CI](https://github.com/oxidecomputer/oxide.rs/actions/runs/13817821578/job/38655523269?pr=1053).

Add linker flags to bump the stack size to 8 MiB for both MSVC and MinGW, matching the default value of Linux and macOS.