### PR TITLE
Generated tabular output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
+dependencies = [
+ "crossterm 0.29.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2482,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "comfy-table",
  "crossterm 0.29.0",
  "dialoguer",
  "dirs",
@@ -4946,13 +4958,17 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "indexmap",
  "newline-converter",
+ "proc-macro2",
  "progenitor",
+ "quote",
  "regex",
  "rustc_version",
  "rustfmt-wrapper",
  "serde_json",
  "similar",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.50", features = ["derive", "string", "env", "wrap_help"] }
 clap_complete = "4.5.59"
 colored = "3.0.0"
+comfy-table = "7.2.1"
 crossterm = { version = "0.29.0", features = [ "event-stream" ] }
 dialoguer = "0.12.0"
 dirs = "6.0.0"
@@ -32,6 +33,7 @@ flume = "0.11.1"
 futures = "0.3.31"
 httpmock = "0.7.0"
 humantime = "2.3.0"
+indexmap = "2.11.3"
 indicatif = "0.18.0"
 libc = "0.2.177"
 log = "0.4.28"
@@ -44,9 +46,11 @@ oxide-httpmock = { path = "sdk-httpmock", version = "0.13.0" }
 oxnet = "0.1.3"
 predicates = "3.1.3"
 pretty_assertions = "1.4.1"
+proc-macro2 = "1.0.101"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", default-features = false }
 progenitor-client = "0.11.2"
 rand = "0.9.2"
+quote = "1.0.40"
 ratatui = "0.29.0"
 rcgen = { version = "0.14.5", features = ["pem"] }
 regex = "1.12.2"
@@ -59,6 +63,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.145"
 similar = "2.7.0"
 support-bundle-viewer = "0.1.2"
+syn = "2.0.106"
 tabwriter = "1.4.1"
 thiserror = "2.0.17"
 tempfile = "3.23.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 colored = { workspace = true }
+comfy-table = { workspace = true }
 crossterm = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -63,6 +63,10 @@
                   "help": "An optional glob pattern for filtering alert class names.\n\nIf provided, only alert classes which match this glob pattern will be included in the response."
                 },
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -105,6 +109,10 @@
               "about": "List alert receivers",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -143,6 +151,10 @@
                     "false"
                   ],
                   "help": "If true, include deliveries which have failed permanently.\n\nIf any of the \"pending\", \"failed\", or \"delivered\" query parameters are set to true, only deliveries matching those state(s) will be included in the response. If NO state filter parameters are set, then all deliveries are included.\n\nA delivery fails permanently when the retry limit of three total attempts is reached without a successful delivery."
+                },
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
                 },
                 {
                   "long": "limit",
@@ -268,6 +280,10 @@
               "about": "Fetch alert receiver",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -373,6 +389,10 @@
                       "name": "list",
                       "about": "List webhook receiver secret IDs",
                       "args": [
+                        {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
+                        },
                         {
                           "long": "profile",
                           "help": "Configuration profile to use for commands",
@@ -497,6 +517,10 @@
             {
               "long": "end-time",
               "help": "Exclusive"
+            },
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
             },
             {
               "long": "limit",
@@ -637,6 +661,10 @@
           "about": "Fetch current silo's auth settings",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "profile",
               "help": "Configuration profile to use for commands",
               "global": true
@@ -745,6 +773,10 @@
           "about": "List all support bundles",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -796,6 +828,10 @@
             {
               "long": "bundle-id",
               "help": "ID of the support bundle"
+            },
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
             },
             {
               "long": "profile",
@@ -879,6 +915,10 @@
           "long_about": "Returns a list of TLS certificates used for the external API (for the current Silo).  These are sorted by creation date, with the most recent certificates appearing first.",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -905,6 +945,10 @@
             {
               "long": "certificate",
               "help": "Name or ID of the certificate"
+            },
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
             },
             {
               "long": "profile",
@@ -981,6 +1025,10 @@
               "long_about": "List device access tokens for the currently authenticated user.",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -1003,6 +1051,10 @@
           "name": "groups",
           "about": "Fetch current user's groups",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -1082,6 +1134,10 @@
               "long_about": "Lists SSH public keys for the currently authenticated user.",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -1106,6 +1162,10 @@
               "long_about": "Fetch SSH public key associated with the currently authenticated user.",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -1122,6 +1182,10 @@
           "name": "view",
           "about": "Fetch user for current session",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "profile",
               "help": "Configuration profile to use for commands",
@@ -1364,6 +1428,10 @@
           "about": "List disks",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -1393,6 +1461,10 @@
             {
               "long": "disk",
               "help": "Name or ID of the disk"
+            },
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
             },
             {
               "long": "profile",
@@ -1514,6 +1586,10 @@
                   "about": "List affinity groups",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -1576,6 +1652,10 @@
                           "help": "Name or ID of the affinity group"
                         },
                         {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
+                        },
+                        {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
                         },
@@ -1625,6 +1705,10 @@
                       "args": [
                         {
                           "long": "affinity-group"
+                        },
+                        {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
                         },
                         {
                           "long": "instance"
@@ -1682,6 +1766,10 @@
                     {
                       "long": "affinity-group",
                       "help": "Name or ID of the affinity group"
+                    },
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
                     },
                     {
                       "long": "profile",
@@ -1777,6 +1865,10 @@
                   "about": "List instrumentation probes",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -1803,6 +1895,10 @@
                   "name": "view",
                   "about": "View instrumentation probe",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "probe",
                       "help": "Name or ID of the probe"
@@ -1836,6 +1932,10 @@
                   "long_about": "Queries are written in OxQL.",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "json-body",
                       "help": "Path to a file that contains the full json body."
                     },
@@ -1868,6 +1968,10 @@
                       "name": "list",
                       "about": "List timeseries schemas",
                       "args": [
+                        {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
+                        },
                         {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
@@ -1920,6 +2024,10 @@
               "about": "Run project-scoped timeseries query",
               "long_about": "Queries are written in OxQL. Project must be specified by name or ID in URL query parameter. The OxQL query will only return timeseries data from the specified project.",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "json-body",
                   "help": "Path to a file that contains the full json body."
@@ -2076,6 +2184,10 @@
           "about": "List floating IPs",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -2140,6 +2252,10 @@
               "help": "Name or ID of the floating IP"
             },
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "profile",
               "help": "Configuration profile to use for commands",
               "global": true
@@ -2166,6 +2282,10 @@
           "name": "list",
           "about": "List groups",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -2279,6 +2399,10 @@
           "long_about": "List images which are global or scoped to the specified project. The images are returned sorted by creation date, with the most recent images appearing first.",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -2326,6 +2450,10 @@
           "about": "Fetch image",
           "long_about": "Fetch the details for a specific image in a project.",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "image",
               "help": "Name or ID of the image"
@@ -2429,6 +2557,10 @@
               "about": "List anti-affinity groups",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -2491,6 +2623,10 @@
                       "help": "Name or ID of the anti affinity group"
                     },
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -2540,6 +2676,10 @@
                   "args": [
                     {
                       "long": "anti-affinity-group"
+                    },
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
                     },
                     {
                       "long": "instance"
@@ -2597,6 +2737,10 @@
                 {
                   "long": "anti-affinity-group",
                   "help": "Name or ID of the anti affinity group"
+                },
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
                 },
                 {
                   "long": "profile",
@@ -2776,6 +2920,10 @@
               "about": "List disks for instance",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "instance",
                   "help": "Name or ID of the instance"
                 },
@@ -2869,6 +3017,10 @@
               "about": "List external IP addresses",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "instance",
                   "help": "Name or ID of the instance"
                 },
@@ -2936,6 +3088,10 @@
           "name": "list",
           "about": "List instances",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -3043,6 +3199,10 @@
               "about": "List network interfaces",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "instance",
                   "help": "Name or ID of the instance"
                 },
@@ -3119,6 +3279,10 @@
               "about": "Fetch network interface",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "instance",
                   "help": "Name or ID of the instance"
                 },
@@ -3154,6 +3318,10 @@
               "about": "List affinity groups containing instance",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "instance",
                   "help": "Name or ID of the instance"
                 },
@@ -3184,6 +3352,10 @@
               "name": "anti-affinity",
               "about": "List anti-affinity groups containing instance",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "instance",
                   "help": "Name or ID of the instance"
@@ -3216,6 +3388,10 @@
               "about": "List SSH public keys for instance",
               "long_about": "List SSH public keys injected via cloud-init during instance creation. Note that this list is a snapshot in time and will not reflect updates made after the instance is created.",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "instance",
                   "help": "Name or ID of the instance"
@@ -3453,6 +3629,10 @@
           "about": "Fetch instance",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "instance",
               "help": "Name or ID of the instance"
             },
@@ -3568,6 +3748,10 @@
               "name": "list",
               "about": "List IP addresses attached to internet gateway",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "gateway",
                   "help": "Name or ID of the internet gateway"
@@ -3755,6 +3939,10 @@
               "about": "List IP pools attached to internet gateway",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "gateway",
                   "help": "Name or ID of the internet gateway"
                 },
@@ -3792,6 +3980,10 @@
           "about": "List internet gateways",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -3822,6 +4014,10 @@
           "name": "view",
           "about": "Fetch internet gateway",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "gateway",
               "help": "Name or ID of the gateway"
@@ -3915,6 +4111,10 @@
           "about": "List IP pools",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -3978,6 +4178,10 @@
               "about": "List ranges for IP pool",
               "long_about": "Ranges are ordered by their first address.",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
@@ -4076,6 +4280,10 @@
                   "long_about": "Ranges are ordered by their first address.",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -4118,6 +4326,10 @@
               "about": "Fetch Oxide service IP pool",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -4141,6 +4353,10 @@
               "about": "Link IP pool to silo",
               "long_about": "Users in linked silos can allocate external IPs from this pool for their instances. A silo can have at most one default pool. IPs are allocated from the default pool when users ask for one without specifying a pool.",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "is-default",
                   "values": [
@@ -4175,6 +4391,10 @@
               "name": "list",
               "about": "List IP pool's linked silos",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
@@ -4284,6 +4504,10 @@
           "about": "Fetch IP pool utilization",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "pool",
               "help": "Name or ID of the IP pool"
             },
@@ -4298,6 +4522,10 @@
           "name": "view",
           "about": "Fetch IP pool",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "pool",
               "help": "Name or ID of the IP pool"
@@ -4316,6 +4544,10 @@
       "about": "Ping API",
       "long_about": "Always responds with Ok if it responds at all.",
       "args": [
+        {
+          "long": "format",
+          "help": "Format in which to print output: 'json' or 'table'"
+        },
         {
           "long": "profile",
           "help": "Configuration profile to use for commands",
@@ -4356,6 +4588,10 @@
           "name": "view",
           "about": "Fetch current silo's IAM policy",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "profile",
               "help": "Configuration profile to use for commands",
@@ -4430,6 +4666,10 @@
               "about": "List IP pools",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -4453,6 +4693,10 @@
               "about": "Fetch IP pool",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "pool",
                   "help": "Name or ID of the IP pool"
                 },
@@ -4469,6 +4713,10 @@
           "name": "list",
           "about": "List projects",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -4526,6 +4774,10 @@
               "about": "Fetch project's IAM policy",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -4571,6 +4823,10 @@
           "name": "view",
           "about": "Fetch project",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "profile",
               "help": "Configuration profile to use for commands",
@@ -4645,6 +4901,10 @@
               "long_about": "Specify the silo by name or ID using the `silo` query parameter.",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -4660,6 +4920,10 @@
               "about": "Fetch SCIM token",
               "long_about": "Specify the silo by name or ID using the `silo` query parameter.",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
@@ -4763,6 +5027,10 @@
               "about": "List identity providers for silo",
               "long_about": "List identity providers for silo by silo name or ID.",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
@@ -4969,6 +5237,10 @@
                   "about": "Fetch SAML identity provider",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -5003,6 +5275,10 @@
               "long_about": "Linked IP pools are available to users in the specified silo. A silo can have at most one default pool. IPs are allocated from the default pool when users ask for one without specifying a pool.",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -5032,6 +5308,10 @@
           "about": "List silos",
           "long_about": "Lists silos that are discoverable based on the current permissions.",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -5089,6 +5369,10 @@
               "about": "Fetch silo IAM policy",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -5115,6 +5399,10 @@
               "name": "list",
               "about": "Lists resource quotas for all silos",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
@@ -5173,6 +5461,10 @@
               "about": "Fetch resource quotas for silo",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -5200,6 +5492,10 @@
               "about": "List built-in (system) users in silo",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -5224,6 +5520,10 @@
               "name": "view",
               "about": "Fetch built-in (system) user",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
@@ -5256,6 +5556,10 @@
               "about": "List current utilization state for all silos",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -5279,6 +5583,10 @@
               "about": "Fetch current utilization for given silo",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -5296,6 +5604,10 @@
           "about": "Fetch silo",
           "long_about": "Fetch silo by name or ID.",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "profile",
               "help": "Configuration profile to use for commands",
@@ -5377,6 +5689,10 @@
           "about": "List snapshots",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
             },
@@ -5403,6 +5719,10 @@
           "name": "view",
           "about": "Fetch snapshot",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "profile",
               "help": "Configuration profile to use for commands",
@@ -5455,6 +5775,10 @@
                   "about": "List physical disks",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -5480,6 +5804,10 @@
                       "help": "ID of the physical disk"
                     },
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -5503,6 +5831,10 @@
                   "about": "List racks",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -5523,6 +5855,10 @@
                   "name": "view",
                   "about": "Fetch rack",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
@@ -5576,6 +5912,10 @@
                   "about": "List physical disks attached to sleds",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -5600,6 +5940,10 @@
                   "name": "instance-list",
                   "about": "List instances running on given sled",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
@@ -5626,6 +5970,10 @@
                   "about": "List sleds",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -5647,6 +5995,10 @@
                   "about": "List uninitialized sleds",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -5661,6 +6013,10 @@
                   "name": "set-provision-policy",
                   "about": "Set sled provision policy",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "json-body",
                       "help": "Path to a file that contains the full json body."
@@ -5693,6 +6049,10 @@
                   "about": "Fetch sled",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -5720,6 +6080,10 @@
                   "about": "List switches",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -5740,6 +6104,10 @@
                   "name": "view",
                   "about": "Fetch switch",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
@@ -5826,6 +6194,10 @@
                   "about": "List switch ports",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -5861,6 +6233,10 @@
                   "name": "status",
                   "about": "Get switch port status",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "port",
                       "help": "A name to use when selecting switch ports."
@@ -6074,6 +6450,10 @@
                           "help": "Name or ID of the address lot"
                         },
                         {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
+                        },
+                        {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
                         },
@@ -6145,6 +6525,10 @@
                   "about": "List address lots",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -6170,6 +6554,10 @@
                     {
                       "long": "address-lot",
                       "help": "Name or ID of the address lot"
+                    },
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
                     },
                     {
                       "long": "profile",
@@ -6219,6 +6607,10 @@
                   "name": "view",
                   "about": "Get user-facing services IP allowlist",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
@@ -6317,6 +6709,10 @@
                   "about": "Get BFD status",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -6392,6 +6788,10 @@
                       "about": "List BGP announce sets",
                       "args": [
                         {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
+                        },
+                        {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
                         },
@@ -6459,6 +6859,10 @@
                         {
                           "long": "announce-set",
                           "help": "Name or ID of the announce set"
+                        },
+                        {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
                         },
                         {
                           "long": "profile",
@@ -6605,6 +7009,10 @@
                       "about": "List BGP configurations",
                       "args": [
                         {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
+                        },
+                        {
                           "long": "limit",
                           "help": "Maximum number of items returned by a single call"
                         },
@@ -6639,6 +7047,10 @@
                       "name": "ipv4",
                       "about": "Get BGP exported routes",
                       "args": [
+                        {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
+                        },
                         {
                           "long": "profile",
                           "help": "Configuration profile to use for commands",
@@ -6739,6 +7151,10 @@
                       "help": "The ASN to filter on. Required."
                     },
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -6762,6 +7178,10 @@
                         {
                           "long": "asn",
                           "help": "The ASN to filter on. Required."
+                        },
+                        {
+                          "long": "format",
+                          "help": "Format in which to print output: 'json' or 'table'"
                         },
                         {
                           "long": "profile",
@@ -7067,6 +7487,10 @@
                   "about": "Get BGP peer status",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -7136,6 +7560,10 @@
                   "name": "view",
                   "about": "Return whether API services can receive limited ICMP traffic",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
@@ -7328,6 +7756,10 @@
                   "about": "Fetch the LLDP neighbors seen on a switch port",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -7427,6 +7859,10 @@
                   "name": "view",
                   "about": "Fetch the LLDP configuration for a switch port",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "port",
                       "help": "A name to use when selecting switch ports."
@@ -7536,6 +7972,10 @@
                   "name": "list",
                   "about": "List loopback addresses",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
@@ -7773,6 +8213,10 @@
                   "about": "List switch port settings",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -7810,6 +8254,10 @@
                   "name": "view",
                   "about": "Get information about switch port",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "port",
                       "help": "A name or id to use when selecting switch port settings info objects."
@@ -7859,6 +8307,10 @@
               "about": "Fetch top-level IAM policy",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -7892,6 +8344,10 @@
                   "about": "List all TUF repositories",
                   "long_about": "Returns a paginated list of all TUF repositories ordered by system version (newest first by default).",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
@@ -7930,6 +8386,10 @@
                   "about": "Fetch system release repository description by version",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -7947,6 +8407,10 @@
               "about": "Fetch system update status",
               "long_about": "Returns information about the current target release and the progress of system software updates.",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
@@ -8041,6 +8505,10 @@
                   "long_about": "A root role is a JSON document describing the cryptographic keys that are trusted to sign system release repositories, as described by The Update Framework. Uploading a repository requires its metadata to be signed by keys trusted by the trust store.",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -8061,6 +8529,10 @@
                   "name": "view",
                   "about": "Fetch trusted root role",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
@@ -8093,6 +8565,10 @@
           "about": "List users",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "group"
             },
             {
@@ -8116,6 +8592,10 @@
           "name": "list-sessions",
           "about": "List user's console sessions",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -8141,6 +8621,10 @@
           "name": "list-tokens",
           "about": "List user's access tokens",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -8183,6 +8667,10 @@
           "about": "Fetch user",
           "args": [
             {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
+            {
               "long": "profile",
               "help": "Configuration profile to use for commands",
               "global": true
@@ -8199,6 +8687,10 @@
       "name": "utilization",
       "about": "Fetch resource utilization for user's current silo",
       "args": [
+        {
+          "long": "format",
+          "help": "Format in which to print output: 'json' or 'table'"
+        },
         {
           "long": "profile",
           "help": "Configuration profile to use for commands",
@@ -8325,6 +8817,10 @@
               "about": "List firewall rules",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -8345,6 +8841,10 @@
           "name": "list",
           "about": "List VPCs",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "limit",
               "help": "Maximum number of items returned by a single call"
@@ -8438,6 +8938,10 @@
               "name": "list",
               "about": "List routers",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
@@ -8545,6 +9049,10 @@
                   "long_about": "List the routes associated with a router in a particular VPC.",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
                     },
@@ -8621,6 +9129,10 @@
                   "about": "Fetch route",
                   "args": [
                     {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
+                    {
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
@@ -8686,6 +9198,10 @@
               "name": "view",
               "about": "Fetch router",
               "args": [
+                {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
                 {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
@@ -8790,6 +9306,10 @@
               "about": "List subnets",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "limit",
                   "help": "Maximum number of items returned by a single call"
                 },
@@ -8830,6 +9350,10 @@
                   "name": "list",
                   "about": "List network interfaces",
                   "args": [
+                    {
+                      "long": "format",
+                      "help": "Format in which to print output: 'json' or 'table'"
+                    },
                     {
                       "long": "limit",
                       "help": "Maximum number of items returned by a single call"
@@ -8909,6 +9433,10 @@
               "about": "Fetch subnet",
               "args": [
                 {
+                  "long": "format",
+                  "help": "Format in which to print output: 'json' or 'table'"
+                },
+                {
                   "long": "profile",
                   "help": "Configuration profile to use for commands",
                   "global": true
@@ -8969,6 +9497,10 @@
           "name": "view",
           "about": "Fetch VPC",
           "args": [
+            {
+              "long": "format",
+              "help": "Format in which to print output: 'json' or 'table'"
+            },
             {
               "long": "profile",
               "help": "Configuration profile to use for commands",

--- a/cli/src/cmd_update.rs
+++ b/cli/src/cmd_update.rs
@@ -14,7 +14,10 @@ use oxide::{Client, ClientSystemUpdateExt};
 use tokio::{fs::File, sync::watch};
 use tokio_util::io::ReaderStream;
 
-use crate::{generated_cli::CliConfig, util::start_progress_bar, AuthenticatedCmd, OxideOverride};
+use crate::{
+    generated_cli::CliConfig, oxide_override::OxideOverride, util::start_progress_bar,
+    AuthenticatedCmd,
+};
 
 #[derive(Parser, Debug, Clone)]
 #[command(verbatim_doc_comment)]

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::path::{Path, PathBuf};
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,22 +8,12 @@
 #![cfg_attr(not(test), deny(clippy::print_stdout, clippy::print_stderr))]
 
 use std::io;
-use std::net::IpAddr;
-use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use async_trait::async_trait;
-use base64::Engine;
 use cli_builder::NewCli;
 use context::Context;
-use generated_cli::CliConfig;
-use oxide::{
-    types::{
-        AllowedSourceIps, DerEncodedKeyPair, IdpMetadataSource, IpRange, Ipv4Range, Ipv6Range,
-    },
-    Client,
-};
+use oxide::Client;
 use url::Url;
 
 mod cmd_api;
@@ -40,6 +30,7 @@ mod cmd_version;
 
 mod cli_builder;
 mod context;
+mod oxide_override;
 #[macro_use]
 mod print;
 mod util;
@@ -132,212 +123,6 @@ async fn main() {
 
         eprintln_nopipe!("{e:#}");
         std::process::exit(1)
-    }
-}
-
-#[derive(Default)]
-struct OxideOverride {
-    needs_comma: AtomicBool,
-}
-
-impl OxideOverride {
-    fn ip_range(matches: &clap::ArgMatches) -> anyhow::Result<IpRange> {
-        let first = matches.get_one::<IpAddr>("first").unwrap();
-        let last = matches.get_one::<IpAddr>("last").unwrap();
-
-        match (first, last) {
-            (IpAddr::V4(first), IpAddr::V4(last)) => {
-                let range = Ipv4Range::try_from(Ipv4Range::builder().first(*first).last(*last))?;
-                Ok(range.into())
-            }
-            (IpAddr::V6(first), IpAddr::V6(last)) => {
-                let range = Ipv6Range::try_from(Ipv6Range::builder().first(*first).last(*last))?;
-                Ok(range.into())
-            }
-            _ => anyhow::bail!(
-                "first and last must either both be ipv4 or ipv6 addresses".to_string()
-            ),
-        }
-    }
-}
-
-impl CliConfig for OxideOverride {
-    fn success_item<T>(&self, value: &oxide::ResponseValue<T>)
-    where
-        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
-    {
-        let s = serde_json::to_string_pretty(std::ops::Deref::deref(value))
-            .expect("failed to serialize return to json");
-        println_nopipe!("{}", s);
-    }
-
-    fn success_no_item(&self, _: &oxide::ResponseValue<()>) {}
-
-    fn error<T>(&self, _value: &oxide::Error<T>)
-    where
-        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
-    {
-        eprintln_nopipe!("error");
-    }
-
-    fn list_start<T>(&self)
-    where
-        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
-    {
-        self.needs_comma
-            .store(false, std::sync::atomic::Ordering::Relaxed);
-        print_nopipe!("[");
-    }
-
-    fn list_item<T>(&self, value: &T)
-    where
-        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
-    {
-        let s = serde_json::to_string_pretty(&[value]).expect("failed to serialize result to json");
-        if self.needs_comma.load(std::sync::atomic::Ordering::Relaxed) {
-            print_nopipe!(", {}", &s[4..s.len() - 2]);
-        } else {
-            print_nopipe!("\n{}", &s[2..s.len() - 2]);
-        };
-        self.needs_comma
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn list_end_success<T>(&self)
-    where
-        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
-    {
-        if self.needs_comma.load(std::sync::atomic::Ordering::Relaxed) {
-            println_nopipe!("\n]");
-        } else {
-            println_nopipe!("]");
-        }
-    }
-
-    fn list_end_error<T>(&self, _value: &oxide::Error<T>)
-    where
-        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
-    {
-        self.list_end_success::<T>()
-    }
-
-    // Deal with all the operations that require an `IpPool` as input
-    fn execute_ip_pool_range_add(
-        &self,
-        matches: &clap::ArgMatches,
-        request: &mut oxide::builder::IpPoolRangeAdd,
-    ) -> anyhow::Result<()> {
-        *request = request.to_owned().body(Self::ip_range(matches)?);
-        Ok(())
-    }
-    fn execute_ip_pool_range_remove(
-        &self,
-        matches: &clap::ArgMatches,
-        request: &mut oxide::builder::IpPoolRangeRemove,
-    ) -> anyhow::Result<()> {
-        *request = request.to_owned().body(Self::ip_range(matches)?);
-        Ok(())
-    }
-    fn execute_ip_pool_service_range_add(
-        &self,
-        matches: &clap::ArgMatches,
-        request: &mut oxide::builder::IpPoolServiceRangeAdd,
-    ) -> anyhow::Result<()> {
-        *request = request.to_owned().body(Self::ip_range(matches)?);
-        Ok(())
-    }
-    fn execute_ip_pool_service_range_remove(
-        &self,
-        matches: &clap::ArgMatches,
-        request: &mut oxide::builder::IpPoolServiceRangeRemove,
-    ) -> anyhow::Result<()> {
-        *request = request.to_owned().body(Self::ip_range(matches)?);
-        Ok(())
-    }
-
-    fn execute_saml_identity_provider_create(
-        &self,
-        matches: &clap::ArgMatches,
-        request: &mut oxide::builder::SamlIdentityProviderCreate,
-    ) -> anyhow::Result<()> {
-        match matches
-            .get_one::<clap::Id>("idp_metadata_source")
-            .map(clap::Id::as_str)
-        {
-            Some("metadata-url") => {
-                let value = matches.get_one::<String>("metadata-url").unwrap();
-                *request = request.to_owned().body_map(|body| {
-                    body.idp_metadata_source(IdpMetadataSource::Url { url: value.clone() })
-                });
-                Ok::<_, anyhow::Error>(())
-            }
-            Some("metadata-value") => {
-                let xml_path = matches.get_one::<PathBuf>("metadata-value").unwrap();
-                let xml_bytes = std::fs::read(xml_path).with_context(|| {
-                    format!("failed to read metadata XML file {}", xml_path.display())
-                })?;
-                let encoded_xml = base64::engine::general_purpose::STANDARD.encode(xml_bytes);
-                *request = request.to_owned().body_map(|body| {
-                    body.idp_metadata_source(IdpMetadataSource::Base64EncodedXml {
-                        data: encoded_xml,
-                    })
-                });
-                Ok(())
-            }
-            _ => unreachable!("invalid value for idp_metadata_source group"),
-        }?;
-
-        if matches.get_one::<clap::Id>("signing_keypair").is_some() {
-            let privkey_path = matches.get_one::<PathBuf>("private-key").unwrap();
-            let privkey_bytes = std::fs::read(privkey_path).with_context(|| {
-                format!("failed to read private key file {}", privkey_path.display())
-            })?;
-            let encoded_privkey = base64::engine::general_purpose::STANDARD.encode(&privkey_bytes);
-
-            let cert_path = matches.get_one::<PathBuf>("public-cert").unwrap();
-            let cert_bytes = std::fs::read(cert_path).with_context(|| {
-                format!("failed to read public cert file {}", cert_path.display())
-            })?;
-            let encoded_cert = base64::engine::general_purpose::STANDARD.encode(&cert_bytes);
-
-            *request = request.to_owned().body_map(|body| {
-                body.signing_keypair(DerEncodedKeyPair {
-                    private_key: encoded_privkey,
-                    public_cert: encoded_cert,
-                })
-            });
-        }
-        Ok(())
-    }
-
-    fn execute_networking_allow_list_update(
-        &self,
-        matches: &clap::ArgMatches,
-        request: &mut oxide::builder::NetworkingAllowListUpdate,
-    ) -> anyhow::Result<()> {
-        match matches
-            .get_one::<clap::Id>("allow-list")
-            .map(clap::Id::as_str)
-        {
-            Some("any") => {
-                let value = matches.get_one::<bool>("any").unwrap();
-                assert!(value);
-                *request = request
-                    .to_owned()
-                    .body_map(|body| body.allowed_ips(AllowedSourceIps::Any));
-            }
-            Some("ips") => {
-                let values: Vec<IpOrNet> = matches.get_many("ips").unwrap().cloned().collect();
-                *request = request.to_owned().body_map(|body| {
-                    body.allowed_ips(AllowedSourceIps::List(
-                        values.into_iter().map(IpOrNet::into_ip_net).collect(),
-                    ))
-                });
-            }
-            _ => unreachable!("invalid value for allow-list group"),
-        }
-
-        Ok(())
     }
 }
 

--- a/cli/src/oxide_override.rs
+++ b/cli/src/oxide_override.rs
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2025 Oxide Computer Company
+
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+
+use crate::generated_cli::CliConfig;
+use crate::{eprintln_nopipe, print_nopipe, println_nopipe, IpOrNet};
+use anyhow::Context as _;
+use base64::Engine;
+use oxide::types::{
+    AllowedSourceIps, DerEncodedKeyPair, IdpMetadataSource, IpRange, Ipv4Range, Ipv6Range,
+};
+
+#[derive(Default)]
+pub struct OxideOverride {
+    needs_comma: AtomicBool,
+}
+
+impl OxideOverride {
+    fn ip_range(matches: &clap::ArgMatches) -> anyhow::Result<IpRange> {
+        let first = matches.get_one::<IpAddr>("first").unwrap();
+        let last = matches.get_one::<IpAddr>("last").unwrap();
+
+        match (first, last) {
+            (IpAddr::V4(first), IpAddr::V4(last)) => {
+                let range = Ipv4Range::try_from(Ipv4Range::builder().first(*first).last(*last))?;
+                Ok(range.into())
+            }
+            (IpAddr::V6(first), IpAddr::V6(last)) => {
+                let range = Ipv6Range::try_from(Ipv6Range::builder().first(*first).last(*last))?;
+                Ok(range.into())
+            }
+            _ => anyhow::bail!(
+                "first and last must either both be ipv4 or ipv6 addresses".to_string()
+            ),
+        }
+    }
+}
+
+impl CliConfig for OxideOverride {
+    fn success_item<T>(&self, value: &oxide::ResponseValue<T>)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
+    {
+        let s = serde_json::to_string_pretty(std::ops::Deref::deref(value))
+            .expect("failed to serialize return to json");
+        println_nopipe!("{}", s);
+    }
+
+    fn success_no_item(&self, _: &oxide::ResponseValue<()>) {}
+
+    fn error<T>(&self, _value: &oxide::Error<T>)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
+    {
+        eprintln_nopipe!("error");
+    }
+
+    fn list_start<T>(&self)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
+    {
+        self.needs_comma
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        print_nopipe!("[");
+    }
+
+    fn list_item<T>(&self, value: &T)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
+    {
+        let s = serde_json::to_string_pretty(&[value]).expect("failed to serialize result to json");
+        if self.needs_comma.load(std::sync::atomic::Ordering::Relaxed) {
+            print_nopipe!(", {}", &s[4..s.len() - 2]);
+        } else {
+            print_nopipe!("\n{}", &s[2..s.len() - 2]);
+        };
+        self.needs_comma
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn list_end_success<T>(&self)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
+    {
+        if self.needs_comma.load(std::sync::atomic::Ordering::Relaxed) {
+            println_nopipe!("\n]");
+        } else {
+            println_nopipe!("]");
+        }
+    }
+
+    fn list_end_error<T>(&self, _value: &oxide::Error<T>)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug,
+    {
+        self.list_end_success::<T>()
+    }
+
+    // Deal with all the operations that require an `IpPool` as input
+    fn execute_ip_pool_range_add(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut oxide::builder::IpPoolRangeAdd,
+    ) -> anyhow::Result<()> {
+        *request = request.to_owned().body(Self::ip_range(matches)?);
+        Ok(())
+    }
+    fn execute_ip_pool_range_remove(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut oxide::builder::IpPoolRangeRemove,
+    ) -> anyhow::Result<()> {
+        *request = request.to_owned().body(Self::ip_range(matches)?);
+        Ok(())
+    }
+    fn execute_ip_pool_service_range_add(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut oxide::builder::IpPoolServiceRangeAdd,
+    ) -> anyhow::Result<()> {
+        *request = request.to_owned().body(Self::ip_range(matches)?);
+        Ok(())
+    }
+    fn execute_ip_pool_service_range_remove(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut oxide::builder::IpPoolServiceRangeRemove,
+    ) -> anyhow::Result<()> {
+        *request = request.to_owned().body(Self::ip_range(matches)?);
+        Ok(())
+    }
+
+    fn execute_saml_identity_provider_create(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut oxide::builder::SamlIdentityProviderCreate,
+    ) -> anyhow::Result<()> {
+        match matches
+            .get_one::<clap::Id>("idp_metadata_source")
+            .map(clap::Id::as_str)
+        {
+            Some("metadata-url") => {
+                let value = matches.get_one::<String>("metadata-url").unwrap();
+                *request = request.to_owned().body_map(|body| {
+                    body.idp_metadata_source(IdpMetadataSource::Url { url: value.clone() })
+                });
+                Ok::<_, anyhow::Error>(())
+            }
+            Some("metadata-value") => {
+                let xml_path = matches.get_one::<PathBuf>("metadata-value").unwrap();
+                let xml_bytes = std::fs::read(xml_path).with_context(|| {
+                    format!("failed to read metadata XML file {}", xml_path.display())
+                })?;
+                let encoded_xml = base64::engine::general_purpose::STANDARD.encode(xml_bytes);
+                *request = request.to_owned().body_map(|body| {
+                    body.idp_metadata_source(IdpMetadataSource::Base64EncodedXml {
+                        data: encoded_xml,
+                    })
+                });
+                Ok(())
+            }
+            _ => unreachable!("invalid value for idp_metadata_source group"),
+        }?;
+
+        if matches.get_one::<clap::Id>("signing_keypair").is_some() {
+            let privkey_path = matches.get_one::<PathBuf>("private-key").unwrap();
+            let privkey_bytes = std::fs::read(privkey_path).with_context(|| {
+                format!("failed to read private key file {}", privkey_path.display())
+            })?;
+            let encoded_privkey = base64::engine::general_purpose::STANDARD.encode(&privkey_bytes);
+
+            let cert_path = matches.get_one::<PathBuf>("public-cert").unwrap();
+            let cert_bytes = std::fs::read(cert_path).with_context(|| {
+                format!("failed to read public cert file {}", cert_path.display())
+            })?;
+            let encoded_cert = base64::engine::general_purpose::STANDARD.encode(&cert_bytes);
+
+            *request = request.to_owned().body_map(|body| {
+                body.signing_keypair(DerEncodedKeyPair {
+                    private_key: encoded_privkey,
+                    public_cert: encoded_cert,
+                })
+            });
+        }
+        Ok(())
+    }
+
+    fn execute_networking_allow_list_update(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut oxide::builder::NetworkingAllowListUpdate,
+    ) -> anyhow::Result<()> {
+        match matches
+            .get_one::<clap::Id>("allow-list")
+            .map(clap::Id::as_str)
+        {
+            Some("any") => {
+                let value = matches.get_one::<bool>("any").unwrap();
+                assert!(value);
+                *request = request
+                    .to_owned()
+                    .body_map(|body| body.allowed_ips(AllowedSourceIps::Any));
+            }
+            Some("ips") => {
+                let values: Vec<IpOrNet> = matches.get_many("ips").unwrap().cloned().collect();
+                *request = request.to_owned().body_map(|body| {
+                    body.allowed_ips(AllowedSourceIps::List(
+                        values.into_iter().map(IpOrNet::into_ip_net).collect(),
+                    ))
+                });
+            }
+            _ => unreachable!("invalid value for allow-list group"),
+        }
+
+        Ok(())
+    }
+}

--- a/cli/tests/data/test_table_anti_affinity_group_members.stdout
+++ b/cli/tests/data/test_table_anti_affinity_group_members.stdout
@@ -1,0 +1,5 @@
+ TYPE      ID                                    NAME    RUN_STATE 
+ Instance  603800ff-07da-3298-0070-bbd45865eabb  qintar  starting  
+ Instance  e272d3bf-c637-7d5d-3a7d-ab4481968f52  suqs    starting  
+ Instance  26254a50-c57c-8083-692d-37f41d8ab55a  umiaq   failed    
+ Instance  a880ac27-4e97-15bf-8098-8119595a2344  qaid    running   

--- a/cli/tests/data/test_table_bgp_routes.stdout
+++ b/cli/tests/data/test_table_bgp_routes.stdout
@@ -1,0 +1,3 @@
+ ADDR      LOCAL_ASN  REMOTE_ASN  STATE         STATE_DURATION_MILLIS  SWITCH  
+ 10.0.0.1  65001      65002       open_confirm  1000000                switch0 
+ 10.0.0.2  65003      65004       established   1000000                switch1 

--- a/cli/tests/data/test_table_project_list_basic_table.stdout
+++ b/cli/tests/data/test_table_project_list_basic_table.stdout
@@ -1,0 +1,5 @@
+ DESCRIPTION  ID                                    NAME     TIME_CREATED          TIME_MODIFIED        
+ qats         fb603800-ff07-da32-9800-70bbd45865ea  qiviuts  1983-04-06T03:52:51Z  2015-10-10T15:39:40Z 
+ qintars      e272d3bf-c637-7d5d-3a7d-ab4481968f52  suqs     1958-10-29T11:12:56Z  1993-07-07T01:08:41Z 
+ qindarkas    254a50c5-7c80-8369-2d37-f41d8ab55a50  suqs     2023-12-07T23:07:16Z  1997-01-29T14:17:53Z 
+ suq          ac274e97-15bf-8098-8119-595a2344c36d  buqsha   1976-06-06T06:59:52Z  1973-08-11T14:45:56Z 

--- a/cli/tests/data/test_table_project_list_json.stdout
+++ b/cli/tests/data/test_table_project_list_json.stdout
@@ -1,0 +1,27 @@
+[
+  {
+    "description": "qats",
+    "id": "fb603800-ff07-da32-9800-70bbd45865ea",
+    "name": "qiviuts",
+    "time_created": "1983-04-06T03:52:51Z",
+    "time_modified": "2015-10-10T15:39:40Z"
+  }, {
+    "description": "qintars",
+    "id": "e272d3bf-c637-7d5d-3a7d-ab4481968f52",
+    "name": "suqs",
+    "time_created": "1958-10-29T11:12:56Z",
+    "time_modified": "1993-07-07T01:08:41Z"
+  }, {
+    "description": "qindarkas",
+    "id": "254a50c5-7c80-8369-2d37-f41d8ab55a50",
+    "name": "suqs",
+    "time_created": "2023-12-07T23:07:16Z",
+    "time_modified": "1997-01-29T14:17:53Z"
+  }, {
+    "description": "suq",
+    "id": "ac274e97-15bf-8098-8119-595a2344c36d",
+    "name": "buqsha",
+    "time_created": "1976-06-06T06:59:52Z",
+    "time_modified": "1973-08-11T14:45:56Z"
+  }
+]

--- a/cli/tests/data/test_table_project_list_table_with_fields.stdout
+++ b/cli/tests/data/test_table_project_list_table_with_fields.stdout
@@ -1,0 +1,5 @@
+ NAME     ID                                   
+ qiviuts  fb603800-ff07-da32-9800-70bbd45865ea 
+ suqs     e272d3bf-c637-7d5d-3a7d-ab4481968f52 
+ suqs     254a50c5-7c80-8369-2d37-f41d8ab55a50 
+ buqsha   ac274e97-15bf-8098-8119-595a2344c36d 

--- a/cli/tests/data/test_table_project_list_table_with_no_requested_fields.stderr
+++ b/cli/tests/data/test_table_project_list_table_with_no_requested_fields.stderr
@@ -1,0 +1,9 @@
+WARNING: 'not_a_field' is not a valid field
+ERROR: None of the requested '--format' fields are present in this command's output
+
+Available fields:
+ description
+ id
+ name
+ time_created
+ time_modified

--- a/cli/tests/test_table.rs
+++ b/cli/tests/test_table.rs
@@ -1,0 +1,256 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2025 Oxide Computer Company
+
+use assert_cmd::Command;
+use httpmock::MockServer;
+use oxide::types::{
+    AntiAffinityGroupMember, AntiAffinityGroupMemberResultsPage, BgpPeerState, BgpPeerStatus,
+    Project, ProjectResultsPage, SwitchLocation,
+};
+use oxide_httpmock::MockServerExt;
+use rand::SeedableRng;
+use test_common::JsonMock;
+
+#[test]
+fn test_table_arg_parse() {
+    let mut src = rand::rngs::SmallRng::seed_from_u64(42);
+    let server = MockServer::start();
+
+    let results = ProjectResultsPage {
+        items: Vec::<Project>::mock_value(&mut src).unwrap(),
+        next_page: None,
+    };
+
+    let mock = server.project_list(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&results);
+    });
+
+    let format_args = [
+        // JSON
+        ["--format", "json"],
+        // Simple table
+        ["--format", "table"],
+        // Table with column names specified
+        ["--format", "table:name,id"],
+        // Table with spaces between column names
+        ["--format", "table: name, id "],
+    ];
+
+    for args in format_args {
+        Command::cargo_bin("oxide")
+            .unwrap()
+            .env("RUST_BACKTRACE", "1")
+            .env("OXIDE_HOST", server.url(""))
+            .env("OXIDE_TOKEN", "fake-token")
+            .arg("project")
+            .arg("list")
+            .arg("--sort-by")
+            .arg("name_ascending")
+            .args(args)
+            .assert()
+            .success();
+    }
+
+    let bad_args = [
+        // Unknown format
+        ["--format", "foo"],
+        // JSON with field args
+        ["--format", "json:name,id"],
+    ];
+
+    for args in bad_args {
+        Command::cargo_bin("oxide")
+            .unwrap()
+            .env("RUST_BACKTRACE", "1")
+            .env("OXIDE_HOST", server.url(""))
+            .env("OXIDE_TOKEN", "fake-token")
+            .arg("project")
+            .arg("list")
+            .arg("--sort-by")
+            .arg("name_ascending")
+            .args(args)
+            .assert()
+            .failure();
+    }
+
+    mock.assert_hits(format_args.len());
+}
+
+#[test]
+fn test_table_project_list() {
+    let mut src = rand::rngs::SmallRng::seed_from_u64(42);
+    let server = MockServer::start();
+
+    let results = ProjectResultsPage {
+        items: Vec::<Project>::mock_value(&mut src).unwrap(),
+        next_page: None,
+    };
+
+    let mock = server.project_list(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&results);
+    });
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("project")
+        .arg("list")
+        .arg("--sort-by")
+        .arg("name_ascending")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .stdout(expectorate::eq_file_or_panic(
+            "tests/data/test_table_project_list_json.stdout",
+        ));
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("project")
+        .arg("list")
+        .arg("--sort-by")
+        .arg("name_ascending")
+        .arg("--format")
+        .arg("table")
+        .assert()
+        .success()
+        .stdout(expectorate::eq_file_or_panic(
+            "tests/data/test_table_project_list_basic_table.stdout",
+        ));
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("project")
+        .arg("list")
+        .arg("--sort-by")
+        .arg("name_ascending")
+        .arg("--format")
+        .arg("table:name,id")
+        .assert()
+        .success()
+        .stdout(expectorate::eq_file_or_panic(
+            "tests/data/test_table_project_list_table_with_fields.stdout",
+        ));
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("project")
+        .arg("list")
+        .arg("--sort-by")
+        .arg("name_ascending")
+        .arg("--format")
+        .arg("table:not_a_field")
+        .assert()
+        .failure()
+        .stderr(expectorate::eq_file_or_panic(
+            "tests/data/test_table_project_list_table_with_no_requested_fields.stderr",
+        ));
+
+    mock.assert_hits(3);
+}
+
+/// Validate an endpoint returning `Vec<T>`.
+#[test]
+fn test_table_bgp_routes() {
+    let server = MockServer::start();
+
+    // Manually construct the response as `Vec<BgpPeerStatus>` is not compatible with
+    // `serde_json::from_value()`.
+    let results = vec![
+        BgpPeerStatus {
+            addr: "10.0.0.1".parse().unwrap(),
+            local_asn: 65001,
+            remote_asn: 65002,
+            state: BgpPeerState::OpenConfirm,
+            state_duration_millis: 1_000_000,
+            switch: SwitchLocation::Switch0,
+        },
+        BgpPeerStatus {
+            addr: "10.0.0.2".parse().unwrap(),
+            local_asn: 65003,
+            remote_asn: 65004,
+            state: BgpPeerState::Established,
+            state_duration_millis: 1_000_000,
+            switch: SwitchLocation::Switch1,
+        },
+    ];
+
+    let mock = server.networking_bgp_status(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&results);
+    });
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("system")
+        .arg("networking")
+        .arg("bgp")
+        .arg("status")
+        .arg("--format")
+        .arg("table")
+        .assert()
+        .success()
+        .stdout(expectorate::eq_file_or_panic(
+            "tests/data/test_table_bgp_routes.stdout",
+        ));
+
+    mock.assert();
+}
+
+/// Validate an endpoint returning an enum.
+#[test]
+fn test_table_anti_affinity_group_members() {
+    let mut src = rand::rngs::SmallRng::seed_from_u64(42);
+    let server = MockServer::start();
+
+    let results = AntiAffinityGroupMemberResultsPage {
+        items: Vec::<AntiAffinityGroupMember>::mock_value(&mut src).unwrap(),
+        next_page: None,
+    };
+
+    let mock = server.anti_affinity_group_member_list(|when, then| {
+        when.into_inner().any_request();
+        then.ok(&results);
+    });
+
+    Command::cargo_bin("oxide")
+        .unwrap()
+        .env("RUST_BACKTRACE", "1")
+        .env("OXIDE_HOST", server.url(""))
+        .env("OXIDE_TOKEN", "fake-token")
+        .arg("instance")
+        .arg("anti-affinity")
+        .arg("member")
+        .arg("list")
+        .arg("--anti-affinity-group")
+        .arg("42e56270-889a-e74d-fa7c-849b22449cd6")
+        .arg("--format")
+        .arg("table")
+        .assert()
+        .success()
+        .stdout(expectorate::eq_file_or_panic(
+            "tests/data/test_table_anti_affinity_group_members.stdout",
+        ));
+
+    mock.assert();
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,10 +6,14 @@ publish = false
 
 [dependencies]
 clap = { workspace = true }
+indexmap = { workspace = true }
 newline-converter = { workspace = true }
+proc-macro2 = { workspace = true }
 progenitor = { workspace = true, default-features = false }
+quote = { workspace = true }
 regex = { workspace = true }
 rustc_version = { workspace = true }
 rustfmt-wrapper = { workspace = true }
 serde_json = { workspace = true }
 similar = { workspace = true }
+syn = { workspace = true }

--- a/xtask/src/cli_extras.rs
+++ b/xtask/src/cli_extras.rs
@@ -1,0 +1,723 @@
+use indexmap::IndexSet;
+use proc_macro2::TokenStream;
+use quote::quote;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+use syn::{
+    Fields, GenericArgument, Generics, Ident, ImplItem, ImplItemFn, Index, Item, ItemEnum,
+    ItemImpl, ItemStruct, Path, PathArguments, ReturnType, Signature, Type, TypePath, Variant,
+};
+
+static UNPRESENTABLE_TYPES: OnceLock<HashSet<&'static str>> = OnceLock::new();
+
+fn is_unpresentable(type_name: &str) -> bool {
+    UNPRESENTABLE_TYPES
+        .get_or_init(|| {
+            HashSet::from([
+                "ByteStream",                       // Unstructured bytes
+                "reqwest::Upgraded",                // HTTP connection
+                "serde_json::Value",                // No defined field names
+                "types::InstanceSerialConsoleData", // Unstructured bytes
+            ])
+        })
+        .contains(type_name)
+}
+
+/// Generate a `ResponseFields` implementation for all types in the `oxide::types` module and
+/// inject it into `CliCommand`.
+pub fn gen_response_fields(sdk_tokens: TokenStream, cli_tokens: TokenStream) -> TokenStream {
+    let sdk_file: syn::File = syn::parse2(sdk_tokens).unwrap();
+    let cli_file: syn::File = syn::parse2(cli_tokens).unwrap();
+
+    let response_field_tokens = gen_response_fields_impls(&sdk_file);
+    let cli_cmd_tokens = gen_cli_command(&sdk_file, &cli_file);
+
+    quote! {
+
+        #response_field_tokens
+
+        #cli_cmd_tokens
+    }
+}
+
+/// Generate `ResponseFields` impls for all types returned by a `send` fn.
+pub fn gen_response_fields_impls(sdk_file: &syn::File) -> TokenStream {
+    let builder_content = mod_content(sdk_file, "builder");
+    let types_content = mod_content(sdk_file, "types");
+
+    let mut implemented_types = HashSet::new();
+    let mut impls = TokenStream::new();
+
+    for impl_items in builder_content.iter().filter_map(|i| match i {
+        Item::Impl(ItemImpl {
+            trait_: None,
+            items,
+            ..
+        }) => Some(items.as_slice()),
+        _ => None,
+    }) {
+        let ret_type = send_return_type(impl_items);
+        let inner_type = response_value_inner_type(ret_type);
+        let Some(ident) = filter_innermost_type_ident(inner_type) else {
+            continue;
+        };
+        if let Some(tokens) = gen_for_ident(types_content, &mut implemented_types, &ident) {
+            impls.extend(tokens);
+        }
+    }
+
+    quote! {
+        /// A trait for flexibly accessing objects returned by the Oxide API.
+        pub trait ResponseFields {
+            /// The individual object type returned from the API.
+            ///
+            /// Generally this is the type wrapped by a `ResponseValue`, but in some cases
+            /// this is a collection of items. For example,
+            /// `/v1/system/networking/bgp-routes-ipv4` returns a
+            /// `ResponseValue<Vec<types::BgpImportedRouteIpv4>>`.
+            type Item: ResponseFields;
+
+            /// Get the field names of the object.
+            ///
+            /// For enums, the variant is included as "type".
+            /// Unnamed fields are accessed as "value" for a tuple of arity 1, or "value_N", for
+            /// larger arities.
+            fn field_names() -> &'static [&'static str];
+
+            /// Attempt to retrieve the specified field of an object as a JSON value.
+            ///
+            /// We convert to JSON instead of a string to provide callers with more flexibility
+            /// in how they format the object.
+            fn get_field(&self, field_name: &str) -> Option<serde_json::Value>;
+
+            /// Get an iterator over all `Item`s contained in the response.
+            fn items(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_>;
+        }
+
+        impl<T: ResponseFields> ResponseFields for Vec<T> {
+            type Item = T;
+
+            fn field_names() -> &'static [&'static str] {
+                T::field_names()
+            }
+
+            fn get_field(&self, _field_name: &str) -> Option<serde_json::Value> {
+                None
+            }
+
+            fn items(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_> {
+                Box::new(self.iter())
+            }
+        }
+
+        impl ResponseFields for types::Error {
+            type Item = Self;
+
+            fn field_names() -> &'static [&'static str] {
+                &[]
+            }
+
+            fn get_field(&self, _field_name: &str) -> Option<serde_json::Value> {
+                None
+            }
+
+            fn items(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_> {
+                Box::new(std::iter::empty())
+            }
+        }
+
+        #impls
+    }
+}
+
+/// Extract the content of a module.
+fn mod_content<'a>(file: &'a syn::File, name: &str) -> &'a Vec<Item> {
+    let module = file
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Mod(module) => Some(module),
+            _ => None,
+        })
+        .find(|m| m.ident == name)
+        .unwrap();
+
+    let Some((_, content)) = &module.content else {
+        unreachable!("no module content");
+    };
+
+    content
+}
+
+/// Get the return type for `send()`.
+fn send_return_type(items: &[ImplItem]) -> Type {
+    items
+        .iter()
+        .filter_map(|i| match i {
+            ImplItem::Fn(ImplItemFn {
+                sig:
+                    Signature {
+                        ident: fn_ident,
+                        output: ReturnType::Type(_, ret),
+                        ..
+                    },
+                ..
+            }) if fn_ident == "send" => Some(ret),
+            _ => None,
+        })
+        .next()
+        .map(|ret_type| *ret_type.clone())
+        .expect("no send fn in block")
+}
+
+/// Extract the inner `T` from `Result<ResponseValue<T>, E>`.
+fn response_value_inner_type(ret_type: Type) -> Type {
+    let Type::Path(TypePath { path, .. }) = ret_type else {
+        unreachable!("type was not a path");
+    };
+
+    // Get the generic arguments to `Result<T>`.
+    let last_segment = path.segments.last().unwrap();
+    let PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+        unreachable!("no angle bracket on path");
+    };
+
+    // Get the first type argument in `Result<T>`.
+    let Some(GenericArgument::Type(Type::Path(type_path))) = args.args.first() else {
+        unreachable!("no generic args in path");
+    };
+
+    // This type must be a `ResponseValue<T>`.
+    let segment = type_path.path.segments.last().unwrap();
+    if segment.ident != "ResponseValue" {
+        unreachable!("return type was not a ResponseValue");
+    }
+
+    // Get its generic argument.
+    let PathArguments::AngleBracketed(inner_args) = &segment.arguments else {
+        unreachable!("no angle bracket on ResponseValue");
+    };
+    let Some(GenericArgument::Type(inner_type)) = inner_args.args.first() else {
+        unreachable!("no generic args in ResponseValue");
+    };
+
+    inner_type.clone()
+}
+
+/// Get the `Ident` of the type being returned, filtering for types that need an
+/// implementation of `ResponseFields`.
+fn filter_innermost_type_ident(ty: Type) -> Option<Ident> {
+    // This filters out `()`.
+    let Type::Path(TypePath { path, .. }) = ty else {
+        return None;
+    };
+
+    let mut inner_ident = path.segments.last()?.ident.clone();
+    let mut path_str = path_to_string(&path);
+
+    if inner_ident == "Vec" {
+        let PathArguments::AngleBracketed(args) = &path.segments.last()?.arguments else {
+            return None;
+        };
+
+        // Take the inner `T`.
+        let GenericArgument::Type(vec_ty) = args.args.first()? else {
+            return None;
+        };
+
+        let Type::Path(TypePath { path: vec_path, .. }) = vec_ty else {
+            return None;
+        };
+        inner_ident = vec_path.segments.last()?.ident.clone();
+        path_str = path_to_string(vec_path);
+    }
+
+    // Only handle `oxide::types` types, we don't need impls for the others.
+    if path_str.starts_with("types::") {
+        Some(inner_ident)
+    } else {
+        None
+    }
+}
+
+/// Generate a `ResponseFields` impl for an `Ident`.
+fn gen_for_ident(
+    types_content: &[Item],
+    implemented_types: &mut HashSet<String>,
+    ty_ident: &Ident,
+) -> Option<TokenStream> {
+    if !implemented_types.insert(ty_ident.to_string()) {
+        return None;
+    }
+
+    match types_content
+        .iter()
+        .find(|i|
+            matches!(i, Item::Enum(ItemEnum { ident, ..} ) | Item::Struct(ItemStruct { ident, .. }) if ident == ty_ident)
+        ) {
+            Some(Item::Enum(e)) => {
+                let (impl_generics, ty_generics, where_clause) = e.generics.split_for_impl();
+                let impls = gen_enum_impl(e);
+                let ident = &e.ident;
+
+                Some(quote! {
+                    impl #impl_generics ResponseFields for types::#ident #ty_generics #where_clause {
+                        #impls
+                    }
+                })
+            }
+            Some(Item::Struct(ItemStruct {
+                fields,
+                ident,
+                generics,
+                ..
+            })) => {
+               if ident.to_string().ends_with("ResultsPage") {
+                   gen_result_page_impl(ident, fields, types_content, generics, implemented_types)
+               } else {
+                let impls = gen_struct_impl(fields);
+                let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+                Some(quote! {
+                    impl #impl_generics ResponseFields for types::#ident #ty_generics #where_clause {
+                        #impls
+                    }
+                })
+               }
+            }
+            _ => unreachable!("return type was neither a struct nor enum"),
+        }
+}
+
+/// Generate a `ResponseFields` impl for a `ResultPage` type and its wrapped `items` type.
+fn gen_result_page_impl(
+    ident: &Ident,
+    fields: &Fields,
+    types_content: &[Item],
+    generics: &Generics,
+    implemented_types: &mut HashSet<String>,
+) -> Option<TokenStream> {
+    let ty = results_page_child_type(fields);
+    let Type::Path(TypePath { path, .. }) = &ty else {
+        return None;
+    };
+
+    let child_ident = path.segments.last().cloned().map(|s| s.ident)?;
+    let child_impl = gen_for_ident(types_content, implemented_types, &child_ident);
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Some(quote! {
+     #child_impl
+
+     impl #impl_generics ResponseFields for types::#ident #ty_generics #where_clause {
+        type Item = types::#ty;
+
+        fn field_names() -> &'static [&'static str] {
+            types::#ty::field_names()
+        }
+
+        fn get_field(&self, _field_name: &str) -> Option<serde_json::Value> {
+            None
+        }
+
+         fn items(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_> {
+             Box::new(self.items.iter())
+         }
+     }
+    })
+}
+
+/// Extract the inner `T` from a `ResultsPage<T>`.
+fn results_page_child_type(fields: &Fields) -> Type {
+    let Fields::Named(named) = fields else {
+        unreachable!("no named fields on ResultsPage");
+    };
+
+    // Find the `items` field on the `ResultsPage`.
+    let items = named
+        .named
+        .iter()
+        .find(|&f| f.ident.as_ref().map(|ident| ident.to_string()) == Some(String::from("items")))
+        .unwrap();
+
+    match &items.ty {
+        Type::Path(TypePath { path, .. }) if path.segments.last().unwrap().ident == "Vec" => {
+            // Access the generic arguments to `Vec<T>`.
+            let PathArguments::AngleBracketed(args) = &path.segments.last().unwrap().arguments
+            else {
+                unreachable!("no angle bracket path on Vec");
+            };
+
+            // Take the inner `T`.
+            let GenericArgument::Type(inner_type) = args.args.first().unwrap() else {
+                unreachable!("no generic argument to Vec");
+            };
+            inner_type.clone()
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Generate a `ResponseFields` impl for a struct.
+fn gen_struct_impl(fields: &Fields) -> TokenStream {
+    match fields {
+        Fields::Named(fields) => {
+            let field_names: Vec<_> = fields
+                .named
+                .iter()
+                .map(|f| f.ident.as_ref().unwrap())
+                .collect();
+
+            let field_accessors: Vec<_> = field_names
+                .iter()
+                .map(|field_name| {
+                    let field_str = field_name.to_string();
+                    quote! {
+                        #field_str => serde_json::to_value(&self.#field_name).ok()
+                    }
+                })
+                .collect();
+
+            let field_strings: Vec<_> = field_names.iter().map(|ident| ident.to_string()).collect();
+
+            quote! {
+                type Item = Self;
+
+                fn field_names() -> &'static [&'static str] {
+                    &[#(#field_strings),*]
+                }
+
+                #[allow(clippy::needless_borrows_for_generic_args)]
+                fn get_field(&self, field_name: &str) -> Option<serde_json::Value> {
+                    match field_name {
+                        #(#field_accessors,)*
+                        _ => None,
+                    }
+                }
+
+                fn items(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_> {
+                    Box::new(std::iter::once(self))
+                }
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let count = fields.unnamed.len();
+            let (field_strings, field_accessors) = if count == 1 {
+                let field_names = vec!["value".to_string()];
+
+                // All single-value tuple structs implement `Deref` to access their payload.
+                let field_accessors = vec![quote! {
+                    "value" => serde_json::to_value(&*self).ok()
+                }];
+                (field_names, field_accessors)
+            } else {
+                let field_strings: Vec<_> = (0..count).map(|i| format!("value_{}", i)).collect();
+
+                let field_accessors: Vec<_> = (0..count)
+                    .map(|i| {
+                        let index = Index::from(i);
+                        let field_str = format!("value_{}", i);
+                        quote! {
+                            #field_str => serde_json::to_value(&self.#index).ok()
+                        }
+                    })
+                    .collect();
+
+                (field_strings, field_accessors)
+            };
+
+            quote! {
+                type Item = Self;
+
+                fn field_names() -> &'static [&'static str] {
+                    &[#(#field_strings),*]
+                }
+
+                #[allow(clippy::borrow_deref_ref)]
+                fn get_field(&self, field_name: &str) -> Option<serde_json::Value> {
+                    match field_name {
+                        #(#field_accessors,)*
+                        _ => None,
+                    }
+                }
+
+                fn items(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_> {
+                    Box::new(std::iter::once(self))
+                }
+            }
+        }
+        // Do not generate a `ResponseFields` impl for Unit structs, nothing to show.
+        Fields::Unit => {
+            quote! {}
+        }
+    }
+}
+
+/// Generate a `ResponseFields` impl for an enum.
+fn gen_enum_impl(data: &ItemEnum) -> TokenStream {
+    let enum_ident = &data.ident;
+
+    // Collect all unique field names across all variants, including the variant name as "type".
+    let mut field_strings = IndexSet::from(["type".to_string()]);
+
+    for variant in &data.variants {
+        match &variant.fields {
+            Fields::Named(fields) => {
+                for field in &fields.named {
+                    field_strings.insert(field.ident.as_ref().unwrap().to_string());
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let count = fields.unnamed.len();
+                if count == 1 {
+                    field_strings.insert("value".to_string());
+                } else {
+                    for i in 0..count {
+                        field_strings.insert(format!("value_{}", i));
+                    }
+                }
+            }
+            Fields::Unit => {}
+        }
+    }
+
+    let field_strings: Vec<_> = field_strings.into_iter().collect();
+
+    let variant_arms: Vec<_> = data
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            let variant_string = variant_ident.to_string();
+
+            match &variant.fields {
+                Fields::Named(fields) => {
+                    let field_idents: Vec<_> = fields
+                        .named
+                        .iter()
+                        .map(|f| f.ident.as_ref().unwrap()).collect();
+
+                    let field_matches: Vec<_> = field_idents.iter().map(|field_ident| {
+                            let field_string = field_ident.to_string();
+                            quote! {
+                                #field_string => serde_json::to_value(#field_ident).ok()
+                            }
+                        })
+                        .collect();
+
+                    quote! {
+                        types::#enum_ident::#variant_ident { #(#field_idents),* } => {
+                            match field_name {
+                                "type" => Some(serde_json::Value::String(String::from(#variant_string))),
+                                #(#field_matches,)*
+                                _ => None,
+                            }
+                        }
+                    }
+                }
+                Fields::Unnamed(fields) => {
+                    let count = fields.unnamed.len();
+
+                    if count == 1 {
+                        quote! {
+                            types::#enum_ident::#variant_ident(value) => {
+                                match field_name {
+                                    "value" => serde_json::to_value(&value).ok(),
+                                    _ => None,
+                                }
+                            }
+                        }
+                    } else {
+                        let field_bindings: Vec<_> = (0..count)
+                            .map(|i| {
+                                syn::Ident::new(
+                                    &format!("field_{}", i),
+                                    proc_macro2::Span::call_site(),
+                                )
+                            })
+                            .collect();
+
+                        let field_matches: Vec<_> = field_bindings.iter().enumerate()
+                            .map(|(i, ident)| {
+                                let field_string = format!("value_{}", i);
+                                quote! {
+                                    #field_string => serde_json::to_value(#ident).ok()
+                                }
+                            })
+                            .collect();
+
+                        quote! {
+                            #enum_ident::#variant_ident(#(#field_bindings),*) => {
+                                match field_name {
+                                    "type" => Some(serde_json::Value::String(String::from(#variant_string))),
+                                    #(#field_matches,)*
+                                    _ => None,
+                                }
+                            }
+                        }
+                    }
+                }
+                Fields::Unit => {
+                    quote! {
+                        types::#enum_ident::#variant_ident => {
+                            match field_name {
+                                "type" => Some(serde_json::Value::String(String::from(#variant_string))),
+                                _ => None,
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        type Item = Self;
+
+        fn field_names() -> &'static [&'static str] {
+            &[#(#field_strings),*]
+        }
+
+        fn get_field(&self, field_name: &str) -> Option<serde_json::Value> {
+            match self {
+                #(#variant_arms,)*
+            }
+        }
+
+        fn items(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_> {
+            Box::new(std::iter::once(self))
+        }
+    }
+}
+
+/// Generate a `field_names` method for `CliCommand` use to determine which subcommands
+/// are eligible for the `--format` flag, and adding the list of available fields `--help`
+/// output.
+fn gen_cli_command(sdk_file: &syn::File, cli_file: &syn::File) -> TokenStream {
+    let builder_content = mod_content(sdk_file, "builder");
+
+    let cli_variants = cli_file
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Enum(ItemEnum {
+                ident, variants, ..
+            }) if ident == "CliCommand" => Some(variants),
+            _ => None,
+        })
+        .next()
+        .unwrap();
+
+    // We expect tabular formatting to be useful when querying. Creation APIs in particular already
+    // have many arguments, adding the bulky `--format` help text on top of that will make them
+    // harder to understand. However, there is no 100% reliable way to determine which subcommand is
+    // performing a query. The return type for create and view endpoints are frequently the same, so
+    // we can't discriminate by type. Trying to limit to `List` and `View` will miss a fair number
+    // of query endpoints, e.g. `NetworkingBgpImportedRoutesIpv4` and `CurrentUserGroups`. The
+    // heuristic below should catch most new write operations.
+    let action_words = HashSet::from([
+        "Add", "Attach", "Create", "Demote", "Detach", "Probe", "Promote", "Reboot", "Resend",
+        "Start", "Stop", "Update",
+    ]);
+
+    let mut match_arms = Vec::new();
+    for Variant {
+        ident: variant_ident,
+        ..
+    } in cli_variants
+    {
+        let variant_str = variant_ident.to_string();
+        let last_word = variant_str
+            .rfind(char::is_uppercase)
+            .map(|i| &variant_str[i..])
+            .unwrap_or_default();
+
+        if action_words.contains(last_word) {
+            continue;
+        }
+
+        let impl_items = builder_type_for_variant(variant_ident, builder_content);
+        let ret_type = send_return_type(impl_items);
+        let inner_type = response_value_inner_type(ret_type);
+        if let Some(return_path) = extract_type_path_expression(inner_type) {
+            match_arms.push(quote! {
+                CliCommand::#variant_ident => #return_path::field_names(),
+            });
+        }
+    }
+
+    quote! {
+        impl CliCommand {
+            pub fn field_names(&self) -> &'static [&'static str] {
+                match self {
+                    #(#match_arms)*
+                    _ => &[],
+                }
+            }
+        }
+    }
+}
+
+/// Find the corresponding `impl` block in the `builder` mod for a `CliCommand` variant.
+fn builder_type_for_variant<'a>(
+    variant_ident: &Ident,
+    builder_content: &'a [Item],
+) -> &'a [ImplItem] {
+    builder_content
+        .iter()
+        .filter_map(|i| match i {
+            Item::Impl(ItemImpl {
+                self_ty,
+                trait_: None,
+                items,
+                ..
+            }) => {
+                let Type::Path(TypePath { path, .. }) = &**self_ty else {
+                    return None;
+                };
+                let struct_ident = path.segments.first()?;
+                if &struct_ident.ident != variant_ident {
+                    return None;
+                }
+                Some(items)
+            }
+            _ => None,
+        })
+        .map(|i| i.as_slice())
+        .next()
+        .expect("no corresponding builder type for CliCommand variant")
+}
+
+/// Convert a `Type` to a `Path` in expression format.
+fn extract_type_path_expression(mut inner_ty: Type) -> Option<Path> {
+    let Type::Path(TypePath { path, .. }) = &mut inner_ty else {
+        return None;
+    };
+    let path_str = path_to_string(path);
+
+    // Skip any variant with a return type that cannot be reasonably presented in table
+    // format.
+    if is_unpresentable(&path_str) {
+        return None;
+    }
+
+    // We need to convert the type name from declaration syntax to expression, e.g.,
+    // `Vec<T>` to `Vec::<T>`.
+    for segment in &mut path.segments {
+        if let PathArguments::AngleBracketed(args) = &mut segment.arguments {
+            // Add the `::` token for turbofish syntax.
+            args.colon2_token = Some(syn::token::PathSep::default());
+        }
+    }
+
+    Some(path.clone())
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.segments
+        .iter()
+        .map(|s| s.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}


### PR DESCRIPTION
Add tabular output with --format flag

Tabular output is much easier to quickly scan for value, as well as
being more amenable to traditional UNIX scripting. For example,
compare finding the block_size for an image in the following output:

```
  $ oxide image list --format=json
  [
    {
      "block_size": 512,
      "description": "Debian 13 generic cloud image",
      "id": "3672f476-51ff-49ab-bd2c-723151a921c6",
      "name": "debian-13",
      "os": "Debian",
      "size": 3221225472,
      "time_created": "2025-08-11T16:48:17.827861Z",
      "time_modified": "2025-08-11T16:52:23.411189Z",
      "version": "13"
    }, {
      "block_size": 4096,
      "description": "Silo image for Packer acceptance testing.",
      "id": "f13b140e-4d34-4060-b898-6316cdcc2f1e",
      "name": "packer-acc-test-silo-image",
      "os": "",
      "size": 1073741824,
      "time_created": "2025-05-15T23:11:14.015948Z",
      "time_modified": "2025-05-15T23:12:02.098119Z",
      "version": ""
    }
  ]
```

Versus:

```
  $ oxide image list --format=table:name,block_size
   NAME                        BLOCK_SIZE
   debian-13                   512
   packer-acc-test-silo-image  4096
```

For response types that are amenable to tabular formatting, we add a
`--format` flag to the subcommand. This takes an optional
comma-separated list of field names to print, as larger response items
can easily overflow typical terminal widths. The available field names
are listed in the `--help` output for the subcommand.

Not all API return values can be reasonably formatted as a table.
Endpoints returning `()`, byte streams, and unstructured
`serde_json::Value` objects are deliberately excluded.

Internally, this is implemented using the newly added `ResponseFields`
trait, which xtask creates as part of the generated CLI. This enables
getting the field names of a type and accessing them as a
`serde_json::Value` via their name.