### PR TITLE
Fixups for new commands

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -6919,6 +6919,56 @@
               ]
             },
             {
+              "name": "inbound-icmp",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands",
+                  "global": true
+                }
+              ],
+              "subcommands": [
+                {
+                  "name": "update",
+                  "about": "Set whether API services can receive limited ICMP traffic",
+                  "args": [
+                    {
+                      "long": "enabled",
+                      "values": [
+                        "true",
+                        "false"
+                      ],
+                      "help": "When enabled, Nexus is able to receive ICMP Destination Unreachable type 3 (port unreachable) and type 4 (fragmentation needed), Redirect, and Time Exceeded messages. These enable Nexus to perform Path MTU discovery and better cope with fragmentation issues. Otherwise all inbound ICMP traffic will be dropped."
+                    },
+                    {
+                      "long": "json-body",
+                      "help": "Path to a file that contains the full json body."
+                    },
+                    {
+                      "long": "json-body-template",
+                      "help": "XXX"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    }
+                  ]
+                },
+                {
+                  "name": "view",
+                  "about": "Return whether API services can receive limited ICMP traffic",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "name": "link",
               "about": "Manage switch port links.",
               "long_about": "Manage switch port links.\n\nLinks carry layer-2 Ethernet properties for a lane or set of lanes on a\nswitch port. Lane geometry is defined in physical port settings. At the\npresent time only single lane configurations are supported, and thus only\na single link per physical port is supported.",
@@ -7720,6 +7770,90 @@
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "trust-root",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands",
+                  "global": true
+                }
+              ],
+              "subcommands": [
+                {
+                  "name": "create",
+                  "about": "Add trusted root role to updates trust store",
+                  "args": [
+                    {
+                      "long": "json-body",
+                      "help": "Path to a file that contains the full json body."
+                    },
+                    {
+                      "long": "json-body-template",
+                      "help": "XXX"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    }
+                  ]
+                },
+                {
+                  "name": "delete",
+                  "about": "Delete trusted root role",
+                  "long_about": "Note that this method does not currently check for any uploaded system release repositories that would become untrusted after deleting the root role.",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "trust-root-id",
+                      "help": "ID of the trust root"
+                    }
+                  ]
+                },
+                {
+                  "name": "list",
+                  "about": "List root roles in the updates trust store",
+                  "long_about": "A root role is a JSON document describing the cryptographic keys that are trusted to sign system release repositories, as described by The Update Framework. Uploading a repository requires its metadata to be signed by keys trusted by the trust store.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "sort-by",
+                      "values": [
+                        "id_ascending"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "view",
+                  "about": "Fetch trusted root role",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "trust-root-id",
+                      "help": "ID of the trust root"
                     }
                   ]
                 }

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -633,6 +633,10 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         // Update subcommands
         CliCommand::TargetReleaseView => Some("system update target-release view"),
         CliCommand::TargetReleaseUpdate => Some("system update target-release update"),
+        CliCommand::SystemUpdateTrustRootList => Some("system update trust-root list"),
+        CliCommand::SystemUpdateTrustRootCreate => Some("system update trust-root create"),
+        CliCommand::SystemUpdateTrustRootView => Some("system update trust-root view"),
+        CliCommand::SystemUpdateTrustRootDelete => Some("system update trust-root delete"),
         // Manually implemented
         CliCommand::SystemUpdatePutRepository => None,
         // Not implemented
@@ -657,6 +661,8 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
 
         CliCommand::NetworkingAllowListView => Some("system networking allow-list view"),
         CliCommand::NetworkingAllowListUpdate => Some("system networking allow-list update"),
+        CliCommand::NetworkingInboundIcmpView => Some("system networking inbound-icmp view"),
+        CliCommand::NetworkingInboundIcmpUpdate => Some("system networking inbound-icmp update"),
 
         CliCommand::CurrentUserView => Some("current-user view"),
         CliCommand::CurrentUserGroups => Some("current-user groups"),
@@ -730,8 +736,6 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         | CliCommand::LoginLocal
         | CliCommand::LoginSaml
         | CliCommand::Logout
-        | CliCommand::RoleList
-        | CliCommand::RoleView
         | CliCommand::SiloMetric
         | CliCommand::SystemMetric
         | CliCommand::UserBuiltinList

--- a/cli/tests/data/json-body-required.txt
+++ b/cli/tests/data/json-body-required.txt
@@ -13,3 +13,4 @@ oxide system policy update
 oxide system networking address-lot create
 oxide system networking switch-port-settings create
 oxide system networking bgp announce-set update
+oxide system update trust-root create


### PR DESCRIPTION
Adds some new (missing) system-level commands around inbound ICMP and update trust roots. I'm unsure whether the latter endpoints are handled correctly.