### PR TITLE
Set longer timeout and read_timeout for bundles

### DIFF
--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -272,6 +272,18 @@ impl<'a> NewCli<'a> {
         if let Some(timeout) = timeout {
             client_config = client_config.with_timeout(timeout);
         }
+        if let Some("bundle") = matches.subcommand_name() {
+            // Keep a reasonable timeout for initial connection.
+            client_config = client_config.with_connect_timeout(15);
+
+            // Bundles may be tens of gigabytes, set a one hour timeout by default.
+            if timeout.is_none() {
+                client_config = client_config.with_timeout(60 * 60);
+            }
+
+            // Kill the connection if we stop receiving data before the connection timeout.
+            client_config = client_config.with_read_timeout(30);
+        }
 
         let ctx = Context::new(client_config)?;
 

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -272,7 +272,11 @@ impl<'a> NewCli<'a> {
         if let Some(timeout) = timeout {
             client_config = client_config.with_timeout(timeout);
         }
-        if let Some("bundle") = matches.subcommand_name() {
+
+        // Set longer timeouts for potentially slow support-bundle subcommands.
+        if matches.subcommand_matches("bundle").is_some_and(|bundle| {
+            matches!(bundle.subcommand_name(), Some("download") | Some("inspect"))
+        }) {
             // Keep a reasonable timeout for initial connection.
             client_config = client_config.with_connect_timeout(15);
 


### PR DESCRIPTION
Commands that interact with support bundles may be much slower than the typical external API endpoint, as bundles may reach tens of gigabytes.

If performing a bundle-related subcommand, set a default timeout of 60 minutes. Previously we would set `connect_timeout` and `timeout` to the same value, but one hour is not reasonable for the initial `connect_timeout`, so we add a separate config item for that.

To avoid keeping an idle connection open, also add a `read_timeout` option, which will terminate a connection prior to its timeout when no data is received.

Closes #1095