### PR TITLE
Add basic support bundle support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -477,6 +486,25 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "camino"
@@ -603,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -615,6 +643,20 @@ dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
  "ryu",
  "static_assertions",
 ]
@@ -667,6 +709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +750,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "futures-core",
+ "mio 1.0.3",
+ "parking_lot",
+ "rustix 0.38.42",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +792,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +845,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1016,6 +1130,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1656,6 +1780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1828,25 @@ dependencies = [
  "portable-atomic",
  "unicode-width 0.2.0",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2004,6 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -2108,7 +2258,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.15",
  "http 1.3.1",
@@ -2248,11 +2398,13 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "built",
+ "bytes",
+ "camino",
  "chrono",
  "clap",
  "clap_complete",
  "colored",
- "crossterm",
+ "crossterm 0.27.0",
  "dialoguer",
  "dirs",
  "dropshot",
@@ -2273,12 +2425,13 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "rand",
- "ratatui",
+ "ratatui 0.26.3",
  "rcgen",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
+ "support-bundle-viewer",
  "tabwriter",
  "tempfile",
  "test-common",
@@ -2657,8 +2810,8 @@ checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
  "bitflags",
  "cassowary",
- "compact_str",
- "crossterm",
+ "compact_str 0.7.1",
+ "crossterm 0.27.0",
  "itertools 0.12.1",
  "lru",
  "paste",
@@ -2667,6 +2820,27 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str 0.8.1",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3171,6 +3345,7 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
+ "mio 1.0.3",
  "signal-hook",
 ]
 
@@ -3182,6 +3357,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
@@ -3358,6 +3539,22 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "support-bundle-viewer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960873bebab69a59f0f8506f78319b924a251bd8fbb24eeca162059cfc3a1fd6"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "camino",
+ "crossterm 0.28.1",
+ "ratatui 0.29.0",
+ "tokio",
+ "zip",
+]
 
 [[package]]
 name = "syn"
@@ -4207,7 +4404,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4632,4 +4829,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "zip"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+dependencies = [
+ "arbitrary",
+ "bzip2",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ assert_cmd = "2.0.17"
 async-trait = "0.1.88"
 base64 = "0.22.1"
 built = { version = "0.7.7", features = ["git2"] }
+bytes = "1.10.1"
+camino = { version = "1.1", features = ["serde1"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive", "string", "env", "wrap_help"] }
 clap_complete = "4.5.48"
@@ -55,6 +57,7 @@ schemars = { version = "0.8.20", features = ["chrono", "uuid1"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.139"
 similar = "2.7.0"
+support-bundle-viewer = "0.1.0"
 tabwriter = "1.4.1"
 thiserror = "2.0.11"
 tempfile = "3.19.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,8 @@ dist = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
+camino = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
@@ -44,6 +46,7 @@ reqwest = { workspace = true, features = ["native-tls-vendored"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+support-bundle-viewer = { workspace = true }
 tabwriter = { workspace = true }
 thouart = { workspace = true }
 toml = { workspace = true }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -557,6 +557,122 @@
       ]
     },
     {
+      "name": "bundle",
+      "args": [
+        {
+          "long": "profile",
+          "help": "Configuration profile to use for commands",
+          "global": true
+        }
+      ],
+      "subcommands": [
+        {
+          "name": "create",
+          "about": "Create a new support bundle",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands",
+              "global": true
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "about": "Delete an existing support bundle",
+          "long_about": "May also be used to cancel a support bundle which is currently being collected, or to remove metadata for a support bundle that has failed.",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands",
+              "global": true
+            },
+            {
+              "long": "support-bundle",
+              "help": "ID of the support bundle"
+            }
+          ]
+        },
+        {
+          "name": "download",
+          "about": "Downloads a support bundle",
+          "args": [
+            {
+              "long": "id",
+              "help": "ID of the bundle"
+            },
+            {
+              "long": "output",
+              "short": "o",
+              "help": "Path where the bundle should be downloaded"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands",
+              "global": true
+            }
+          ]
+        },
+        {
+          "name": "inspect",
+          "about": "Inspects a support bundle",
+          "long_about": "Inspects a support bundle\n\nSupport bundles may be inspected before they are downloaded (via\nsmaller HTTP requests), or after the entire zip file has been\ndownloaded.",
+          "args": [
+            {
+              "long": "id",
+              "help": "ID of the bundle to be inspected, if accessing via API"
+            },
+            {
+              "long": "path",
+              "short": "p",
+              "help": "Path of the bundle to inspect, if downloaded"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands",
+              "global": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "about": "List all support bundles",
+          "args": [
+            {
+              "long": "limit",
+              "help": "Maximum number of items returned by a single call"
+            },
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands",
+              "global": true
+            },
+            {
+              "long": "sort-by",
+              "values": [
+                "id_ascending"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "about": "View a support bundle",
+          "args": [
+            {
+              "long": "profile",
+              "help": "Configuration profile to use for commands",
+              "global": true
+            },
+            {
+              "long": "support-bundle",
+              "help": "ID of the support bundle"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "certificate",
       "args": [
         {

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -647,13 +647,16 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
             Some("experimental system timeseries schema list")
         }
 
-        // Support bundles are not yet implemented.
-        CliCommand::SupportBundleList
-        | CliCommand::SupportBundleCreate
-        | CliCommand::SupportBundleView
-        | CliCommand::SupportBundleDelete
-        | CliCommand::SupportBundleDownload
-        | CliCommand::SupportBundleHead
+        // Support bundle commands
+        CliCommand::SupportBundleList => Some("bundle list"),
+        CliCommand::SupportBundleCreate => Some("bundle create"),
+        CliCommand::SupportBundleView => Some("bundle view"),
+        CliCommand::SupportBundleDelete => Some("bundle delete"),
+        // Implemented as custom command to specify output file
+        CliCommand::SupportBundleDownload => None,
+
+        // Support bundles are not fully implemented.
+        CliCommand::SupportBundleHead
         | CliCommand::SupportBundleDownloadFile
         | CliCommand::SupportBundleHeadFile
         | CliCommand::SupportBundleIndex => None,

--- a/cli/src/cmd_support_bundle.rs
+++ b/cli/src/cmd_support_bundle.rs
@@ -1,0 +1,238 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2025 Oxide Computer Company
+
+use anyhow::bail;
+use anyhow::Context as _;
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Buf;
+use bytes::Bytes;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use clap::Parser;
+use futures::Stream;
+use futures::StreamExt;
+use oxide::Client;
+use oxide::ClientHiddenExt;
+use std::io;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+use support_bundle_viewer::BoxedFileAccessor;
+use support_bundle_viewer::LocalFileAccess;
+use support_bundle_viewer::SupportBundleAccessor;
+use support_bundle_viewer::SupportBundleIndex;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWriteExt;
+use tokio::io::ReadBuf;
+use uuid::Uuid;
+
+/// Downloads a support bundle
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(args_conflicts_with_subcommands(true))]
+pub struct CmdDownload {
+    /// ID of the bundle
+    #[clap(long)]
+    id: Uuid,
+
+    /// Path where the bundle should be downloaded
+    #[clap(short, long)]
+    output: Utf8PathBuf,
+}
+
+#[async_trait]
+impl crate::AuthenticatedCmd for CmdDownload {
+    fn is_subtree() -> bool {
+        false
+    }
+
+    async fn run(&self, client: &Client) -> Result<()> {
+        let mut output = tokio::fs::File::create(&self.output)
+            .await
+            .with_context(|| format!("Cannot create output file: {}", self.output))?;
+
+        // NOTE: It might be worth adding a progress bar here?
+        let mut stream = client
+            .support_bundle_download()
+            .support_bundle(self.id)
+            .send()
+            .await?
+            .into_inner_stream();
+
+        while let Some(data) = stream.next().await {
+            match data {
+                Err(err) => bail!(err),
+                Ok(data) => output.write_all(&data).await?,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Inspects a support bundle
+///
+/// Support bundles may be inspected before they are downloaded (via
+/// smaller HTTP requests), or after the entire zip file has been
+/// downloaded.
+#[derive(Parser, Debug, Clone)]
+#[command(verbatim_doc_comment)]
+#[command(args_conflicts_with_subcommands(true))]
+pub struct CmdInspect {
+    /// ID of the bundle to be inspected, if accessing via API
+    #[clap(long)]
+    id: Option<Uuid>,
+
+    /// Path of the bundle to inspect, if downloaded
+    #[clap(short, long)]
+    path: Option<Utf8PathBuf>,
+}
+
+#[async_trait]
+impl crate::AuthenticatedCmd for CmdInspect {
+    fn is_subtree() -> bool {
+        false
+    }
+
+    async fn run(&self, client: &Client) -> Result<()> {
+        let accessor: Box<dyn SupportBundleAccessor> = match (self.id, &self.path) {
+            (None, Some(path)) => Box::new(LocalFileAccess::new(path)?),
+            (Some(id), None) => Box::new(ApiAccess::new(client, id)),
+            (None, None) => {
+                bail!("Must specify at least one of --id or --path");
+            }
+            (Some(_), Some(_)) => {
+                bail!("Cannot specify both --id and --path");
+            }
+        };
+
+        support_bundle_viewer::run_dashboard(accessor).await
+    }
+}
+
+struct StreamedFile<'a> {
+    client: &'a Client,
+    id: Uuid,
+    path: Utf8PathBuf,
+    stream: Option<Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>>>,
+    buffer: Bytes,
+}
+
+impl<'a> StreamedFile<'a> {
+    fn new(client: &'a Client, id: Uuid, path: Utf8PathBuf) -> Self {
+        Self {
+            client,
+            id,
+            path,
+            stream: None,
+            buffer: Bytes::new(),
+        }
+    }
+
+    // NOTE: This is a distinct method from "new", because ideally some day we could
+    // use range requests to stream out portions of the file.
+    //
+    // This means that we would potentially want to restart the stream with a different position.
+    async fn start_stream(&mut self) -> anyhow::Result<()> {
+        // TODO: Add range headers, for range requests? Though this
+        // will require adding support to Progenitor + Nexus too.
+        let stream = self
+            .client
+            .support_bundle_download_file()
+            .support_bundle(self.id)
+            .file(self.path.as_str())
+            .send()
+            .await
+            .with_context(|| format!("downloading support bundle file {}: {}", self.id, self.path))?
+            .into_inner_stream();
+
+        self.stream = Some(Box::pin(stream));
+        Ok(())
+    }
+}
+
+impl AsyncRead for StreamedFile<'_> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        while self.buffer.is_empty() {
+            match futures::ready!(self
+                .stream
+                .as_mut()
+                .expect("Stream must be initialized before polling")
+                .as_mut()
+                .poll_next(cx))
+            {
+                Some(Ok(bytes)) => {
+                    self.buffer = bytes;
+                }
+                Some(Err(e)) => {
+                    return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, e)));
+                }
+                None => return Poll::Ready(Ok(())), // EOF
+            }
+        }
+
+        let to_copy = std::cmp::min(self.buffer.len(), buf.remaining());
+        buf.put_slice(&self.buffer[..to_copy]);
+        self.buffer.advance(to_copy);
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Access to a support bundle from the external API
+struct ApiAccess<'a> {
+    client: &'a Client,
+    id: Uuid,
+}
+
+impl<'a> ApiAccess<'a> {
+    fn new(client: &'a Client, id: Uuid) -> Self {
+        Self { client, id }
+    }
+}
+
+async fn utf8_stream_to_string(
+    mut stream: impl futures::Stream<Item = reqwest::Result<bytes::Bytes>> + std::marker::Unpin,
+) -> anyhow::Result<String> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8(bytes)?)
+}
+
+#[async_trait]
+impl<'c> SupportBundleAccessor for ApiAccess<'c> {
+    async fn get_index(&self) -> anyhow::Result<SupportBundleIndex> {
+        let stream = self
+            .client
+            .support_bundle_index()
+            .support_bundle(self.id)
+            .send()
+            .await
+            .with_context(|| format!("downloading support bundle index {}", self.id))?
+            .into_inner_stream();
+        let s = utf8_stream_to_string(stream).await?;
+
+        Ok(SupportBundleIndex::new(&s))
+    }
+
+    async fn get_file<'a>(&mut self, path: &Utf8Path) -> anyhow::Result<BoxedFileAccessor<'a>>
+    where
+        'c: 'a,
+    {
+        let mut file = StreamedFile::new(self.client, self.id, path.to_path_buf());
+        file.start_stream()
+            .await
+            .with_context(|| "failed to start stream in get_file")?;
+        Ok(Box::new(file))
+    }
+}

--- a/cli/src/cmd_support_bundle.rs
+++ b/cli/src/cmd_support_bundle.rs
@@ -46,10 +46,6 @@ pub struct CmdDownload {
 
 #[async_trait]
 impl crate::AuthenticatedCmd for CmdDownload {
-    fn is_subtree() -> bool {
-        false
-    }
-
     async fn run(&self, client: &Client) -> Result<()> {
         let mut output = tokio::fs::File::create(&self.output)
             .await
@@ -93,10 +89,6 @@ pub struct CmdInspect {
 
 #[async_trait]
 impl crate::AuthenticatedCmd for CmdInspect {
-    fn is_subtree() -> bool {
-        false
-    }
-
     async fn run(&self, client: &Client) -> Result<()> {
         let accessor: Box<dyn SupportBundleAccessor> = match (self.id, &self.path) {
             (None, Some(path)) => Box::new(LocalFileAccess::new(path)?),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,7 @@ mod cmd_disk;
 mod cmd_docs;
 mod cmd_instance;
 mod cmd_net;
+mod cmd_support_bundle;
 mod cmd_timeseries;
 mod context;
 
@@ -94,6 +95,8 @@ pub fn make_cli() -> NewCli<'static> {
         .add_custom::<cmd_net::CmdBgpAuth>("system networking bgp auth")
         .add_custom::<cmd_net::CmdBgpLocalPref>("system networking bgp pref")
         .add_custom::<cmd_net::CmdStaticRoute>("system networking route")
+        .add_custom::<cmd_support_bundle::CmdDownload>("bundle download")
+        .add_custom::<cmd_support_bundle::CmdInspect>("bundle inspect")
 }
 
 #[tokio::main(flavor = "current_thread")]


### PR DESCRIPTION
This mimics commands already present in omdb, relying on the new https://github.com/oxidecomputer/support-bundle-viewer crate to access the same logic for the TUI.

The implementation of `SupportBundleAccessor` is similar to the implementation used by the internal API, but in this case, using the external API instead.