### PR TITLE
Take paths instead of base64 for SAML creation

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1051,10 +1051,6 @@
               "help": "The version of this image (e.g. 11, focal, a9e77e3a, 2023-04-06T14:23:34Z)"
             },
             {
-              "long": "parallelism",
-              "help": "The degree or parallelism to use during upload"
-            },
-            {
               "long": "path",
               "help": "Path to the file to import"
             },
@@ -4656,26 +4652,28 @@
                       "help": "idp's entity id"
                     },
                     {
-                      "long": "json-body",
-                      "help": "Path to a file that contains the full json body."
+                      "long": "metadata-path",
+                      "help": "the path to an XML file containing an identity provider metadata descriptor"
                     },
                     {
-                      "long": "json-body-template",
-                      "help": "XXX"
-                    },
-                    {
-                      "long": "metadata-url"
-                    },
-                    {
-                      "long": "metadata-value"
+                      "long": "metadata-url",
+                      "help": "the URL of an identity provider metadata descriptor"
                     },
                     {
                       "long": "name"
                     },
                     {
+                      "long": "private-key-path",
+                      "help": "the path to the request signing RSA private key in PKCS#1 DER format"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
+                    },
+                    {
+                      "long": "public-cert-path",
+                      "help": "the path to the request signing public certificate in DER format"
                     },
                     {
                       "long": "silo",

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -4652,6 +4652,14 @@
                       "help": "idp's entity id"
                     },
                     {
+                      "long": "json-body",
+                      "help": "Path to a file that contains the full json body."
+                    },
+                    {
+                      "long": "json-body-template",
+                      "help": "XXX"
+                    },
+                    {
                       "long": "metadata-url",
                       "help": "the URL of an identity provider metadata descriptor"
                     },

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -4652,19 +4652,19 @@
                       "help": "idp's entity id"
                     },
                     {
-                      "long": "metadata-path",
-                      "help": "the path to an XML file containing an identity provider metadata descriptor"
-                    },
-                    {
                       "long": "metadata-url",
                       "help": "the URL of an identity provider metadata descriptor"
+                    },
+                    {
+                      "long": "metadata-value",
+                      "help": "path to an XML file containing an identity provider metadata descriptor"
                     },
                     {
                       "long": "name"
                     },
                     {
-                      "long": "private-key-path",
-                      "help": "the path to the request signing RSA private key in PKCS#1 DER format"
+                      "long": "private-key",
+                      "help": "path to the request signing RSA private key in PKCS#1 DER format"
                     },
                     {
                       "long": "profile",
@@ -4672,8 +4672,8 @@
                       "global": true
                     },
                     {
-                      "long": "public-cert-path",
-                      "help": "the path to the request signing public certificate in DER format"
+                      "long": "public-cert",
+                      "help": "path to the request signing public certificate in DER format"
                     },
                     {
                       "long": "silo",

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -135,8 +135,7 @@ impl Default for NewCli<'_> {
                     ),
 
                 CliCommand::SamlIdentityProviderCreate => cmd
-                    .mut_arg("json-body", |arg| arg.required(false).hide(true))
-                    .mut_arg("json-body-template", |arg| arg.hide(true))
+                    .mut_arg("json-body", |arg| arg.required(false))
                     .arg(
                         clap::Arg::new("metadata-url")
                             .long("metadata-url")

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -135,22 +135,45 @@ impl Default for NewCli<'_> {
                     ),
 
                 CliCommand::SamlIdentityProviderCreate => cmd
-                    .mut_arg("json-body", |arg| arg.required(false))
+                    .mut_arg("json-body", |arg| arg.required(false).hide(true))
+                    .mut_arg("json-body-template", |arg| arg.hide(true))
                     .arg(
                         clap::Arg::new("metadata-url")
                             .long("metadata-url")
                             .value_name("url")
-                            .value_parser(clap::value_parser!(String)),
+                            .value_parser(clap::value_parser!(String))
+                            .help("the URL of an identity provider metadata descriptor"),
                     )
                     .arg(
-                        clap::Arg::new("metadata-value")
-                            .long("metadata-value")
-                            .value_name("xml")
-                            .value_parser(clap::value_parser!(String)),
+                        clap::Arg::new("metadata-path")
+                            .long("metadata-path")
+                            .value_name("xml_file")
+                            .value_parser(clap::value_parser!(PathBuf))
+                            .help("the path to an XML file containing an identity provider metadata descriptor"),
+                    )
+                    .arg(
+                        clap::Arg::new("private-key-path")
+                            .long("private-key-path")
+                            .value_name("key_file")
+                            .value_parser(clap::value_parser!(PathBuf))
+                            .help("the path to the request signing RSA private key in PKCS#1 DER format"),
+                    )
+                    .arg(
+                        clap::Arg::new("public-cert-path")
+                            .long("public-cert-path")
+                            .value_name("cert_file")
+                            .value_parser(clap::value_parser!(PathBuf))
+                            .help("the path to the request signing public certificate in DER format"),
+                    )
+                    .group(
+                        clap::ArgGroup::new("signing_keypair")
+                            .args(["private-key-path", "public-cert-path"])
+                            .requires_all(["private-key-path", "public-cert-path"])
+                            .multiple(true),
                     )
                     .group(
                         clap::ArgGroup::new("idp_metadata_source")
-                            .args(["metadata-url", "metadata-value"])
+                            .args(["metadata-url", "metadata-path"])
                             .required(true)
                             .multiple(false),
                     ),

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -145,35 +145,35 @@ impl Default for NewCli<'_> {
                             .help("the URL of an identity provider metadata descriptor"),
                     )
                     .arg(
-                        clap::Arg::new("metadata-path")
-                            .long("metadata-path")
-                            .value_name("xml_file")
+                        clap::Arg::new("metadata-value")
+                            .long("metadata-value")
+                            .value_name("xml-file")
                             .value_parser(clap::value_parser!(PathBuf))
-                            .help("the path to an XML file containing an identity provider metadata descriptor"),
+                            .help("path to an XML file containing an identity provider metadata descriptor"),
                     )
                     .arg(
-                        clap::Arg::new("private-key-path")
-                            .long("private-key-path")
-                            .value_name("key_file")
+                        clap::Arg::new("private-key")
+                            .long("private-key")
+                            .value_name("key-file")
                             .value_parser(clap::value_parser!(PathBuf))
-                            .help("the path to the request signing RSA private key in PKCS#1 DER format"),
+                            .help("path to the request signing RSA private key in PKCS#1 DER format"),
                     )
                     .arg(
-                        clap::Arg::new("public-cert-path")
-                            .long("public-cert-path")
-                            .value_name("cert_file")
+                        clap::Arg::new("public-cert")
+                            .long("public-cert")
+                            .value_name("cert-file")
                             .value_parser(clap::value_parser!(PathBuf))
-                            .help("the path to the request signing public certificate in DER format"),
+                            .help("path to the request signing public certificate in DER format"),
                     )
                     .group(
                         clap::ArgGroup::new("signing_keypair")
-                            .args(["private-key-path", "public-cert-path"])
-                            .requires_all(["private-key-path", "public-cert-path"])
+                            .args(["private-key", "public-cert"])
+                            .requires_all(["private-key", "public-cert"])
                             .multiple(true),
                     )
                     .group(
                         clap::ArgGroup::new("idp_metadata_source")
-                            .args(["metadata-url", "metadata-path"])
+                            .args(["metadata-url", "metadata-value"])
                             .required(true)
                             .multiple(false),
                     ),

--- a/cli/src/cmd_docs.rs
+++ b/cli/src/cmd_docs.rs
@@ -66,6 +66,7 @@ fn to_json(cmd: &Command) -> JsonDoc {
     let mut args = cmd
         .get_arguments()
         .filter(|arg| arg.get_long() != Some("help"))
+        .filter(|arg| !arg.is_hide_set())
         .map(|arg| JsonArg {
             name: (arg.get_long().is_none() && arg.get_short().is_none())
                 .then_some(arg.get_id().to_string()),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -255,8 +255,8 @@ impl CliConfig for OxideOverride {
                 });
                 Ok::<_, anyhow::Error>(())
             }
-            Some("metadata-path") => {
-                let xml_path = matches.get_one::<PathBuf>("metadata-path").unwrap();
+            Some("metadata-value") => {
+                let xml_path = matches.get_one::<PathBuf>("metadata-value").unwrap();
                 let xml_bytes = std::fs::read(xml_path).with_context(|| {
                     format!("failed to read metadata XML file {}", xml_path.display())
                 })?;
@@ -272,13 +272,13 @@ impl CliConfig for OxideOverride {
         }?;
 
         if matches.get_one::<clap::Id>("signing_keypair").is_some() {
-            let privkey_path = matches.get_one::<PathBuf>("private-key-path").unwrap();
+            let privkey_path = matches.get_one::<PathBuf>("private-key").unwrap();
             let privkey_bytes = std::fs::read(privkey_path).with_context(|| {
                 format!("failed to read private key file {}", privkey_path.display())
             })?;
             let encoded_privkey = base64::engine::general_purpose::STANDARD.encode(&privkey_bytes);
 
-            let cert_path = matches.get_one::<PathBuf>("public-cert-path").unwrap();
+            let cert_path = matches.get_one::<PathBuf>("public-cert").unwrap();
             let cert_bytes = std::fs::read(cert_path).with_context(|| {
                 format!("failed to read public cert file {}", cert_path.display())
             })?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,15 +9,19 @@
 
 use std::io;
 use std::net::IpAddr;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use async_trait::async_trait;
+use base64::Engine;
 use cli_builder::NewCli;
 use context::Context;
 use generated_cli::CliConfig;
 use oxide::{
-    types::{AllowedSourceIps, IdpMetadataSource, IpRange, Ipv4Range, Ipv6Range},
+    types::{
+        AllowedSourceIps, DerEncodedKeyPair, IdpMetadataSource, IpRange, Ipv4Range, Ipv6Range,
+    },
     Client,
 };
 use url::Url;
@@ -249,16 +253,43 @@ impl CliConfig for OxideOverride {
                 *request = request.to_owned().body_map(|body| {
                     body.idp_metadata_source(IdpMetadataSource::Url { url: value.clone() })
                 });
+                Ok::<_, anyhow::Error>(())
             }
-            Some("metadata-value") => {
-                let value = matches.get_one::<String>("metadata-value").unwrap();
+            Some("metadata-path") => {
+                let xml_path = matches.get_one::<PathBuf>("metadata-path").unwrap();
+                let xml_bytes = std::fs::read(xml_path).with_context(|| {
+                    format!("failed to read metadata XML file {}", xml_path.display())
+                })?;
+                let encoded_xml = base64::engine::general_purpose::STANDARD.encode(xml_bytes);
                 *request = request.to_owned().body_map(|body| {
                     body.idp_metadata_source(IdpMetadataSource::Base64EncodedXml {
-                        data: value.clone(),
+                        data: encoded_xml,
                     })
                 });
+                Ok(())
             }
             _ => unreachable!("invalid value for idp_metadata_source group"),
+        }?;
+
+        if matches.get_one::<clap::Id>("signing_keypair").is_some() {
+            let privkey_path = matches.get_one::<PathBuf>("private-key-path").unwrap();
+            let privkey_bytes = std::fs::read(privkey_path).with_context(|| {
+                format!("failed to read private key file {}", privkey_path.display())
+            })?;
+            let encoded_privkey = base64::engine::general_purpose::STANDARD.encode(&privkey_bytes);
+
+            let cert_path = matches.get_one::<PathBuf>("public-cert-path").unwrap();
+            let cert_bytes = std::fs::read(cert_path).with_context(|| {
+                format!("failed to read public cert file {}", cert_path.display())
+            })?;
+            let encoded_cert = base64::engine::general_purpose::STANDARD.encode(&cert_bytes);
+
+            *request = request.to_owned().body_map(|body| {
+                body.signing_keypair(DerEncodedKeyPair {
+                    private_key: encoded_privkey,
+                    public_cert: encoded_cert,
+                })
+            });
         }
         Ok(())
     }

--- a/cli/tests/data/test_silo_idp_saml_create_requires_key_and_cert.stderr
+++ b/cli/tests/data/test_silo_idp_saml_create_requires_key_and_cert.stderr
@@ -1,0 +1,6 @@
+error: the following required arguments were not provided:
+  --public-cert <cert-file>
+
+Usage: oxide silo idp saml create --silo <silo> --private-key <key-file> --public-cert <cert-file> --name <name> --description <description> --acs-url <acs-url> --slo-url <slo-url> --sp-client-id <sp-client-id> --idp-entity-id <idp-entity-id> --technical-contact-email <technical-contact-email> <--metadata-url <url>|--metadata-value <xml-file>>
+
+For more information, try '--help'.

--- a/cli/tests/data/test_silo_idp_saml_create_requires_key_and_cert.stderr
+++ b/cli/tests/data/test_silo_idp_saml_create_requires_key_and_cert.stderr
@@ -1,6 +1,0 @@
-error: the following required arguments were not provided:
-  --public-cert <cert-file>
-
-Usage: oxide silo idp saml create --silo <silo> --private-key <key-file> --public-cert <cert-file> --name <name> --description <description> --acs-url <acs-url> --slo-url <slo-url> --sp-client-id <sp-client-id> --idp-entity-id <idp-entity-id> --technical-contact-email <technical-contact-email> <--metadata-url <url>|--metadata-value <xml-file>>
-
-For more information, try '--help'.

--- a/cli/tests/data/test_silo_idp_saml_create_with_files.stdout
+++ b/cli/tests/data/test_silo_idp_saml_create_with_files.stdout
@@ -1,0 +1,13 @@
+{
+  "acs_url": "http://nope.nope",
+  "description": "for all the security I guess",
+  "id": "6270889a-e74d-fa7c-849b-22449cd6138e",
+  "idp_entity_id": "17",
+  "name": "samlrific",
+  "public_cert": "bXkgY29vbCBwdWJsaWMga2V5",
+  "slo_url": "http://nope.nope",
+  "sp_client_id": "17",
+  "technical_contact_email": "anyone@but.adam",
+  "time_created": "1977-12-10T14:17:08Z",
+  "time_modified": "2022-11-13T08:30:19Z"
+}

--- a/cli/tests/test_silo_idp_saml.rs
+++ b/cli/tests/test_silo_idp_saml.rs
@@ -207,8 +207,5 @@ fn test_silo_idp_saml_create_requires_key_and_cert() {
         .arg("--private-key")
         .arg("/fails-without-cert")
         .assert()
-        .failure()
-        .stderr(expectorate::eq_file_or_panic(
-            "tests/data/test_silo_idp_saml_create_requires_key_and_cert.stderr",
-        ));
+        .failure();
 }

--- a/cli/tests/test_silo_idp_saml.rs
+++ b/cli/tests/test_silo_idp_saml.rs
@@ -5,10 +5,14 @@
 // Copyright 2023 Oxide Computer Company
 
 use assert_cmd::Command;
+use base64::Engine;
 use httpmock::MockServer;
-use oxide::types::{IdpMetadataSource, SamlIdentityProvider, SamlIdentityProviderCreate};
+use oxide::types::{
+    DerEncodedKeyPair, IdpMetadataSource, SamlIdentityProvider, SamlIdentityProviderCreate,
+};
 use oxide_httpmock::MockServerExt;
 use rand::SeedableRng;
+use tempfile::TempDir;
 use test_common::JsonMock;
 
 #[test]
@@ -77,4 +81,134 @@ fn test_silo_idp_saml_create() {
         ));
 
     mock.assert();
+}
+
+#[test]
+fn test_silo_idp_saml_create_with_files() {
+    let mut src = rand::rngs::SmallRng::seed_from_u64(42);
+    let server = MockServer::start();
+
+    let tmp = TempDir::new().unwrap();
+
+    let xml = "<foo>XML</foo>";
+    let encoded_xml = base64::engine::general_purpose::STANDARD.encode(xml);
+    let xml_path = tmp.path().join("metadata.xml");
+    std::fs::write(&xml_path, xml).unwrap();
+
+    let key = "my cool private key";
+    let encoded_key = base64::engine::general_purpose::STANDARD.encode(key);
+    let key_path = tmp.path().join("key.pem");
+    std::fs::write(&key_path, key).unwrap();
+
+    let cert = "my cool public key";
+    let encoded_cert = base64::engine::general_purpose::STANDARD.encode(cert);
+    let cert_path = tmp.path().join("cert.pem");
+    std::fs::write(&cert_path, cert).unwrap();
+
+    let mock = server.saml_identity_provider_create(|when, then| {
+        let body = SamlIdentityProviderCreate::builder()
+            .name("samlrific")
+            .description("for all the security I guess")
+            .acs_url("http://nope.nope")
+            .slo_url("http://nope.nope")
+            .sp_client_id("17")
+            .idp_entity_id("17")
+            .idp_metadata_source(IdpMetadataSource::Base64EncodedXml { data: encoded_xml })
+            .technical_contact_email("anyone@but.adam")
+            .signing_keypair(DerEncodedKeyPair {
+                private_key: encoded_key,
+                public_cert: encoded_cert,
+            })
+            .try_into()
+            .unwrap();
+        when.body(&body);
+        then.created(&SamlIdentityProvider {
+            acs_url: body.acs_url.clone(),
+            description: body.description.clone(),
+            idp_entity_id: body.idp_entity_id.clone(),
+            name: body.name.clone(),
+            slo_url: body.slo_url.clone(),
+            sp_client_id: body.sp_client_id.clone(),
+            technical_contact_email: body.technical_contact_email,
+            public_cert: body.signing_keypair.map(|kp| kp.public_cert),
+            ..JsonMock::mock_value(&mut src).unwrap()
+        });
+    });
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("silo")
+        .arg("idp")
+        .arg("saml")
+        .arg("create")
+        .arg("--name")
+        .arg("samlrific")
+        .arg("--description")
+        .arg("for all the security I guess")
+        .arg("--silo")
+        .arg("mysilo")
+        .arg("--acs-url")
+        .arg("http://nope.nope")
+        .arg("--slo-url")
+        .arg("http://nope.nope")
+        .arg("--sp-client-id")
+        .arg("17")
+        .arg("--idp-entity-id")
+        .arg("17")
+        .arg("--metadata-value")
+        .arg(&xml_path)
+        .arg("--technical-contact-email")
+        .arg("anyone@but.adam")
+        .arg("--private-key")
+        .arg(&key_path)
+        .arg("--public-cert")
+        .arg(&cert_path)
+        .assert()
+        .success()
+        .stdout(expectorate::eq_file_or_panic(
+            "tests/data/test_silo_idp_saml_create_with_files.stdout",
+        ));
+
+    mock.assert();
+}
+
+#[test]
+fn test_silo_idp_saml_create_requires_key_and_cert() {
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", "invalid.url")
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("silo")
+        .arg("idp")
+        .arg("saml")
+        .arg("create")
+        .arg("--name")
+        .arg("samlrific")
+        .arg("--description")
+        .arg("for all the security I guess")
+        .arg("--silo")
+        .arg("mysilo")
+        .arg("--acs-url")
+        .arg("http://nope.nope")
+        .arg("--slo-url")
+        .arg("http://nope.nope")
+        .arg("--sp-client-id")
+        .arg("17")
+        .arg("--idp-entity-id")
+        .arg("17")
+        .arg("--metadata-url")
+        .arg("http://nope.nope")
+        .arg("--technical-contact-email")
+        .arg("anyone@but.adam")
+        .arg("--private-key")
+        .arg("/fails-without-cert")
+        .assert()
+        .failure()
+        .stderr(expectorate::eq_file_or_panic(
+            "tests/data/test_silo_idp_saml_create_requires_key_and_cert.stderr",
+        ));
 }


### PR DESCRIPTION
Currently the CLI's SAML IdP creation flow does not provide flags for signing keys, requiring the cryptic `--json-body` argument. These and the XML metadata must be manually base64-encoded by the user as well.

Make this process more convenient by converting the keys and XML metadata args to take the path of the source files, which we then read and encode ourselves.

While we're at it, stop generating docs for hidden items.

Example command:

```
$ oxide silo idp saml create \
--silo cli \
--name "keycloak" \
--description "Keybloke" \
--sp-client-id cli \
--acs-url "https://cli.sys.example.com/login/cli/saml/keycloak" \
--idp-entity-id "https://keycloak.example.com/realms/cli" \
--slo-url "" \
--technical-contact-email "user@example.com" \
--group-attribute-name group
--metadata-path ./cli-metadata.xml \
--public-cert-path ./cli-cert.der \
--private-key-path ./cli-key.der
```