### PR TITLE
Enable code signing for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      SSLDOTCOM_USERNAME: ${{ secrets.SSLDOTCOM_USERNAME }}
+      SSLDOTCOM_PASSWORD: ${{ secrets.SSLDOTCOM_PASSWORD }}
+      SSLDOTCOM_CREDENTIAL_ID: ${{ secrets.SSLDOTCOM_CREDENTIAL_ID }}
+      SSLDOTCOM_TOTP_SECRET: ${{ secrets.SSLDOTCOM_TOTP_SECRET }}
       CODESIGN_CERTIFICATE: ${{ secrets.CODESIGN_CERTIFICATE }}
       CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
       CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,6 +17,8 @@ pr-run-mode = "plan"
 github-build-setup = "../manylinux.yml"
 # Whether to sign macOS executables
 macos-sign = true
+# Whether to sign Windows executables
+ssldotcom-windows-sign = "prod"
 # A GitHub repo to push Homebrew formulas to
 tap = "oxidecomputer/homebrew-tap"
 # Publish jobs to run in CI


### PR DESCRIPTION
Our SSL.com account is fully setup, enable code signing for our Windows binaries.

Closes https://github.com/oxidecomputer/oxide.rs/issues/943