### PR TITLE
cli: Set user_agent header

### DIFF
--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -272,8 +272,9 @@ impl<'a> NewCli<'a> {
             .init();
 
         let mut client_config = ClientConfig::default().with_user_agent(format!(
-            "Oxide CLI {}",
-            crate::cmd_version::built_info::PKG_VERSION
+            "oxide-cli/{} ({})",
+            crate::cmd_version::built_info::PKG_VERSION,
+            crate::cmd_version::built_info::TARGET
         ));
 
         if let Some(profile_name) = profile {

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -271,7 +271,10 @@ impl<'a> NewCli<'a> {
             .with_span_list(false)
             .init();
 
-        let mut client_config = ClientConfig::default();
+        let mut client_config = ClientConfig::default().with_user_agent(format!(
+            "Oxide CLI {}",
+            crate::cmd_version::built_info::PKG_VERSION
+        ));
 
         if let Some(profile_name) = profile {
             client_config = client_config.with_profile(profile_name);

--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -42,13 +42,13 @@ struct ResolveValue {
 pub struct ClientConfig {
     config_dir: PathBuf,
     auth_method: AuthMethod,
+    user_agent: String,
     resolve: Option<ResolveValue>,
     cert: Option<reqwest::Certificate>,
     insecure: bool,
     timeout: Option<u64>,
     connect_timeout: Option<u64>,
     read_timeout: Option<u64>,
-    user_agent: Option<String>,
 }
 
 #[derive(Clone)]
@@ -66,17 +66,13 @@ impl Default for ClientConfig {
         Self {
             config_dir,
             auth_method: AuthMethod::DefaultProfile,
+            user_agent: format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
             resolve: None,
             cert: None,
             insecure: false,
             timeout: None,
             connect_timeout: None,
             read_timeout: None,
-            user_agent: Some(format!(
-                "{} {}",
-                env!("CARGO_PKG_NAME"),
-                env!("CARGO_PKG_VERSION")
-            )),
         }
     }
 }
@@ -147,7 +143,7 @@ impl ClientConfig {
 
     /// Specify the user_agent header to be sent by the client.
     pub fn with_user_agent(mut self, user_agent: impl ToString) -> Self {
-        self.user_agent = Some(user_agent.to_string());
+        self.user_agent = user_agent.to_string();
         self
     }
 

--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -72,7 +72,11 @@ impl Default for ClientConfig {
             timeout: None,
             connect_timeout: None,
             read_timeout: None,
-            user_agent: None,
+            user_agent: Some(format!(
+                "{} {}",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION")
+            )),
         }
     }
 }
@@ -142,8 +146,8 @@ impl ClientConfig {
     }
 
     /// Specify the user_agent header to be sent by the client.
-    pub fn with_user_agent(mut self, user_agent: String) -> Self {
-        self.user_agent = Some(user_agent);
+    pub fn with_user_agent(mut self, user_agent: impl ToString) -> Self {
+        self.user_agent = Some(user_agent.to_string());
         self
     }
 

--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -48,6 +48,7 @@ pub struct ClientConfig {
     timeout: Option<u64>,
     connect_timeout: Option<u64>,
     read_timeout: Option<u64>,
+    user_agent: Option<String>,
 }
 
 #[derive(Clone)]
@@ -71,6 +72,7 @@ impl Default for ClientConfig {
             timeout: None,
             connect_timeout: None,
             read_timeout: None,
+            user_agent: None,
         }
     }
 }
@@ -136,6 +138,12 @@ impl ClientConfig {
     /// Specify the desired client read_timeout in seconds.
     pub fn with_read_timeout(mut self, read_timeout: u64) -> Self {
         self.read_timeout = Some(read_timeout);
+        self
+    }
+
+    /// Specify the user_agent header to be sent by the client.
+    pub fn with_user_agent(mut self, user_agent: String) -> Self {
+        self.user_agent = Some(user_agent);
         self
     }
 
@@ -216,6 +224,7 @@ impl ClientConfig {
             timeout,
             connect_timeout,
             read_timeout,
+            user_agent,
             ..
         } = self;
         const DEFAULT_TIMEOUT: u64 = 15;
@@ -248,6 +257,10 @@ impl ClientConfig {
             client_builder = client_builder
                 .danger_accept_invalid_hostnames(true)
                 .danger_accept_invalid_certs(true);
+        }
+
+        if let Some(user_agent) = user_agent {
+            client_builder = client_builder.user_agent(user_agent);
         }
 
         client_builder

--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -230,7 +230,7 @@ impl ClientConfig {
         const DEFAULT_TIMEOUT: u64 = 15;
 
         let dur = std::time::Duration::from_secs(timeout.unwrap_or(DEFAULT_TIMEOUT));
-        let mut client_builder = ClientBuilder::new().timeout(dur);
+        let mut client_builder = ClientBuilder::new().timeout(dur).user_agent(user_agent);
 
         // Use an explicit connect_timeout if provided, otherwise fallback to
         // timeout or default.
@@ -257,10 +257,6 @@ impl ClientConfig {
             client_builder = client_builder
                 .danger_accept_invalid_hostnames(true)
                 .danger_accept_invalid_certs(true);
-        }
-
-        if let Some(user_agent) = user_agent {
-            client_builder = client_builder.user_agent(user_agent);
         }
 
         client_builder


### PR DESCRIPTION
Our newly introduced audit log captures the user agent of the client, but currently the CLI does not set this header.

Add an option to configure the user agent to the SDK and set it for the CLI.

Closes https://github.com/oxidecomputer/oxide.rs/issues/1179