### PR TITLE
Add event logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -603,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1837,7 +1837,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1851,7 +1851,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -1957,6 +1957,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "md5"
@@ -2073,6 +2082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,7 +2127,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.15",
  "http 1.3.1",
@@ -2214,6 +2233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "oxide"
 version = "0.11.0+20250409.0.0"
 dependencies = [
@@ -2236,6 +2261,7 @@ dependencies = [
  "tokio",
  "toml",
  "toml_edit",
+ "tracing",
  "uuid",
 ]
 
@@ -2286,6 +2312,8 @@ dependencies = [
  "tokio",
  "toml",
  "toml_edit",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -2709,8 +2737,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2721,8 +2758,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3139,6 +3182,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3813,7 +3865,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3823,6 +3887,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4001,6 +4108,12 @@ dependencies = [
  "getrandom 0.3.1",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -4207,7 +4320,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ thouart = { git = "https://github.com/oxidecomputer/thouart" }
 tokio = { version = "1.44.2", features = ["full"] }
 toml = "0.8.22"
 toml_edit = "0.22.24"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 url = "2.5.4"
 uuid = { version = "1.16.0", features = ["serde", "v4"] }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,6 +49,8 @@ thouart = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 

--- a/cli/tests/test_net.rs
+++ b/cli/tests/test_net.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use assert_cmd::Command;
 use chrono::prelude::*;
@@ -295,7 +295,7 @@ fn test_port_config() {
             then.ok(&switch1_qsfp0_view);
         });
 
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     Command::cargo_bin("oxide")
         .unwrap()

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -25,6 +25,7 @@ thiserror =  { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -2,14 +2,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
 
+use chrono::{DateTime, Utc};
+use reqwest::{Method, Url};
 use thiserror::Error;
+use tracing::{Level, Span};
 
 mod auth;
 #[cfg(feature = "clap")]
@@ -40,4 +46,117 @@ pub enum OxideAuthError {
     NoProfile(PathBuf, String),
     #[error("no authenticated hosts; use oxide auth login to authenticate")]
     NoAuthenticatedHosts,
+}
+
+impl progenitor_client::ClientHooks for Client {
+    async fn exec(
+        &self,
+        request: reqwest::Request,
+        op_info: &progenitor_client::OperationInfo,
+    ) -> reqwest::Result<reqwest::Response> {
+        let url = request.url();
+        let span = tracing::debug_span!("oxide", request = format!("{} {}", request.method(), url));
+
+        #[derive(Clone, Debug)]
+        struct StartDetails {
+            op_id: &'static str,
+            url: Url,
+            method: Method,
+            start_time: SystemTime,
+            body: Option<String>,
+            span: Span,
+        }
+
+        let mut details = StartDetails {
+            op_id: op_info.operation_id,
+            url: url.clone(),
+            method: request.method().clone(),
+            body: None,
+            start_time: SystemTime::now(),
+            span,
+        };
+
+        // Log up to the first KiB of the request body. Avoid performing this relatively
+        // expensive operation unless the log level is DEBUG or above.
+        if tracing::enabled!(target: "oxide", Level::DEBUG) {
+            let body_bytes = request.body().and_then(|b| b.as_bytes());
+            let body = body_bytes.map(|b| {
+                let len = b.len().min(1024);
+                let mut out = String::from_utf8_lossy(&b[..len]).into_owned();
+                if b.len() > 1024 {
+                    out.push_str("...");
+                }
+                out
+            });
+
+            if let Some(b) = body {
+                details.body = Some(b);
+            }
+        }
+
+        let result = self.client().execute(request).await;
+
+        let duration_ms: u64 = SystemTime::now()
+            .duration_since(details.start_time)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+
+        let _enter = details.span.enter();
+        match &result {
+            Ok(resp) => {
+                tracing::debug!(
+                    url = %details.url,
+                    path = details.url.path(),
+                    operation_id = %details.op_id,
+                    remote_addr = resp.remote_addr().map(|a| a.to_string()),
+                    http.request.method = %details.method,
+                    http.request.body = details.body,
+                    http.response.content_length = resp.content_length(),
+                    http.response.status_code = resp.status().as_u16(),
+                    start_time = format_time(details.start_time),
+                    duration_ms,
+                    oxide.request_id = get_request_id(resp),
+                    "request succeeded",
+                );
+            }
+            Err(e) => {
+                use std::error::Error;
+                tracing::debug!(
+                    url = %details.url,
+                    path = details.url.path(),
+                    operation_id = %details.op_id,
+                    http.request.method = %details.method,
+                    http.request.body = details.body,
+                    http.response.status_code = ?e.status(),
+                    start_time = format_time(details.start_time),
+                    duration_ms,
+                    error.message = e.to_string(),
+                    error.cause = ?e.source(),
+                    "request failed",
+                );
+            }
+        }
+        result
+    }
+}
+
+fn get_request_id(response: &reqwest::Response) -> Option<&str> {
+    response
+        .headers()
+        .get("x-request-id")
+        .and_then(|id| id.to_str().ok())
+        .map(|id| id.trim_matches('"'))
+}
+
+fn format_time(time: SystemTime) -> String {
+    let datetime = time
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| DateTime::from_timestamp(d.as_secs() as i64, d.subsec_nanos()))
+        .ok()
+        .flatten()
+        .unwrap_or_else(Utc::now);
+
+    datetime.format("%Y-%m-%dT%H:%M:%S.%6fZ").to_string()
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -48,6 +48,7 @@ pub enum OxideAuthError {
     NoAuthenticatedHosts,
 }
 
+// Hook into the generated API client to capture and log request metadata.
 impl progenitor_client::ClientHooks for Client {
     async fn exec(
         &self,


### PR DESCRIPTION
when debug logging is enabled. Adding debug logging for all requests will enable users to troubleshoot issues on any API endpoint.

To do this, we use the newly added exec hook feature in Progenitor to capture the details of the API call.

In addition to the log event, we also create a `Span`. This is ignored by the CLI, but may be useful for other consumers of the SDK that want to integrate it with their monitoring infrastructure.

An example event:

  {
    "timestamp": "2025-05-07T19:51:02.464942Z",
    "level": "DEBUG",
    "message": "request succeeded",
    "url": "https://oxide.sys.r3.oxide-preview.com/v1/instances?project=will",
    "path": "/v1/instances",
    "operation_id": "instance_list",
    "remote_addr": "45.154.216.35:443",
    "http.request.method": "GET",
    "http.response.content_length": 2377,
    "http.response.status_code": 200,
    "start_time": "2025-05-07T19:51:02.079228Z",
    "duration_ms": 385,
    "oxide.request_id": "1ff7d872-3a14-4604-8392-1e9d6e2ba8fd",
    "target": "oxide"
  }

Closes #1014