### PR TITLE
Update CLI for update status + TUF repo list + related changes

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1836,6 +1836,14 @@
                   "long_about": "Queries are written in OxQL.",
                   "args": [
                     {
+                      "long": "include-summaries",
+                      "values": [
+                        "true",
+                        "false"
+                      ],
+                      "help": "Whether to include ClickHouse query summaries in the response."
+                    },
+                    {
                       "long": "json-body",
                       "help": "Path to a file that contains the full json body."
                     },
@@ -2064,6 +2072,14 @@
               "about": "Run project-scoped timeseries query",
               "long_about": "Queries are written in OxQL. Project must be specified by name or ID in URL query parameter. The OxQL query will only return timeseries data from the specified project.",
               "args": [
+                {
+                  "long": "include-summaries",
+                  "values": [
+                    "true",
+                    "false"
+                  ],
+                  "help": "Whether to include ClickHouse query summaries in the response."
+                },
                 {
                   "long": "json-body",
                   "help": "Path to a file that contains the full json body."

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1902,6 +1902,18 @@
               ],
               "subcommands": [
                 {
+                  "name": "status",
+                  "about": "Fetch system update status",
+                  "long_about": "Returns information about the current target release and the progress of system software updates.",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    }
+                  ]
+                },
+                {
                   "name": "target-release",
                   "args": [
                     {
@@ -1913,8 +1925,8 @@
                   "subcommands": [
                     {
                       "name": "update",
-                      "about": "Set the current target release of the rack's system software",
-                      "long_about": "The rack reconfigurator will treat the software specified here as a goal state for the rack's software, and attempt to asynchronously update to that release.",
+                      "about": "Set target release",
+                      "long_about": "Set the current target release of the rack's system software. The rack reconfigurator will treat the software specified here as a goal state for the rack's software, and attempt to asynchronously update to that release. Use the update status endpoint to view the current target release.",
                       "args": [
                         {
                           "long": "json-body",
@@ -1932,18 +1944,6 @@
                         {
                           "long": "system-version",
                           "help": "Version of the system software to make the target release."
-                        }
-                      ]
-                    },
-                    {
-                      "name": "view",
-                      "about": "Get the current target release of the rack's system software",
-                      "long_about": "This may not correspond to the actual software running on the rack at the time of request; it is instead the release that the rack reconfigurator should be moving towards as a goal state. After some number of planning and execution phases, the software running on the rack should eventually correspond to the release described here.",
-                      "args": [
-                        {
-                          "long": "profile",
-                          "help": "Configuration profile to use for commands",
-                          "global": true
                         }
                       ]
                     }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1902,54 +1902,6 @@
               ],
               "subcommands": [
                 {
-                  "name": "status",
-                  "about": "Fetch system update status",
-                  "long_about": "Returns information about the current target release and the progress of system software updates.",
-                  "args": [
-                    {
-                      "long": "profile",
-                      "help": "Configuration profile to use for commands",
-                      "global": true
-                    }
-                  ]
-                },
-                {
-                  "name": "target-release",
-                  "args": [
-                    {
-                      "long": "profile",
-                      "help": "Configuration profile to use for commands",
-                      "global": true
-                    }
-                  ],
-                  "subcommands": [
-                    {
-                      "name": "update",
-                      "about": "Set target release",
-                      "long_about": "Set the current target release of the rack's system software. The rack reconfigurator will treat the software specified here as a goal state for the rack's software, and attempt to asynchronously update to that release. Use the update status endpoint to view the current target release.",
-                      "args": [
-                        {
-                          "long": "json-body",
-                          "help": "Path to a file that contains the full json body."
-                        },
-                        {
-                          "long": "json-body-template",
-                          "help": "XXX"
-                        },
-                        {
-                          "long": "profile",
-                          "help": "Configuration profile to use for commands",
-                          "global": true
-                        },
-                        {
-                          "long": "system-version",
-                          "help": "Version of the system software to make the target release."
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "name": "trust-root",
                   "args": [
                     {
@@ -7944,6 +7896,29 @@
               ],
               "subcommands": [
                 {
+                  "name": "list",
+                  "about": "List all TUF repositories",
+                  "long_about": "Returns a paginated list of all TUF repositories ordered by system version (newest first by default).",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "sort-by",
+                      "values": [
+                        "version_ascending",
+                        "version_descending"
+                      ]
+                    }
+                  ]
+                },
+                {
                   "name": "upload",
                   "args": [
                     {
@@ -7955,6 +7930,69 @@
                       "long": "profile",
                       "help": "Configuration profile to use for commands",
                       "global": true
+                    }
+                  ]
+                },
+                {
+                  "name": "view",
+                  "about": "Fetch system release repository description by version",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "system-version",
+                      "help": "The version to get."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "status",
+              "about": "Fetch system update status",
+              "long_about": "Returns information about the current target release and the progress of system software updates.",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands",
+                  "global": true
+                }
+              ]
+            },
+            {
+              "name": "target-release",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands",
+                  "global": true
+                }
+              ],
+              "subcommands": [
+                {
+                  "name": "update",
+                  "about": "Set target release",
+                  "long_about": "Set the current target release of the rack's system software. The rack reconfigurator will treat the software specified here as a goal state for the rack's software, and attempt to asynchronously update to that release. Use the update status endpoint to view the current target release.",
+                  "args": [
+                    {
+                      "long": "json-body",
+                      "help": "Path to a file that contains the full json body."
+                    },
+                    {
+                      "long": "json-body-template",
+                      "help": "XXX"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "system-version",
+                      "help": "Version of the system software to make the target release."
                     }
                   ]
                 }

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -1890,102 +1890,6 @@
                   ]
                 }
               ]
-            },
-            {
-              "name": "update",
-              "args": [
-                {
-                  "long": "profile",
-                  "help": "Configuration profile to use for commands",
-                  "global": true
-                }
-              ],
-              "subcommands": [
-                {
-                  "name": "trust-root",
-                  "args": [
-                    {
-                      "long": "profile",
-                      "help": "Configuration profile to use for commands",
-                      "global": true
-                    }
-                  ],
-                  "subcommands": [
-                    {
-                      "name": "create",
-                      "about": "Add trusted root role to updates trust store",
-                      "args": [
-                        {
-                          "long": "json-body",
-                          "help": "Path to a file that contains the full json body."
-                        },
-                        {
-                          "long": "json-body-template",
-                          "help": "XXX"
-                        },
-                        {
-                          "long": "profile",
-                          "help": "Configuration profile to use for commands",
-                          "global": true
-                        }
-                      ]
-                    },
-                    {
-                      "name": "delete",
-                      "about": "Delete trusted root role",
-                      "long_about": "Note that this method does not currently check for any uploaded system release repositories that would become untrusted after deleting the root role.",
-                      "args": [
-                        {
-                          "long": "profile",
-                          "help": "Configuration profile to use for commands",
-                          "global": true
-                        },
-                        {
-                          "long": "trust-root-id",
-                          "help": "ID of the trust root"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "list",
-                      "about": "List root roles in the updates trust store",
-                      "long_about": "A root role is a JSON document describing the cryptographic keys that are trusted to sign system release repositories, as described by The Update Framework. Uploading a repository requires its metadata to be signed by keys trusted by the trust store.",
-                      "args": [
-                        {
-                          "long": "limit",
-                          "help": "Maximum number of items returned by a single call"
-                        },
-                        {
-                          "long": "profile",
-                          "help": "Configuration profile to use for commands",
-                          "global": true
-                        },
-                        {
-                          "long": "sort-by",
-                          "values": [
-                            "id_ascending"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "name": "view",
-                      "about": "Fetch trusted root role",
-                      "args": [
-                        {
-                          "long": "profile",
-                          "help": "Configuration profile to use for commands",
-                          "global": true
-                        },
-                        {
-                          "long": "trust-root-id",
-                          "help": "ID of the trust root"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
             }
           ]
         },
@@ -7993,6 +7897,90 @@
                     {
                       "long": "system-version",
                       "help": "Version of the system software to make the target release."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "trust-root",
+              "args": [
+                {
+                  "long": "profile",
+                  "help": "Configuration profile to use for commands",
+                  "global": true
+                }
+              ],
+              "subcommands": [
+                {
+                  "name": "create",
+                  "about": "Add trusted root role to updates trust store",
+                  "args": [
+                    {
+                      "long": "json-body",
+                      "help": "Path to a file that contains the full json body."
+                    },
+                    {
+                      "long": "json-body-template",
+                      "help": "XXX"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    }
+                  ]
+                },
+                {
+                  "name": "delete",
+                  "about": "Delete trusted root role",
+                  "long_about": "Note that this method does not currently check for any uploaded system release repositories that would become untrusted after deleting the root role.",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "trust-root-id",
+                      "help": "ID of the trust root"
+                    }
+                  ]
+                },
+                {
+                  "name": "list",
+                  "about": "List root roles in the updates trust store",
+                  "long_about": "A root role is a JSON document describing the cryptographic keys that are trusted to sign system release repositories, as described by The Update Framework. Uploading a repository requires its metadata to be signed by keys trusted by the trust store.",
+                  "args": [
+                    {
+                      "long": "limit",
+                      "help": "Maximum number of items returned by a single call"
+                    },
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "sort-by",
+                      "values": [
+                        "id_ascending"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "view",
+                  "about": "Fetch trusted root role",
+                  "args": [
+                    {
+                      "long": "profile",
+                      "help": "Configuration profile to use for commands",
+                      "global": true
+                    },
+                    {
+                      "long": "trust-root-id",
+                      "help": "ID of the trust root"
                     }
                   ]
                 }

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -645,9 +645,9 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
             Some("experimental system update trust-root delete")
         }
         // Manually implemented
-        CliCommand::SystemUpdatePutRepository => None,
-        // Not implemented
-        CliCommand::SystemUpdateGetRepository => None,
+        CliCommand::SystemUpdateRepositoryList => None,
+        CliCommand::SystemUpdateRepositoryUpload => None,
+        CliCommand::SystemUpdateRepositoryView => None,
 
         CliCommand::SwitchList => Some("system hardware switch list"),
         CliCommand::SwitchView => Some("system hardware switch view"),

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -634,8 +634,8 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::AuthSettingsUpdate => Some("auth-settings update"),
 
         // Update subcommands
-        CliCommand::TargetReleaseView => Some("experimental system update target-release view"),
         CliCommand::TargetReleaseUpdate => Some("experimental system update target-release update"),
+        CliCommand::SystemUpdateStatus => Some("experimental system update status"),
         CliCommand::SystemUpdateTrustRootList => Some("experimental system update trust-root list"),
         CliCommand::SystemUpdateTrustRootCreate => {
             Some("experimental system update trust-root create")

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -634,8 +634,6 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::AuthSettingsUpdate => Some("auth-settings update"),
 
         // Update subcommands
-        CliCommand::TargetReleaseUpdate => Some("experimental system update target-release update"),
-        CliCommand::SystemUpdateStatus => Some("experimental system update status"),
         CliCommand::SystemUpdateTrustRootList => Some("experimental system update trust-root list"),
         CliCommand::SystemUpdateTrustRootCreate => {
             Some("experimental system update trust-root create")
@@ -644,10 +642,11 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::SystemUpdateTrustRootDelete => {
             Some("experimental system update trust-root delete")
         }
-        // Manually implemented
-        CliCommand::SystemUpdateRepositoryList => None,
-        CliCommand::SystemUpdateRepositoryUpload => None,
-        CliCommand::SystemUpdateRepositoryView => None,
+        CliCommand::TargetReleaseUpdate => Some("system update target-release update"),
+        CliCommand::SystemUpdateStatus => Some("system update status"),
+        CliCommand::SystemUpdateRepositoryList => Some("system update repo list"),
+        CliCommand::SystemUpdateRepositoryView => Some("system update repo view"),
+        CliCommand::SystemUpdateRepositoryUpload => None, // Manually implemented
 
         CliCommand::SwitchList => Some("system hardware switch list"),
         CliCommand::SwitchView => Some("system hardware switch view"),

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -634,14 +634,10 @@ fn xxx<'a>(command: CliCommand) -> Option<&'a str> {
         CliCommand::AuthSettingsUpdate => Some("auth-settings update"),
 
         // Update subcommands
-        CliCommand::SystemUpdateTrustRootList => Some("experimental system update trust-root list"),
-        CliCommand::SystemUpdateTrustRootCreate => {
-            Some("experimental system update trust-root create")
-        }
-        CliCommand::SystemUpdateTrustRootView => Some("experimental system update trust-root view"),
-        CliCommand::SystemUpdateTrustRootDelete => {
-            Some("experimental system update trust-root delete")
-        }
+        CliCommand::SystemUpdateTrustRootList => Some("system update trust-root list"),
+        CliCommand::SystemUpdateTrustRootCreate => Some("system update trust-root create"),
+        CliCommand::SystemUpdateTrustRootView => Some("system update trust-root view"),
+        CliCommand::SystemUpdateTrustRootDelete => Some("system update trust-root delete"),
         CliCommand::TargetReleaseUpdate => Some("system update target-release update"),
         CliCommand::SystemUpdateStatus => Some("system update status"),
         CliCommand::SystemUpdateRepositoryList => Some("system update repo list"),

--- a/cli/src/cmd_timeseries/dashboard.rs
+++ b/cli/src/cmd_timeseries/dashboard.rs
@@ -219,7 +219,10 @@ async fn client_query_loop(
             _ = interval.tick() => {
                 let request = client
                     .system_timeseries_query()
-                    .body(TimeseriesQuery { query: query.clone() });
+                    .body(TimeseriesQuery {
+                        query: query.clone(),
+                        include_summaries: false,
+                    });
                 match request.send().await {
                     Ok(response) => {
                         tx.send(Message::Table(response.into_inner().tables))

--- a/cli/src/cmd_update.rs
+++ b/cli/src/cmd_update.rs
@@ -51,7 +51,7 @@ impl AuthenticatedCmd for CmdUpload {
         let body = reqwest::Body::wrap_stream(file_stream);
 
         let response = client
-            .system_update_put_repository()
+            .system_update_repository_upload()
             .file_name(file_name)
             .body(body)
             .send()

--- a/cli/src/generated_cli.rs
+++ b/cli/src/generated_cli.rs
@@ -306,7 +306,7 @@ impl<T: CliConfig> Cli<T> {
             CliCommand::SystemUpdateRepositoryList => Self::cli_system_update_repository_list(),
             CliCommand::SystemUpdateRepositoryUpload => Self::cli_system_update_repository_upload(),
             CliCommand::SystemUpdateRepositoryView => Self::cli_system_update_repository_view(),
-            CliCommand::TargetReleaseView => Self::cli_target_release_view(),
+            CliCommand::SystemUpdateStatus => Self::cli_system_update_status(),
             CliCommand::TargetReleaseUpdate => Self::cli_target_release_update(),
             CliCommand::SystemUpdateTrustRootList => Self::cli_system_update_trust_root_list(),
             CliCommand::SystemUpdateTrustRootCreate => Self::cli_system_update_trust_root_create(),
@@ -6974,15 +6974,12 @@ impl<T: CliConfig> Cli<T> {
             .about("Fetch system release repository description by version")
     }
 
-    pub fn cli_target_release_view() -> ::clap::Command {
+    pub fn cli_system_update_status() -> ::clap::Command {
         ::clap::Command::new("")
-            .about("Get the current target release of the rack's system software")
+            .about("Fetch system update status")
             .long_about(
-                "This may not correspond to the actual software running on the rack at the time \
-                 of request; it is instead the release that the rack reconfigurator should be \
-                 moving towards as a goal state. After some number of planning and execution \
-                 phases, the software running on the rack should eventually correspond to the \
-                 release described here.",
+                "Returns information about the current target release and the progress of system \
+                 software updates.",
             )
     }
 
@@ -7011,10 +7008,12 @@ impl<T: CliConfig> Cli<T> {
                     .action(::clap::ArgAction::SetTrue)
                     .help("XXX"),
             )
-            .about("Set the current target release of the rack's system software")
+            .about("Set target release")
             .long_about(
-                "The rack reconfigurator will treat the software specified here as a goal state \
-                 for the rack's software, and attempt to asynchronously update to that release.",
+                "Set the current target release of the rack's system software. The rack \
+                 reconfigurator will treat the software specified here as a goal state for the \
+                 rack's software, and attempt to asynchronously update to that release. Use the \
+                 update status endpoint to view the current target release.",
             )
     }
 
@@ -8953,7 +8952,7 @@ impl<T: CliConfig> Cli<T> {
             CliCommand::SystemUpdateRepositoryView => {
                 self.execute_system_update_repository_view(matches).await
             }
-            CliCommand::TargetReleaseView => self.execute_target_release_view(matches).await,
+            CliCommand::SystemUpdateStatus => self.execute_system_update_status(matches).await,
             CliCommand::TargetReleaseUpdate => self.execute_target_release_update(matches).await,
             CliCommand::SystemUpdateTrustRootList => {
                 self.execute_system_update_trust_root_list(matches).await
@@ -16707,13 +16706,13 @@ impl<T: CliConfig> Cli<T> {
         }
     }
 
-    pub async fn execute_target_release_view(
+    pub async fn execute_system_update_status(
         &self,
         matches: &::clap::ArgMatches,
     ) -> anyhow::Result<()> {
-        let mut request = self.client.target_release_view();
+        let mut request = self.client.system_update_status();
         self.config
-            .execute_target_release_view(matches, &mut request)?;
+            .execute_system_update_status(matches, &mut request)?;
         let result = request.send().await;
         match result {
             Ok(r) => {
@@ -16750,7 +16749,7 @@ impl<T: CliConfig> Cli<T> {
         let result = request.send().await;
         match result {
             Ok(r) => {
-                self.config.success_item(&r);
+                self.config.success_no_item(&r);
                 Ok(())
             }
             Err(r) => {
@@ -20211,10 +20210,10 @@ pub trait CliConfig {
         Ok(())
     }
 
-    fn execute_target_release_view(
+    fn execute_system_update_status(
         &self,
         matches: &::clap::ArgMatches,
-        request: &mut builder::TargetReleaseView,
+        request: &mut builder::SystemUpdateStatus,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -20817,7 +20816,7 @@ pub enum CliCommand {
     SystemUpdateRepositoryList,
     SystemUpdateRepositoryUpload,
     SystemUpdateRepositoryView,
-    TargetReleaseView,
+    SystemUpdateStatus,
     TargetReleaseUpdate,
     SystemUpdateTrustRootList,
     SystemUpdateTrustRootCreate,
@@ -21096,7 +21095,7 @@ impl CliCommand {
             CliCommand::SystemUpdateRepositoryList,
             CliCommand::SystemUpdateRepositoryUpload,
             CliCommand::SystemUpdateRepositoryView,
-            CliCommand::TargetReleaseView,
+            CliCommand::SystemUpdateStatus,
             CliCommand::TargetReleaseUpdate,
             CliCommand::SystemUpdateTrustRootList,
             CliCommand::SystemUpdateTrustRootCreate,

--- a/cli/tests/data/json-body-required.txt
+++ b/cli/tests/data/json-body-required.txt
@@ -9,8 +9,8 @@ oxide vpc router route create
 oxide vpc router route update
 oxide alert receiver webhook create
 oxide disk create
-oxide experimental system update trust-root create
 oxide system policy update
 oxide system networking address-lot create
 oxide system networking switch-port-settings create
 oxide system networking bgp announce-set update
+oxide system update trust-root create

--- a/cli/tests/data/test_update_upload.stdout
+++ b/cli/tests/data/test_update_upload.stdout
@@ -1,23 +1,9 @@
 {
-  "recorded": {
-    "artifacts": [
-      {
-        "hash": "ish",
-        "id": {
-          "kind": "buds",
-          "name": "trees",
-          "version": "4.2.0"
-        },
-        "size": 440401920
-      }
-    ],
-    "repo": {
-      "file_name": "repo",
-      "hash": "browns",
-      "system_version": "0.0.0",
-      "targets_role_version": 42,
-      "valid_until": "2038-01-19T03:14:08Z"
-    }
+  "repo": {
+    "file_name": "repo",
+    "hash": "browns",
+    "system_version": "0.0.0",
+    "time_created": "2038-01-19T03:14:08Z"
   },
   "status": "inserted"
 }

--- a/cli/tests/test_update.rs
+++ b/cli/tests/test_update.rs
@@ -7,10 +7,7 @@
 use assert_cmd::Command;
 use chrono::{DateTime, Utc};
 use httpmock::MockServer;
-use oxide::types::{
-    ArtifactId, TufArtifactMeta, TufRepoDescription, TufRepoInsertResponse, TufRepoInsertStatus,
-    TufRepoMeta,
-};
+use oxide::types::{TufRepo, TufRepoUpload, TufRepoUploadStatus};
 use oxide_httpmock::MockServerExt;
 
 #[test]
@@ -18,30 +15,16 @@ fn test_update_upload() {
     const CONTENTS: &str = "nuggets";
     let server = MockServer::start();
 
-    let mock = server.system_update_put_repository(|when, then| {
+    let mock = server.system_update_repository_upload(|when, then| {
         when.into_inner().body(CONTENTS);
-        then.ok(&TufRepoInsertResponse {
-            recorded: TufRepoDescription {
-                artifacts: vec![TufArtifactMeta {
-                    hash: String::from("ish"),
-                    id: ArtifactId {
-                        kind: String::from("buds"),
-                        name: String::from("trees"),
-                        version: String::from("4.2.0"),
-                    },
-                    size: 420 * 1024 * 1024,
-                    sign: None,
-                    board: None,
-                }],
-                repo: TufRepoMeta {
-                    file_name: String::from("repo"),
-                    hash: String::from("browns"),
-                    system_version: "0.0.0".parse().unwrap(),
-                    targets_role_version: 42,
-                    valid_until: DateTime::<Utc>::from_timestamp(0x8000_0000, 0).unwrap(),
-                },
+        then.ok(&TufRepoUpload {
+            repo: TufRepo {
+                file_name: String::from("repo"),
+                hash: String::from("browns"),
+                system_version: "0.0.0".parse().unwrap(),
+                time_created: DateTime::<Utc>::from_timestamp(0x8000_0000, 0).unwrap(),
             },
-            status: TufRepoInsertStatus::Inserted,
+            status: TufRepoUploadStatus::Inserted,
         });
     });
 

--- a/mock-server/src/main.rs
+++ b/mock-server/src/main.rs
@@ -7,12 +7,13 @@
 use std::time::Duration;
 
 use chrono::DateTime;
+use chrono::Utc;
 use dropshot::{
     endpoint, ApiDescription, ConfigDropshot, ConfigLogging, ConfigLoggingLevel, HttpError,
     HttpResponseOk, Query, RequestContext, ServerBuilder, StreamingBody,
 };
 use futures::{pin_mut, StreamExt};
-use oxide::types::{TufRepoDescription, TufRepoInsertResponse, TufRepoInsertStatus, TufRepoMeta};
+use oxide::types::{TufRepo, TufRepoUpload, TufRepoUploadStatus};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::time::{sleep, Instant};
@@ -35,7 +36,7 @@ async fn system_update_put_repository(
     _rqctx: RequestContext<()>,
     query: Query<UpdatesPutRepositoryParams>,
     body: StreamingBody,
-) -> Result<HttpResponseOk<TufRepoInsertResponse>, HttpError> {
+) -> Result<HttpResponseOk<TufRepoUpload>, HttpError> {
     const BYTES_PER_SEC: usize = 200 * MIB;
 
     let start = Instant::now();
@@ -59,18 +60,14 @@ async fn system_update_put_repository(
         }
     }
 
-    Ok(HttpResponseOk(TufRepoInsertResponse {
-        recorded: TufRepoDescription {
-            artifacts: vec![],
-            repo: TufRepoMeta {
-                file_name: query.into_inner().file_name,
-                hash: String::new(),
-                system_version: "1.2.3".parse().unwrap(),
-                targets_role_version: 100,
-                valid_until: DateTime::from_timestamp(0x8000_0000, 0).unwrap(),
-            },
+    Ok(HttpResponseOk(TufRepoUpload {
+        repo: TufRepo {
+            file_name: query.into_inner().file_name,
+            hash: String::new(),
+            system_version: "1.2.3".parse().unwrap(),
+            time_created: DateTime::<Utc>::from_timestamp(0x8000_0000, 0).unwrap(),
         },
-        status: TufRepoInsertStatus::Inserted,
+        status: TufRepoUploadStatus::Inserted,
     }))
 }
 

--- a/oxide.json
+++ b/oxide.json
@@ -25868,11 +25868,11 @@
         "type": "object",
         "properties": {
           "file_name": {
-            "description": "The file name of the repository\n\nThis is purely used for debugging and may not always be correct (e.g., with wicket, we read the file contents from stdin so we don't know the correct file name).",
+            "description": "The file name of the repository\n\nThis is intended for debugging and may not always be correct.",
             "type": "string"
           },
           "hash": {
-            "description": "The hash of the repository.\n\nThis is a slight abuse of `ArtifactHash`, since that's the hash of individual artifacts within the repository. However, we use it here for convenience.",
+            "description": "The hash of the repository",
             "type": "string",
             "format": "hex string (32 bytes)"
           },
@@ -26117,7 +26117,7 @@
         "type": "object",
         "properties": {
           "components_by_release_version": {
-            "description": "Count of components running each release version",
+            "description": "Count of components running each release version\n\nKeys will be either:\n\n* Semver-like release version strings * \"install dataset\", representing the initial rack software before any updates * \"unknown\", which means there is no TUF repo uploaded that matches the software running on the component)",
             "type": "object",
             "additionalProperties": {
               "type": "integer",
@@ -26125,8 +26125,8 @@
               "minimum": 0
             }
           },
-          "paused": {
-            "description": "Whether update activity is paused\n\nWhen true, the system has stopped attempting to make progress toward the target release. This happens after a MUPdate because the system wants to make sure of the operator's intent. To resume update, set a new target release.",
+          "suspended": {
+            "description": "Whether automatic update is suspended due to manual update activity\n\nAfter a manual support procedure that changes the system software, automatic update activity is suspended to avoid undoing the change. To resume automatic update, first upload the TUF repository matching the manually applied update, then set that as the target release.",
             "type": "boolean"
           },
           "target_release": {
@@ -26138,17 +26138,17 @@
               }
             ]
           },
-          "time_last_blueprint": {
-            "description": "Time of most recent update planning activity\n\nThis is intended as a rough indicator of the last time something happened in the update planner. A blueprint is the update system's plan for the next state of the system, so this timestamp indicates the last time the update system made a plan.",
+          "time_last_step_planned": {
+            "description": "Time of most recent update planning activity\n\nThis is intended as a rough indicator of the last time something happened in the update planner.",
             "type": "string",
             "format": "date-time"
           }
         },
         "required": [
           "components_by_release_version",
-          "paused",
+          "suspended",
           "target_release",
-          "time_last_blueprint"
+          "time_last_step_planned"
         ]
       },
       "UpdatesTrustRoot": {

--- a/oxide.json
+++ b/oxide.json
@@ -11050,21 +11050,21 @@
         }
       }
     },
-    "/v1/system/update/target-release": {
+    "/v1/system/update/status": {
       "get": {
         "tags": [
           "system/update"
         ],
-        "summary": "Get the current target release of the rack's system software",
-        "description": "This may not correspond to the actual software running on the rack at the time of request; it is instead the release that the rack reconfigurator should be moving towards as a goal state. After some number of planning and execution phases, the software running on the rack should eventually correspond to the release described here.",
-        "operationId": "target_release_view",
+        "summary": "Fetch system update status",
+        "description": "Returns information about the current target release and the progress of system software updates.",
+        "operationId": "system_update_status",
         "responses": {
           "200": {
             "description": "successful operation",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TargetRelease"
+                  "$ref": "#/components/schemas/UpdateStatus"
                 }
               }
             }
@@ -11076,13 +11076,15 @@
             "$ref": "#/components/responses/Error"
           }
         }
-      },
+      }
+    },
+    "/v1/system/update/target-release": {
       "put": {
         "tags": [
           "system/update"
         ],
-        "summary": "Set the current target release of the rack's system software",
-        "description": "The rack reconfigurator will treat the software specified here as a goal state for the rack's software, and attempt to asynchronously update to that release.",
+        "summary": "Set target release",
+        "description": "Set the current target release of the rack's system software. The rack reconfigurator will treat the software specified here as a goal state for the rack's software, and attempt to asynchronously update to that release. Use the update status endpoint to view the current target release.",
         "operationId": "target_release_update",
         "requestBody": {
           "content": {
@@ -11095,15 +11097,8 @@
           "required": true
         },
         "responses": {
-          "201": {
-            "description": "successful creation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TargetRelease"
-                }
-              }
-            }
+          "204": {
+            "description": "resource updated"
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -25722,72 +25717,23 @@
         ]
       },
       "TargetRelease": {
-        "description": "View of a system software target release.",
+        "description": "View of a system software target release",
         "type": "object",
         "properties": {
-          "generation": {
-            "description": "The target-release generation number.",
-            "type": "integer",
-            "format": "int64"
-          },
-          "release_source": {
-            "description": "The source of the target release.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TargetReleaseSource"
-              }
-            ]
-          },
           "time_requested": {
-            "description": "The time it was set as the target release.",
+            "description": "Time this was set as the target release",
             "type": "string",
             "format": "date-time"
+          },
+          "version": {
+            "description": "The specified release of the rack's system software",
+            "type": "string",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
           }
         },
         "required": [
-          "generation",
-          "release_source",
-          "time_requested"
-        ]
-      },
-      "TargetReleaseSource": {
-        "description": "Source of a system software target release.",
-        "oneOf": [
-          {
-            "description": "Unspecified or unknown source (probably MUPdate).",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "unspecified"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "description": "The specified release of the rack's system software.",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "system_version"
-                ]
-              },
-              "version": {
-                "type": "string",
-                "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-              }
-            },
-            "required": [
-              "type",
-              "version"
-            ]
-          }
+          "time_requested",
+          "version"
         ]
       },
       "Timeseries": {
@@ -26165,6 +26111,44 @@
               "rpm"
             ]
           }
+        ]
+      },
+      "UpdateStatus": {
+        "type": "object",
+        "properties": {
+          "components_by_release_version": {
+            "description": "Count of components running each release version",
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "paused": {
+            "description": "Whether update activity is paused\n\nWhen true, the system has stopped attempting to make progress toward the target release. This happens after a MUPdate because the system wants to make sure of the operator's intent. To resume update, set a new target release.",
+            "type": "boolean"
+          },
+          "target_release": {
+            "nullable": true,
+            "description": "Current target release of the system software\n\nThis may not correspond to the actual system software running at the time of request; it is instead the release that the system should be moving towards as a goal state. The system asynchronously updates software to match this target release.\n\nWill only be null if a target release has never been set. In that case, the system is not automatically attempting to manage software versions.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TargetRelease"
+              }
+            ]
+          },
+          "time_last_blueprint": {
+            "description": "Time of most recent update planning activity\n\nThis is intended as a rough indicator of the last time something happened in the update planner. A blueprint is the update system's plan for the next state of the system, so this timestamp indicates the last time the update system made a plan.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "components_by_release_version",
+          "paused",
+          "target_release",
+          "time_last_blueprint"
         ]
       },
       "UpdatesTrustRoot": {

--- a/oxide.json
+++ b/oxide.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "20250730.0.0"
+    "version": "20251008.0.0"
   },
   "paths": {
     "/device/auth": {
@@ -10903,14 +10903,72 @@
         }
       }
     },
-    "/v1/system/update/repository": {
+    "/v1/system/update/repositories": {
+      "get": {
+        "tags": [
+          "system/update"
+        ],
+        "summary": "List all TUF repositories",
+        "description": "Returns a paginated list of all TUF repositories ordered by system version (newest first by default).",
+        "operationId": "system_update_repository_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/VersionSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TufRepoResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": {
+          "required": []
+        }
+      },
       "put": {
         "tags": [
           "system/update"
         ],
         "summary": "Upload system release repository",
         "description": "System release repositories are verified by the updates trust store.",
-        "operationId": "system_update_put_repository",
+        "operationId": "system_update_repository_upload",
         "parameters": [
           {
             "in": "query",
@@ -10939,7 +10997,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TufRepoInsertResponse"
+                  "$ref": "#/components/schemas/TufRepoUpload"
                 }
               }
             }
@@ -10953,13 +11011,13 @@
         }
       }
     },
-    "/v1/system/update/repository/{system_version}": {
+    "/v1/system/update/repositories/{system_version}": {
       "get": {
         "tags": [
           "system/update"
         ],
         "summary": "Fetch system release repository description by version",
-        "operationId": "system_update_get_repository",
+        "operationId": "system_update_repository_view",
         "parameters": [
           {
             "in": "path",
@@ -10978,7 +11036,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TufRepoGetResponse"
+                  "$ref": "#/components/schemas/TufRepo"
                 }
               }
             }
@@ -14592,29 +14650,6 @@
             ]
           }
         }
-      },
-      "ArtifactId": {
-        "description": "An identifier for an artifact.",
-        "type": "object",
-        "properties": {
-          "kind": {
-            "description": "The kind of artifact this is.",
-            "type": "string"
-          },
-          "name": {
-            "description": "The artifact's name.",
-            "type": "string"
-          },
-          "version": {
-            "description": "The artifact's version.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "kind",
-          "name",
-          "version"
-        ]
       },
       "AuditLogEntry": {
         "description": "Audit log entry",
@@ -21199,6 +21234,54 @@
           "items"
         ]
       },
+      "IoCount": {
+        "description": "A count of bytes / rows accessed during a query.",
+        "type": "object",
+        "properties": {
+          "bytes": {
+            "description": "The number of bytes accessed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "rows": {
+            "description": "The number of rows accessed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "bytes",
+          "rows"
+        ]
+      },
+      "IoSummary": {
+        "description": "Summary of the I/O resources used by a query.",
+        "type": "object",
+        "properties": {
+          "read": {
+            "description": "The bytes and rows read by the query.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IoCount"
+              }
+            ]
+          },
+          "written": {
+            "description": "The bytes and rows written by the query.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IoCount"
+              }
+            ]
+          }
+        },
+        "required": [
+          "read",
+          "written"
+        ]
+      },
       "IpNet": {
         "x-rust-type": {
           "crate": "oxnet",
@@ -22316,6 +22399,14 @@
         "description": "The result of a successful OxQL query.",
         "type": "object",
         "properties": {
+          "query_summaries": {
+            "nullable": true,
+            "description": "Summaries of queries run against ClickHouse.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OxqlQuerySummary"
+            }
+          },
           "tables": {
             "description": "Tables resulting from the query, each containing timeseries.",
             "type": "array",
@@ -22326,6 +22417,41 @@
         },
         "required": [
           "tables"
+        ]
+      },
+      "OxqlQuerySummary": {
+        "description": "Basic metadata about the resource usage of a single ClickHouse SQL query.",
+        "type": "object",
+        "properties": {
+          "elapsed_ms": {
+            "description": "The total duration of the ClickHouse query (network plus execution).",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "id": {
+            "description": "The database-assigned query ID.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "io_summary": {
+            "description": "Summary of the data read and written.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IoSummary"
+              }
+            ]
+          },
+          "query": {
+            "description": "The raw ClickHouse SQL query.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "elapsed_ms",
+          "id",
+          "io_summary",
+          "query"
         ]
       },
       "OxqlTable": {
@@ -25709,6 +25835,11 @@
         "description": "A timeseries query string, written in the Oximeter query language.",
         "type": "object",
         "properties": {
+          "include_summaries": {
+            "description": "Whether to include ClickHouse query summaries in the response.",
+            "default": false,
+            "type": "boolean"
+          },
           "query": {
             "description": "A timeseries query string, written in the Oximeter query language.",
             "type": "string"
@@ -25786,144 +25917,12 @@
           "items"
         ]
       },
-      "TufArtifactMeta": {
-        "description": "Metadata about an individual TUF artifact.\n\nFound within a `TufRepoDescription`.",
-        "type": "object",
-        "properties": {
-          "board": {
-            "nullable": true,
-            "description": "Contents of the `BORD` field of a Hubris archive caboose. Only applicable to artifacts that are Hubris archives.\n\nThis field should always be `Some(_)` if `sign` is `Some(_)`, but the opposite is not true (SP images will have a `board` but not a `sign`).",
-            "type": "string"
-          },
-          "hash": {
-            "description": "The hash of the artifact.",
-            "type": "string",
-            "format": "hex string (32 bytes)"
-          },
-          "id": {
-            "description": "The artifact ID.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ArtifactId"
-              }
-            ]
-          },
-          "sign": {
-            "nullable": true,
-            "description": "Contents of the `SIGN` field of a Hubris archive caboose, i.e., an identifier for the set of valid signing keys. Currently only applicable to RoT image and bootloader artifacts, where it will be an LPC55 Root Key Table Hash (RKTH).",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
-          },
-          "size": {
-            "description": "The size of the artifact in bytes.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "hash",
-          "id",
-          "size"
-        ]
-      },
-      "TufRepoDescription": {
-        "description": "A description of an uploaded TUF repository.",
-        "type": "object",
-        "properties": {
-          "artifacts": {
-            "description": "Information about the artifacts present in the repository.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TufArtifactMeta"
-            }
-          },
-          "repo": {
-            "description": "Information about the repository.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TufRepoMeta"
-              }
-            ]
-          }
-        },
-        "required": [
-          "artifacts",
-          "repo"
-        ]
-      },
-      "TufRepoGetResponse": {
-        "description": "Data about a successful TUF repo get from Nexus.",
-        "type": "object",
-        "properties": {
-          "description": {
-            "description": "The description of the repository.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TufRepoDescription"
-              }
-            ]
-          }
-        },
-        "required": [
-          "description"
-        ]
-      },
-      "TufRepoInsertResponse": {
-        "description": "Data about a successful TUF repo import into Nexus.",
-        "type": "object",
-        "properties": {
-          "recorded": {
-            "description": "The repository as present in the database.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TufRepoDescription"
-              }
-            ]
-          },
-          "status": {
-            "description": "Whether this repository already existed or is new.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TufRepoInsertStatus"
-              }
-            ]
-          }
-        },
-        "required": [
-          "recorded",
-          "status"
-        ]
-      },
-      "TufRepoInsertStatus": {
-        "description": "Status of a TUF repo import.\n\nPart of `TufRepoInsertResponse`.",
-        "oneOf": [
-          {
-            "description": "The repository already existed in the database.",
-            "type": "string",
-            "enum": [
-              "already_exists"
-            ]
-          },
-          {
-            "description": "The repository did not exist, and was inserted into the database.",
-            "type": "string",
-            "enum": [
-              "inserted"
-            ]
-          }
-        ]
-      },
-      "TufRepoMeta": {
-        "description": "Metadata about a TUF repository.\n\nFound within a `TufRepoDescription`.",
+      "TufRepo": {
+        "description": "Metadata about a TUF repository",
         "type": "object",
         "properties": {
           "file_name": {
-            "description": "The file name of the repository.\n\nThis is purely used for debugging and may not always be correct (e.g. with wicket, we read the file contents from stdin so we don't know the correct file name).",
+            "description": "The file name of the repository\n\nThis is purely used for debugging and may not always be correct (e.g., with wicket, we read the file contents from stdin so we don't know the correct file name).",
             "type": "string"
           },
           "hash": {
@@ -25932,18 +25931,12 @@
             "format": "hex string (32 bytes)"
           },
           "system_version": {
-            "description": "The system version in artifacts.json.",
+            "description": "The system version in artifacts.json",
             "type": "string",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
           },
-          "targets_role_version": {
-            "description": "The version of the targets role.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "valid_until": {
-            "description": "The time until which the repo is valid.",
+          "time_created": {
+            "description": "Time the repository was uploaded",
             "type": "string",
             "format": "date-time"
           }
@@ -25952,8 +25945,62 @@
           "file_name",
           "hash",
           "system_version",
-          "targets_role_version",
-          "valid_until"
+          "time_created"
+        ]
+      },
+      "TufRepoResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TufRepo"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "TufRepoUpload": {
+        "type": "object",
+        "properties": {
+          "repo": {
+            "$ref": "#/components/schemas/TufRepo"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TufRepoUploadStatus"
+          }
+        },
+        "required": [
+          "repo",
+          "status"
+        ]
+      },
+      "TufRepoUploadStatus": {
+        "description": "Whether the uploaded TUF repo already existed or was new and had to be inserted. Part of `TufRepoUpload`.",
+        "oneOf": [
+          {
+            "description": "The repository already existed in the database",
+            "type": "string",
+            "enum": [
+              "already_exists"
+            ]
+          },
+          {
+            "description": "The repository did not exist, and was inserted into the database",
+            "type": "string",
+            "enum": [
+              "inserted"
+            ]
+          }
         ]
       },
       "TxEqConfig": {
@@ -27882,6 +27929,25 @@
         "enum": [
           "ascending",
           "descending"
+        ]
+      },
+      "VersionSortMode": {
+        "description": "Supported sort modes when scanning by semantic version",
+        "oneOf": [
+          {
+            "description": "Sort in increasing semantic version order (oldest first)",
+            "type": "string",
+            "enum": [
+              "version_ascending"
+            ]
+          },
+          {
+            "description": "Sort in decreasing semantic version order (newest first)",
+            "type": "string",
+            "enum": [
+              "version_descending"
+            ]
+          }
         ]
       },
       "NameSortMode": {

--- a/sdk-httpmock/src/generated_httpmock.rs
+++ b/sdk-httpmock/src/generated_httpmock.rs
@@ -17860,13 +17860,13 @@ pub mod operations {
         }
     }
 
-    pub struct SystemUpdatePutRepositoryWhen(::httpmock::When);
-    impl SystemUpdatePutRepositoryWhen {
+    pub struct SystemUpdateRepositoryListWhen(::httpmock::When);
+    impl SystemUpdateRepositoryListWhen {
         pub fn new(inner: ::httpmock::When) -> Self {
             Self(
                 inner
-                    .method(::httpmock::Method::PUT)
-                    .path_matches(regex::Regex::new("^/v1/system/update/repository$").unwrap()),
+                    .method(::httpmock::Method::GET)
+                    .path_matches(regex::Regex::new("^/v1/system/update/repositories$").unwrap()),
             )
         }
 
@@ -17874,17 +17874,57 @@ pub mod operations {
             self.0
         }
 
-        pub fn file_name(self, value: &str) -> Self {
-            Self(self.0.query_param("file_name", value.to_string()))
+        pub fn limit<T>(self, value: T) -> Self
+        where
+            T: Into<Option<::std::num::NonZeroU32>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("limit", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "limit"))
+                        .is_none()
+                }))
+            }
         }
 
-        pub fn body(self, value: ::serde_json::Value) -> Self {
-            Self(self.0.json_body(value))
+        pub fn page_token<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a str>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page_token", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "page_token"))
+                        .is_none()
+                }))
+            }
+        }
+
+        pub fn sort_by<T>(self, value: T) -> Self
+        where
+            T: Into<Option<types::VersionSortMode>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("sort_by", value.to_string()))
+            } else {
+                Self(self.0.matches(|req| {
+                    req.query_params
+                        .as_ref()
+                        .and_then(|qs| qs.iter().find(|(key, _)| key == "sort_by"))
+                        .is_none()
+                }))
+            }
         }
     }
 
-    pub struct SystemUpdatePutRepositoryThen(::httpmock::Then);
-    impl SystemUpdatePutRepositoryThen {
+    pub struct SystemUpdateRepositoryListThen(::httpmock::Then);
+    impl SystemUpdateRepositoryListThen {
         pub fn new(inner: ::httpmock::Then) -> Self {
             Self(inner)
         }
@@ -17893,7 +17933,7 @@ pub mod operations {
             self.0
         }
 
-        pub fn ok(self, value: &types::TufRepoInsertResponse) -> Self {
+        pub fn ok(self, value: &types::TufRepoResultsPage) -> Self {
             Self(
                 self.0
                     .status(200u16)
@@ -17923,13 +17963,13 @@ pub mod operations {
         }
     }
 
-    pub struct SystemUpdateGetRepositoryWhen(::httpmock::When);
-    impl SystemUpdateGetRepositoryWhen {
+    pub struct SystemUpdateRepositoryUploadWhen(::httpmock::When);
+    impl SystemUpdateRepositoryUploadWhen {
         pub fn new(inner: ::httpmock::When) -> Self {
             Self(
-                inner.method(::httpmock::Method::GET).path_matches(
-                    regex::Regex::new("^/v1/system/update/repository/[^/]*$").unwrap(),
-                ),
+                inner
+                    .method(::httpmock::Method::PUT)
+                    .path_matches(regex::Regex::new("^/v1/system/update/repositories$").unwrap()),
             )
         }
 
@@ -17937,18 +17977,17 @@ pub mod operations {
             self.0
         }
 
-        pub fn system_version(self, value: &types::SystemUpdateGetRepositorySystemVersion) -> Self {
-            let re = regex::Regex::new(&format!(
-                "^/v1/system/update/repository/{}$",
-                value.to_string()
-            ))
-            .unwrap();
-            Self(self.0.path_matches(re))
+        pub fn file_name(self, value: &str) -> Self {
+            Self(self.0.query_param("file_name", value.to_string()))
+        }
+
+        pub fn body(self, value: ::serde_json::Value) -> Self {
+            Self(self.0.json_body(value))
         }
     }
 
-    pub struct SystemUpdateGetRepositoryThen(::httpmock::Then);
-    impl SystemUpdateGetRepositoryThen {
+    pub struct SystemUpdateRepositoryUploadThen(::httpmock::Then);
+    impl SystemUpdateRepositoryUploadThen {
         pub fn new(inner: ::httpmock::Then) -> Self {
             Self(inner)
         }
@@ -17957,7 +17996,74 @@ pub mod operations {
             self.0
         }
 
-        pub fn ok(self, value: &types::TufRepoGetResponse) -> Self {
+        pub fn ok(self, value: &types::TufRepoUpload) -> Self {
+            Self(
+                self.0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn client_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 4u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+
+        pub fn server_error(self, status: u16, value: &types::Error) -> Self {
+            assert_eq!(status / 100u16, 5u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+
+    pub struct SystemUpdateRepositoryViewWhen(::httpmock::When);
+    impl SystemUpdateRepositoryViewWhen {
+        pub fn new(inner: ::httpmock::When) -> Self {
+            Self(
+                inner.method(::httpmock::Method::GET).path_matches(
+                    regex::Regex::new("^/v1/system/update/repositories/[^/]*$").unwrap(),
+                ),
+            )
+        }
+
+        pub fn into_inner(self) -> ::httpmock::When {
+            self.0
+        }
+
+        pub fn system_version(
+            self,
+            value: &types::SystemUpdateRepositoryViewSystemVersion,
+        ) -> Self {
+            let re = regex::Regex::new(&format!(
+                "^/v1/system/update/repositories/{}$",
+                value.to_string()
+            ))
+            .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+
+    pub struct SystemUpdateRepositoryViewThen(::httpmock::Then);
+    impl SystemUpdateRepositoryViewThen {
+        pub fn new(inner: ::httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> ::httpmock::Then {
+            self.0
+        }
+
+        pub fn ok(self, value: &types::TufRepo) -> Self {
             Self(
                 self.0
                     .status(200u16)
@@ -22903,17 +23009,23 @@ pub trait MockServerExt {
             operations::SystemTimeseriesSchemaListWhen,
             operations::SystemTimeseriesSchemaListThen,
         );
-    fn system_update_put_repository<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    fn system_update_repository_list<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
         F: FnOnce(
-            operations::SystemUpdatePutRepositoryWhen,
-            operations::SystemUpdatePutRepositoryThen,
+            operations::SystemUpdateRepositoryListWhen,
+            operations::SystemUpdateRepositoryListThen,
         );
-    fn system_update_get_repository<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    fn system_update_repository_upload<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
         F: FnOnce(
-            operations::SystemUpdateGetRepositoryWhen,
-            operations::SystemUpdateGetRepositoryThen,
+            operations::SystemUpdateRepositoryUploadWhen,
+            operations::SystemUpdateRepositoryUploadThen,
+        );
+    fn system_update_repository_view<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    where
+        F: FnOnce(
+            operations::SystemUpdateRepositoryViewWhen,
+            operations::SystemUpdateRepositoryViewThen,
         );
     fn target_release_view<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
@@ -25957,32 +26069,47 @@ impl MockServerExt for ::httpmock::MockServer {
         })
     }
 
-    fn system_update_put_repository<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    fn system_update_repository_list<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
         F: FnOnce(
-            operations::SystemUpdatePutRepositoryWhen,
-            operations::SystemUpdatePutRepositoryThen,
+            operations::SystemUpdateRepositoryListWhen,
+            operations::SystemUpdateRepositoryListThen,
         ),
     {
         self.mock(|when, then| {
             config_fn(
-                operations::SystemUpdatePutRepositoryWhen::new(when),
-                operations::SystemUpdatePutRepositoryThen::new(then),
+                operations::SystemUpdateRepositoryListWhen::new(when),
+                operations::SystemUpdateRepositoryListThen::new(then),
             )
         })
     }
 
-    fn system_update_get_repository<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    fn system_update_repository_upload<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
         F: FnOnce(
-            operations::SystemUpdateGetRepositoryWhen,
-            operations::SystemUpdateGetRepositoryThen,
+            operations::SystemUpdateRepositoryUploadWhen,
+            operations::SystemUpdateRepositoryUploadThen,
         ),
     {
         self.mock(|when, then| {
             config_fn(
-                operations::SystemUpdateGetRepositoryWhen::new(when),
-                operations::SystemUpdateGetRepositoryThen::new(then),
+                operations::SystemUpdateRepositoryUploadWhen::new(when),
+                operations::SystemUpdateRepositoryUploadThen::new(then),
+            )
+        })
+    }
+
+    fn system_update_repository_view<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    where
+        F: FnOnce(
+            operations::SystemUpdateRepositoryViewWhen,
+            operations::SystemUpdateRepositoryViewThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::SystemUpdateRepositoryViewWhen::new(when),
+                operations::SystemUpdateRepositoryViewThen::new(then),
             )
         })
     }

--- a/sdk-httpmock/src/generated_httpmock.rs
+++ b/sdk-httpmock/src/generated_httpmock.rs
@@ -18093,13 +18093,13 @@ pub mod operations {
         }
     }
 
-    pub struct TargetReleaseViewWhen(::httpmock::When);
-    impl TargetReleaseViewWhen {
+    pub struct SystemUpdateStatusWhen(::httpmock::When);
+    impl SystemUpdateStatusWhen {
         pub fn new(inner: ::httpmock::When) -> Self {
             Self(
                 inner
                     .method(::httpmock::Method::GET)
-                    .path_matches(regex::Regex::new("^/v1/system/update/target-release$").unwrap()),
+                    .path_matches(regex::Regex::new("^/v1/system/update/status$").unwrap()),
             )
         }
 
@@ -18108,8 +18108,8 @@ pub mod operations {
         }
     }
 
-    pub struct TargetReleaseViewThen(::httpmock::Then);
-    impl TargetReleaseViewThen {
+    pub struct SystemUpdateStatusThen(::httpmock::Then);
+    impl SystemUpdateStatusThen {
         pub fn new(inner: ::httpmock::Then) -> Self {
             Self(inner)
         }
@@ -18118,7 +18118,7 @@ pub mod operations {
             self.0
         }
 
-        pub fn ok(self, value: &types::TargetRelease) -> Self {
+        pub fn ok(self, value: &types::UpdateStatus) -> Self {
             Self(
                 self.0
                     .status(200u16)
@@ -18177,13 +18177,8 @@ pub mod operations {
             self.0
         }
 
-        pub fn created(self, value: &types::TargetRelease) -> Self {
-            Self(
-                self.0
-                    .status(201u16)
-                    .header("content-type", "application/json")
-                    .json_body_obj(value),
-            )
+        pub fn no_content(self) -> Self {
+            Self(self.0.status(204u16))
         }
 
         pub fn client_error(self, status: u16, value: &types::Error) -> Self {
@@ -23027,9 +23022,9 @@ pub trait MockServerExt {
             operations::SystemUpdateRepositoryViewWhen,
             operations::SystemUpdateRepositoryViewThen,
         );
-    fn target_release_view<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    fn system_update_status<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
-        F: FnOnce(operations::TargetReleaseViewWhen, operations::TargetReleaseViewThen);
+        F: FnOnce(operations::SystemUpdateStatusWhen, operations::SystemUpdateStatusThen);
     fn target_release_update<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
         F: FnOnce(operations::TargetReleaseUpdateWhen, operations::TargetReleaseUpdateThen);
@@ -26114,14 +26109,14 @@ impl MockServerExt for ::httpmock::MockServer {
         })
     }
 
-    fn target_release_view<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
+    fn system_update_status<F>(&self, config_fn: F) -> ::httpmock::Mock<'_>
     where
-        F: FnOnce(operations::TargetReleaseViewWhen, operations::TargetReleaseViewThen),
+        F: FnOnce(operations::SystemUpdateStatusWhen, operations::SystemUpdateStatusThen),
     {
         self.mock(|when, then| {
             config_fn(
-                operations::TargetReleaseViewWhen::new(when),
-                operations::TargetReleaseViewThen::new(then),
+                operations::SystemUpdateStatusWhen::new(when),
+                operations::SystemUpdateStatusThen::new(then),
             )
         })
     }

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -30021,16 +30021,12 @@ pub mod types {
     ///  ],
     ///  "properties": {
     ///    "file_name": {
-    ///      "description": "The file name of the repository\n\nThis is purely
-    /// used for debugging and may not always be correct (e.g., with wicket, we
-    /// read the file contents from stdin so we don't know the correct file
-    /// name).",
+    ///      "description": "The file name of the repository\n\nThis is intended
+    /// for debugging and may not always be correct.",
     ///      "type": "string"
     ///    },
     ///    "hash": {
-    ///      "description": "The hash of the repository.\n\nThis is a slight
-    /// abuse of `ArtifactHash`, since that's the hash of individual artifacts
-    /// within the repository. However, we use it here for convenience.",
+    ///      "description": "The hash of the repository",
     ///      "type": "string",
     ///      "format": "hex string (32 bytes)"
     ///    },
@@ -30057,15 +30053,9 @@ pub mod types {
     pub struct TufRepo {
         /// The file name of the repository
         ///
-        /// This is purely used for debugging and may not always be correct
-        /// (e.g., with wicket, we read the file contents from stdin so we don't
-        /// know the correct file name).
+        /// This is intended for debugging and may not always be correct.
         pub file_name: ::std::string::String,
-        /// The hash of the repository.
-        ///
-        /// This is a slight abuse of `ArtifactHash`, since that's the hash of
-        /// individual artifacts within the repository. However, we use it here
-        /// for convenience.
+        /// The hash of the repository
         pub hash: ::std::string::String,
         /// The system version in artifacts.json
         pub system_version: TufRepoSystemVersion,
@@ -30897,13 +30887,17 @@ pub mod types {
     ///  "type": "object",
     ///  "required": [
     ///    "components_by_release_version",
-    ///    "paused",
+    ///    "suspended",
     ///    "target_release",
-    ///    "time_last_blueprint"
+    ///    "time_last_step_planned"
     ///  ],
     ///  "properties": {
     ///    "components_by_release_version": {
-    ///      "description": "Count of components running each release version",
+    ///      "description": "Count of components running each release
+    /// version\n\nKeys will be either:\n\n* Semver-like release version strings
+    /// * \"install dataset\", representing the initial rack software before any
+    /// updates * \"unknown\", which means there is no TUF repo uploaded that
+    /// matches the software running on the component)",
     ///      "type": "object",
     ///      "additionalProperties": {
     ///        "type": "integer",
@@ -30911,11 +30905,12 @@ pub mod types {
     ///        "minimum": 0.0
     ///      }
     ///    },
-    ///    "paused": {
-    ///      "description": "Whether update activity is paused\n\nWhen true, the
-    /// system has stopped attempting to make progress toward the target
-    /// release. This happens after a MUPdate because the system wants to make
-    /// sure of the operator's intent. To resume update, set a new target
+    ///    "suspended": {
+    ///      "description": "Whether automatic update is suspended due to manual
+    /// update activity\n\nAfter a manual support procedure that changes the
+    /// system software, automatic update activity is suspended to avoid undoing
+    /// the change. To resume automatic update, first upload the TUF repository
+    /// matching the manually applied update, then set that as the target
     /// release.",
     ///      "type": "boolean"
     ///    },
@@ -30934,12 +30929,10 @@ pub mod types {
     ///        }
     ///      ]
     ///    },
-    ///    "time_last_blueprint": {
+    ///    "time_last_step_planned": {
     ///      "description": "Time of most recent update planning
     /// activity\n\nThis is intended as a rough indicator of the last time
-    /// something happened in the update planner. A blueprint is the update
-    /// system's plan for the next state of the system, so this timestamp
-    /// indicates the last time the update system made a plan.",
+    /// something happened in the update planner.",
     ///      "type": "string",
     ///      "format": "date-time"
     ///    }
@@ -30952,14 +30945,21 @@ pub mod types {
     )]
     pub struct UpdateStatus {
         /// Count of components running each release version
-        pub components_by_release_version: ::std::collections::HashMap<::std::string::String, u32>,
-        /// Whether update activity is paused
         ///
-        /// When true, the system has stopped attempting to make progress toward
-        /// the target release. This happens after a MUPdate because the system
-        /// wants to make sure of the operator's intent. To resume update, set a
-        /// new target release.
-        pub paused: bool,
+        /// Keys will be either:
+        ///
+        /// * Semver-like release version strings * "install dataset",
+        ///   representing the initial rack software before any updates *
+        ///   "unknown", which means there is no TUF repo uploaded that matches
+        ///   the software running on the component)
+        pub components_by_release_version: ::std::collections::HashMap<::std::string::String, u32>,
+        /// Whether automatic update is suspended due to manual update activity
+        ///
+        /// After a manual support procedure that changes the system software,
+        /// automatic update activity is suspended to avoid undoing the change.
+        /// To resume automatic update, first upload the TUF repository matching
+        /// the manually applied update, then set that as the target release.
+        pub suspended: bool,
         /// Current target release of the system software
         ///
         /// This may not correspond to the actual system software running at the
@@ -30974,10 +30974,8 @@ pub mod types {
         /// Time of most recent update planning activity
         ///
         /// This is intended as a rough indicator of the last time something
-        /// happened in the update planner. A blueprint is the update system's
-        /// plan for the next state of the system, so this timestamp indicates
-        /// the last time the update system made a plan.
-        pub time_last_blueprint: ::chrono::DateTime<::chrono::offset::Utc>,
+        /// happened in the update planner.
+        pub time_last_step_planned: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
     impl ::std::convert::From<&UpdateStatus> for UpdateStatus {
@@ -58389,12 +58387,12 @@ pub mod types {
                 ::std::collections::HashMap<::std::string::String, u32>,
                 ::std::string::String,
             >,
-            paused: ::std::result::Result<bool, ::std::string::String>,
+            suspended: ::std::result::Result<bool, ::std::string::String>,
             target_release: ::std::result::Result<
                 ::std::option::Option<super::TargetRelease>,
                 ::std::string::String,
             >,
-            time_last_blueprint: ::std::result::Result<
+            time_last_step_planned: ::std::result::Result<
                 ::chrono::DateTime<::chrono::offset::Utc>,
                 ::std::string::String,
             >,
@@ -58406,10 +58404,10 @@ pub mod types {
                     components_by_release_version: Err("no value supplied for \
                                                         components_by_release_version"
                         .to_string()),
-                    paused: Err("no value supplied for paused".to_string()),
+                    suspended: Err("no value supplied for suspended".to_string()),
                     target_release: Err("no value supplied for target_release".to_string()),
-                    time_last_blueprint: Err(
-                        "no value supplied for time_last_blueprint".to_string()
+                    time_last_step_planned: Err(
+                        "no value supplied for time_last_step_planned".to_string()
                     ),
                 }
             }
@@ -58429,14 +58427,14 @@ pub mod types {
                 });
                 self
             }
-            pub fn paused<T>(mut self, value: T) -> Self
+            pub fn suspended<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<bool>,
                 T::Error: ::std::fmt::Display,
             {
-                self.paused = value
+                self.suspended = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for paused: {}", e));
+                    .map_err(|e| format!("error converting supplied value for suspended: {}", e));
                 self
             }
             pub fn target_release<T>(mut self, value: T) -> Self
@@ -58449,14 +58447,14 @@ pub mod types {
                 });
                 self
             }
-            pub fn time_last_blueprint<T>(mut self, value: T) -> Self
+            pub fn time_last_step_planned<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_last_blueprint = value.try_into().map_err(|e| {
+                self.time_last_step_planned = value.try_into().map_err(|e| {
                     format!(
-                        "error converting supplied value for time_last_blueprint: {}",
+                        "error converting supplied value for time_last_step_planned: {}",
                         e
                     )
                 });
@@ -58471,9 +58469,9 @@ pub mod types {
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
                     components_by_release_version: value.components_by_release_version?,
-                    paused: value.paused?,
+                    suspended: value.suspended?,
                     target_release: value.target_release?,
-                    time_last_blueprint: value.time_last_blueprint?,
+                    time_last_step_planned: value.time_last_step_planned?,
                 })
             }
         }
@@ -58482,9 +58480,9 @@ pub mod types {
             fn from(value: super::UpdateStatus) -> Self {
                 Self {
                     components_by_release_version: Ok(value.components_by_release_version),
-                    paused: Ok(value.paused),
+                    suspended: Ok(value.suspended),
                     target_release: Ok(value.target_release),
-                    time_last_blueprint: Ok(value.time_last_blueprint),
+                    time_last_step_planned: Ok(value.time_last_step_planned),
                 }
             }
         }

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -2949,60 +2949,6 @@ pub mod types {
         }
     }
 
-    /// An identifier for an artifact.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "An identifier for an artifact.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "kind",
-    ///    "name",
-    ///    "version"
-    ///  ],
-    ///  "properties": {
-    ///    "kind": {
-    ///      "description": "The kind of artifact this is.",
-    ///      "type": "string"
-    ///    },
-    ///    "name": {
-    ///      "description": "The artifact's name.",
-    ///      "type": "string"
-    ///    },
-    ///    "version": {
-    ///      "description": "The artifact's version.",
-    ///      "type": "string"
-    ///    }
-    ///  }
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
-    )]
-    pub struct ArtifactId {
-        /// The kind of artifact this is.
-        pub kind: ::std::string::String,
-        /// The artifact's name.
-        pub name: ::std::string::String,
-        /// The artifact's version.
-        pub version: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&ArtifactId> for ArtifactId {
-        fn from(value: &ArtifactId) -> Self {
-            value.clone()
-        }
-    }
-
-    impl ArtifactId {
-        pub fn builder() -> builder::ArtifactId {
-            Default::default()
-        }
-    }
-
     /// Audit log entry
     ///
     /// <details><summary>JSON schema</summary>
@@ -17071,6 +17017,112 @@ pub mod types {
         }
     }
 
+    /// A count of bytes / rows accessed during a query.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "A count of bytes / rows accessed during a query.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "bytes",
+    ///    "rows"
+    ///  ],
+    ///  "properties": {
+    ///    "bytes": {
+    ///      "description": "The number of bytes accessed.",
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "rows": {
+    ///      "description": "The number of rows accessed.",
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct IoCount {
+        /// The number of bytes accessed.
+        pub bytes: u64,
+        /// The number of rows accessed.
+        pub rows: u64,
+    }
+
+    impl ::std::convert::From<&IoCount> for IoCount {
+        fn from(value: &IoCount) -> Self {
+            value.clone()
+        }
+    }
+
+    impl IoCount {
+        pub fn builder() -> builder::IoCount {
+            Default::default()
+        }
+    }
+
+    /// Summary of the I/O resources used by a query.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Summary of the I/O resources used by a query.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "read",
+    ///    "written"
+    ///  ],
+    ///  "properties": {
+    ///    "read": {
+    ///      "description": "The bytes and rows read by the query.",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/IoCount"
+    ///        }
+    ///      ]
+    ///    },
+    ///    "written": {
+    ///      "description": "The bytes and rows written by the query.",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/IoCount"
+    ///        }
+    ///      ]
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct IoSummary {
+        /// The bytes and rows read by the query.
+        pub read: IoCount,
+        /// The bytes and rows written by the query.
+        pub written: IoCount,
+    }
+
+    impl ::std::convert::From<&IoSummary> for IoSummary {
+        fn from(value: &IoSummary) -> Self {
+            value.clone()
+        }
+    }
+
+    impl IoSummary {
+        pub fn builder() -> builder::IoSummary {
+            Default::default()
+        }
+    }
+
     /// `IpNet`
     ///
     /// <details><summary>JSON schema</summary>
@@ -20570,6 +20622,16 @@ pub mod types {
     ///    "tables"
     ///  ],
     ///  "properties": {
+    ///    "query_summaries": {
+    ///      "description": "Summaries of queries run against ClickHouse.",
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/OxqlQuerySummary"
+    ///      }
+    ///    },
     ///    "tables": {
     ///      "description": "Tables resulting from the query, each containing
     /// timeseries.",
@@ -20586,6 +20648,9 @@ pub mod types {
         :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
     )]
     pub struct OxqlQueryResult {
+        /// Summaries of queries run against ClickHouse.
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub query_summaries: ::std::option::Option<::std::vec::Vec<OxqlQuerySummary>>,
         /// Tables resulting from the query, each containing timeseries.
         pub tables: ::std::vec::Vec<OxqlTable>,
     }
@@ -20598,6 +20663,77 @@ pub mod types {
 
     impl OxqlQueryResult {
         pub fn builder() -> builder::OxqlQueryResult {
+            Default::default()
+        }
+    }
+
+    /// Basic metadata about the resource usage of a single ClickHouse SQL
+    /// query.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Basic metadata about the resource usage of a single
+    /// ClickHouse SQL query.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "elapsed_ms",
+    ///    "id",
+    ///    "io_summary",
+    ///    "query"
+    ///  ],
+    ///  "properties": {
+    ///    "elapsed_ms": {
+    ///      "description": "The total duration of the ClickHouse query (network
+    /// plus execution).",
+    ///      "type": "integer",
+    ///      "format": "uint",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "id": {
+    ///      "description": "The database-assigned query ID.",
+    ///      "type": "string",
+    ///      "format": "uuid"
+    ///    },
+    ///    "io_summary": {
+    ///      "description": "Summary of the data read and written.",
+    ///      "allOf": [
+    ///        {
+    ///          "$ref": "#/components/schemas/IoSummary"
+    ///        }
+    ///      ]
+    ///    },
+    ///    "query": {
+    ///      "description": "The raw ClickHouse SQL query.",
+    ///      "type": "string"
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct OxqlQuerySummary {
+        /// The total duration of the ClickHouse query (network plus execution).
+        pub elapsed_ms: u32,
+        /// The database-assigned query ID.
+        pub id: ::uuid::Uuid,
+        /// Summary of the data read and written.
+        pub io_summary: IoSummary,
+        /// The raw ClickHouse SQL query.
+        pub query: ::std::string::String,
+    }
+
+    impl ::std::convert::From<&OxqlQuerySummary> for OxqlQuerySummary {
+        fn from(value: &OxqlQuerySummary) -> Self {
+            value.clone()
+        }
+    }
+
+    impl OxqlQuerySummary {
+        pub fn builder() -> builder::OxqlQuerySummary {
             Default::default()
         }
     }
@@ -29100,7 +29236,7 @@ pub mod types {
         }
     }
 
-    /// `SystemUpdateGetRepositorySystemVersion`
+    /// `SystemUpdateRepositoryViewSystemVersion`
     ///
     /// <details><summary>JSON schema</summary>
     ///
@@ -29126,29 +29262,29 @@ pub mod types {
         schemars :: JsonSchema,
     )]
     #[serde(transparent)]
-    pub struct SystemUpdateGetRepositorySystemVersion(::std::string::String);
-    impl ::std::ops::Deref for SystemUpdateGetRepositorySystemVersion {
+    pub struct SystemUpdateRepositoryViewSystemVersion(::std::string::String);
+    impl ::std::ops::Deref for SystemUpdateRepositoryViewSystemVersion {
         type Target = ::std::string::String;
         fn deref(&self) -> &::std::string::String {
             &self.0
         }
     }
 
-    impl ::std::convert::From<SystemUpdateGetRepositorySystemVersion> for ::std::string::String {
-        fn from(value: SystemUpdateGetRepositorySystemVersion) -> Self {
+    impl ::std::convert::From<SystemUpdateRepositoryViewSystemVersion> for ::std::string::String {
+        fn from(value: SystemUpdateRepositoryViewSystemVersion) -> Self {
             value.0
         }
     }
 
-    impl ::std::convert::From<&SystemUpdateGetRepositorySystemVersion>
-        for SystemUpdateGetRepositorySystemVersion
+    impl ::std::convert::From<&SystemUpdateRepositoryViewSystemVersion>
+        for SystemUpdateRepositoryViewSystemVersion
     {
-        fn from(value: &SystemUpdateGetRepositorySystemVersion) -> Self {
+        fn from(value: &SystemUpdateRepositoryViewSystemVersion) -> Self {
             value.clone()
         }
     }
 
-    impl ::std::str::FromStr for SystemUpdateGetRepositorySystemVersion {
+    impl ::std::str::FromStr for SystemUpdateRepositoryViewSystemVersion {
         type Err = self::error::ConversionError;
         fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
             static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
@@ -29172,14 +29308,14 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::TryFrom<&str> for SystemUpdateGetRepositorySystemVersion {
+    impl ::std::convert::TryFrom<&str> for SystemUpdateRepositoryViewSystemVersion {
         type Error = self::error::ConversionError;
         fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
             value.parse()
         }
     }
 
-    impl ::std::convert::TryFrom<&::std::string::String> for SystemUpdateGetRepositorySystemVersion {
+    impl ::std::convert::TryFrom<&::std::string::String> for SystemUpdateRepositoryViewSystemVersion {
         type Error = self::error::ConversionError;
         fn try_from(
             value: &::std::string::String,
@@ -29188,7 +29324,7 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::TryFrom<::std::string::String> for SystemUpdateGetRepositorySystemVersion {
+    impl ::std::convert::TryFrom<::std::string::String> for SystemUpdateRepositoryViewSystemVersion {
         type Error = self::error::ConversionError;
         fn try_from(
             value: ::std::string::String,
@@ -29197,7 +29333,7 @@ pub mod types {
         }
     }
 
-    impl<'de> ::serde::Deserialize<'de> for SystemUpdateGetRepositorySystemVersion {
+    impl<'de> ::serde::Deserialize<'de> for SystemUpdateRepositoryViewSystemVersion {
         fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where
             D: ::serde::Deserializer<'de>,
@@ -29773,6 +29909,12 @@ pub mod types {
     ///    "query"
     ///  ],
     ///  "properties": {
+    ///    "include_summaries": {
+    ///      "description": "Whether to include ClickHouse query summaries in
+    /// the response.",
+    ///      "default": false,
+    ///      "type": "boolean"
+    ///    },
     ///    "query": {
     ///      "description": "A timeseries query string, written in the Oximeter
     /// query language.",
@@ -29786,6 +29928,9 @@ pub mod types {
         :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
     )]
     pub struct TimeseriesQuery {
+        /// Whether to include ClickHouse query summaries in the response.
+        #[serde(default)]
+        pub include_summaries: bool,
         /// A timeseries query string, written in the Oximeter query language.
         pub query: ::std::string::String,
     }
@@ -29941,386 +30086,24 @@ pub mod types {
         }
     }
 
-    /// Metadata about an individual TUF artifact.
-    ///
-    /// Found within a `TufRepoDescription`.
+    /// Metadata about a TUF repository
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     /// {
-    ///  "description": "Metadata about an individual TUF artifact.\n\nFound
-    /// within a `TufRepoDescription`.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "hash",
-    ///    "id",
-    ///    "size"
-    ///  ],
-    ///  "properties": {
-    ///    "board": {
-    ///      "description": "Contents of the `BORD` field of a Hubris archive caboose. Only applicable to artifacts that are Hubris archives.\n\nThis field should always be `Some(_)` if `sign` is `Some(_)`, but the opposite is not true (SP images will have a `board` but not a `sign`).",
-    ///      "type": [
-    ///        "string",
-    ///        "null"
-    ///      ]
-    ///    },
-    ///    "hash": {
-    ///      "description": "The hash of the artifact.",
-    ///      "type": "string",
-    ///      "format": "hex string (32 bytes)"
-    ///    },
-    ///    "id": {
-    ///      "description": "The artifact ID.",
-    ///      "allOf": [
-    ///        {
-    ///          "$ref": "#/components/schemas/ArtifactId"
-    ///        }
-    ///      ]
-    ///    },
-    ///    "sign": {
-    ///      "description": "Contents of the `SIGN` field of a Hubris archive
-    /// caboose, i.e., an identifier for the set of valid signing keys.
-    /// Currently only applicable to RoT image and bootloader artifacts, where
-    /// it will be an LPC55 Root Key Table Hash (RKTH).",
-    ///      "type": [
-    ///        "array",
-    ///        "null"
-    ///      ],
-    ///      "items": {
-    ///        "type": "integer",
-    ///        "format": "uint8",
-    ///        "minimum": 0.0
-    ///      }
-    ///    },
-    ///    "size": {
-    ///      "description": "The size of the artifact in bytes.",
-    ///      "type": "integer",
-    ///      "format": "uint64",
-    ///      "minimum": 0.0
-    ///    }
-    ///  }
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
-    )]
-    pub struct TufArtifactMeta {
-        /// Contents of the `BORD` field of a Hubris archive caboose. Only
-        /// applicable to artifacts that are Hubris archives.
-        ///
-        /// This field should always be `Some(_)` if `sign` is `Some(_)`, but
-        /// the opposite is not true (SP images will have a `board` but not a
-        /// `sign`).
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        pub board: ::std::option::Option<::std::string::String>,
-        /// The hash of the artifact.
-        pub hash: ::std::string::String,
-        /// The artifact ID.
-        pub id: ArtifactId,
-        /// Contents of the `SIGN` field of a Hubris archive caboose, i.e., an
-        /// identifier for the set of valid signing keys. Currently only
-        /// applicable to RoT image and bootloader artifacts, where it will be
-        /// an LPC55 Root Key Table Hash (RKTH).
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        pub sign: ::std::option::Option<::std::vec::Vec<u8>>,
-        /// The size of the artifact in bytes.
-        pub size: u64,
-    }
-
-    impl ::std::convert::From<&TufArtifactMeta> for TufArtifactMeta {
-        fn from(value: &TufArtifactMeta) -> Self {
-            value.clone()
-        }
-    }
-
-    impl TufArtifactMeta {
-        pub fn builder() -> builder::TufArtifactMeta {
-            Default::default()
-        }
-    }
-
-    /// A description of an uploaded TUF repository.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "A description of an uploaded TUF repository.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "artifacts",
-    ///    "repo"
-    ///  ],
-    ///  "properties": {
-    ///    "artifacts": {
-    ///      "description": "Information about the artifacts present in the
-    /// repository.",
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/TufArtifactMeta"
-    ///      }
-    ///    },
-    ///    "repo": {
-    ///      "description": "Information about the repository.",
-    ///      "allOf": [
-    ///        {
-    ///          "$ref": "#/components/schemas/TufRepoMeta"
-    ///        }
-    ///      ]
-    ///    }
-    ///  }
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
-    )]
-    pub struct TufRepoDescription {
-        /// Information about the artifacts present in the repository.
-        pub artifacts: ::std::vec::Vec<TufArtifactMeta>,
-        /// Information about the repository.
-        pub repo: TufRepoMeta,
-    }
-
-    impl ::std::convert::From<&TufRepoDescription> for TufRepoDescription {
-        fn from(value: &TufRepoDescription) -> Self {
-            value.clone()
-        }
-    }
-
-    impl TufRepoDescription {
-        pub fn builder() -> builder::TufRepoDescription {
-            Default::default()
-        }
-    }
-
-    /// Data about a successful TUF repo get from Nexus.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "Data about a successful TUF repo get from Nexus.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "description"
-    ///  ],
-    ///  "properties": {
-    ///    "description": {
-    ///      "description": "The description of the repository.",
-    ///      "allOf": [
-    ///        {
-    ///          "$ref": "#/components/schemas/TufRepoDescription"
-    ///        }
-    ///      ]
-    ///    }
-    ///  }
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
-    )]
-    pub struct TufRepoGetResponse {
-        /// The description of the repository.
-        pub description: TufRepoDescription,
-    }
-
-    impl ::std::convert::From<&TufRepoGetResponse> for TufRepoGetResponse {
-        fn from(value: &TufRepoGetResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl TufRepoGetResponse {
-        pub fn builder() -> builder::TufRepoGetResponse {
-            Default::default()
-        }
-    }
-
-    /// Data about a successful TUF repo import into Nexus.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "Data about a successful TUF repo import into Nexus.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "recorded",
-    ///    "status"
-    ///  ],
-    ///  "properties": {
-    ///    "recorded": {
-    ///      "description": "The repository as present in the database.",
-    ///      "allOf": [
-    ///        {
-    ///          "$ref": "#/components/schemas/TufRepoDescription"
-    ///        }
-    ///      ]
-    ///    },
-    ///    "status": {
-    ///      "description": "Whether this repository already existed or is
-    /// new.",
-    ///      "allOf": [
-    ///        {
-    ///          "$ref": "#/components/schemas/TufRepoInsertStatus"
-    ///        }
-    ///      ]
-    ///    }
-    ///  }
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
-    )]
-    pub struct TufRepoInsertResponse {
-        /// The repository as present in the database.
-        pub recorded: TufRepoDescription,
-        /// Whether this repository already existed or is new.
-        pub status: TufRepoInsertStatus,
-    }
-
-    impl ::std::convert::From<&TufRepoInsertResponse> for TufRepoInsertResponse {
-        fn from(value: &TufRepoInsertResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl TufRepoInsertResponse {
-        pub fn builder() -> builder::TufRepoInsertResponse {
-            Default::default()
-        }
-    }
-
-    /// Status of a TUF repo import.
-    ///
-    /// Part of `TufRepoInsertResponse`.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "Status of a TUF repo import.\n\nPart of
-    /// `TufRepoInsertResponse`.",
-    ///  "oneOf": [
-    ///    {
-    ///      "description": "The repository already existed in the database.",
-    ///      "type": "string",
-    ///      "enum": [
-    ///        "already_exists"
-    ///      ]
-    ///    },
-    ///    {
-    ///      "description": "The repository did not exist, and was inserted into
-    /// the database.",
-    ///      "type": "string",
-    ///      "enum": [
-    ///        "inserted"
-    ///      ]
-    ///    }
-    ///  ]
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize,
-        :: serde :: Serialize,
-        Clone,
-        Copy,
-        Debug,
-        Eq,
-        Hash,
-        Ord,
-        PartialEq,
-        PartialOrd,
-        schemars :: JsonSchema,
-    )]
-    pub enum TufRepoInsertStatus {
-        /// The repository already existed in the database.
-        #[serde(rename = "already_exists")]
-        AlreadyExists,
-        /// The repository did not exist, and was inserted into the database.
-        #[serde(rename = "inserted")]
-        Inserted,
-    }
-
-    impl ::std::convert::From<&Self> for TufRepoInsertStatus {
-        fn from(value: &TufRepoInsertStatus) -> Self {
-            value.clone()
-        }
-    }
-
-    impl ::std::fmt::Display for TufRepoInsertStatus {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-            match *self {
-                Self::AlreadyExists => f.write_str("already_exists"),
-                Self::Inserted => f.write_str("inserted"),
-            }
-        }
-    }
-
-    impl ::std::str::FromStr for TufRepoInsertStatus {
-        type Err = self::error::ConversionError;
-        fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-            match value {
-                "already_exists" => Ok(Self::AlreadyExists),
-                "inserted" => Ok(Self::Inserted),
-                _ => Err("invalid value".into()),
-            }
-        }
-    }
-
-    impl ::std::convert::TryFrom<&str> for TufRepoInsertStatus {
-        type Error = self::error::ConversionError;
-        fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-
-    impl ::std::convert::TryFrom<&::std::string::String> for TufRepoInsertStatus {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-
-    impl ::std::convert::TryFrom<::std::string::String> for TufRepoInsertStatus {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: ::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-
-    /// Metadata about a TUF repository.
-    ///
-    /// Found within a `TufRepoDescription`.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
-    ///  "description": "Metadata about a TUF repository.\n\nFound within a
-    /// `TufRepoDescription`.",
+    ///  "description": "Metadata about a TUF repository",
     ///  "type": "object",
     ///  "required": [
     ///    "file_name",
     ///    "hash",
     ///    "system_version",
-    ///    "targets_role_version",
-    ///    "valid_until"
+    ///    "time_created"
     ///  ],
     ///  "properties": {
     ///    "file_name": {
-    ///      "description": "The file name of the repository.\n\nThis is purely
-    /// used for debugging and may not always be correct (e.g. with wicket, we
+    ///      "description": "The file name of the repository\n\nThis is purely
+    /// used for debugging and may not always be correct (e.g., with wicket, we
     /// read the file contents from stdin so we don't know the correct file
     /// name).",
     ///      "type": "string"
@@ -30333,21 +30116,15 @@ pub mod types {
     ///      "format": "hex string (32 bytes)"
     ///    },
     ///    "system_version": {
-    ///      "description": "The system version in artifacts.json.",
+    ///      "description": "The system version in artifacts.json",
     ///      "type": "string",
     ///      "pattern":
     /// "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*
     /// [a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*
     /// ))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     ///    },
-    ///    "targets_role_version": {
-    ///      "description": "The version of the targets role.",
-    ///      "type": "integer",
-    ///      "format": "uint64",
-    ///      "minimum": 0.0
-    ///    },
-    ///    "valid_until": {
-    ///      "description": "The time until which the repo is valid.",
+    ///    "time_created": {
+    ///      "description": "Time the repository was uploaded",
     ///      "type": "string",
     ///      "format": "date-time"
     ///    }
@@ -30358,11 +30135,11 @@ pub mod types {
     #[derive(
         :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
     )]
-    pub struct TufRepoMeta {
-        /// The file name of the repository.
+    pub struct TufRepo {
+        /// The file name of the repository
         ///
         /// This is purely used for debugging and may not always be correct
-        /// (e.g. with wicket, we read the file contents from stdin so we don't
+        /// (e.g., with wicket, we read the file contents from stdin so we don't
         /// know the correct file name).
         pub file_name: ::std::string::String,
         /// The hash of the repository.
@@ -30371,33 +30148,85 @@ pub mod types {
         /// individual artifacts within the repository. However, we use it here
         /// for convenience.
         pub hash: ::std::string::String,
-        /// The system version in artifacts.json.
-        pub system_version: TufRepoMetaSystemVersion,
-        /// The version of the targets role.
-        pub targets_role_version: u64,
-        /// The time until which the repo is valid.
-        pub valid_until: ::chrono::DateTime<::chrono::offset::Utc>,
+        /// The system version in artifacts.json
+        pub system_version: TufRepoSystemVersion,
+        /// Time the repository was uploaded
+        pub time_created: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&TufRepoMeta> for TufRepoMeta {
-        fn from(value: &TufRepoMeta) -> Self {
+    impl ::std::convert::From<&TufRepo> for TufRepo {
+        fn from(value: &TufRepo) -> Self {
             value.clone()
         }
     }
 
-    impl TufRepoMeta {
-        pub fn builder() -> builder::TufRepoMeta {
+    impl TufRepo {
+        pub fn builder() -> builder::TufRepo {
             Default::default()
         }
     }
 
-    /// The system version in artifacts.json.
+    /// A single page of results
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     /// {
-    ///  "description": "The system version in artifacts.json.",
+    ///  "description": "A single page of results",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "items"
+    ///  ],
+    ///  "properties": {
+    ///    "items": {
+    ///      "description": "list of items on this page of results",
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/TufRepo"
+    ///      }
+    ///    },
+    ///    "next_page": {
+    ///      "description": "token used to fetch the next page of results (if
+    /// any)",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct TufRepoResultsPage {
+        /// list of items on this page of results
+        pub items: ::std::vec::Vec<TufRepo>,
+        /// token used to fetch the next page of results (if any)
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub next_page: ::std::option::Option<::std::string::String>,
+    }
+
+    impl ::std::convert::From<&TufRepoResultsPage> for TufRepoResultsPage {
+        fn from(value: &TufRepoResultsPage) -> Self {
+            value.clone()
+        }
+    }
+
+    impl TufRepoResultsPage {
+        pub fn builder() -> builder::TufRepoResultsPage {
+            Default::default()
+        }
+    }
+
+    /// The system version in artifacts.json
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "The system version in artifacts.json",
     ///  "type": "string",
     ///  "pattern":
     /// "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*
@@ -30418,27 +30247,27 @@ pub mod types {
         schemars :: JsonSchema,
     )]
     #[serde(transparent)]
-    pub struct TufRepoMetaSystemVersion(::std::string::String);
-    impl ::std::ops::Deref for TufRepoMetaSystemVersion {
+    pub struct TufRepoSystemVersion(::std::string::String);
+    impl ::std::ops::Deref for TufRepoSystemVersion {
         type Target = ::std::string::String;
         fn deref(&self) -> &::std::string::String {
             &self.0
         }
     }
 
-    impl ::std::convert::From<TufRepoMetaSystemVersion> for ::std::string::String {
-        fn from(value: TufRepoMetaSystemVersion) -> Self {
+    impl ::std::convert::From<TufRepoSystemVersion> for ::std::string::String {
+        fn from(value: TufRepoSystemVersion) -> Self {
             value.0
         }
     }
 
-    impl ::std::convert::From<&TufRepoMetaSystemVersion> for TufRepoMetaSystemVersion {
-        fn from(value: &TufRepoMetaSystemVersion) -> Self {
+    impl ::std::convert::From<&TufRepoSystemVersion> for TufRepoSystemVersion {
+        fn from(value: &TufRepoSystemVersion) -> Self {
             value.clone()
         }
     }
 
-    impl ::std::str::FromStr for TufRepoMetaSystemVersion {
+    impl ::std::str::FromStr for TufRepoSystemVersion {
         type Err = self::error::ConversionError;
         fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
             static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
@@ -30462,14 +30291,14 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::TryFrom<&str> for TufRepoMetaSystemVersion {
+    impl ::std::convert::TryFrom<&str> for TufRepoSystemVersion {
         type Error = self::error::ConversionError;
         fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
             value.parse()
         }
     }
 
-    impl ::std::convert::TryFrom<&::std::string::String> for TufRepoMetaSystemVersion {
+    impl ::std::convert::TryFrom<&::std::string::String> for TufRepoSystemVersion {
         type Error = self::error::ConversionError;
         fn try_from(
             value: &::std::string::String,
@@ -30478,7 +30307,7 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::TryFrom<::std::string::String> for TufRepoMetaSystemVersion {
+    impl ::std::convert::TryFrom<::std::string::String> for TufRepoSystemVersion {
         type Error = self::error::ConversionError;
         fn try_from(
             value: ::std::string::String,
@@ -30487,7 +30316,7 @@ pub mod types {
         }
     }
 
-    impl<'de> ::serde::Deserialize<'de> for TufRepoMetaSystemVersion {
+    impl<'de> ::serde::Deserialize<'de> for TufRepoSystemVersion {
         fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where
             D: ::serde::Deserializer<'de>,
@@ -30497,6 +30326,150 @@ pub mod types {
                 .map_err(|e: self::error::ConversionError| {
                     <D::Error as ::serde::de::Error>::custom(e.to_string())
                 })
+        }
+    }
+
+    /// `TufRepoUpload`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "type": "object",
+    ///  "required": [
+    ///    "repo",
+    ///    "status"
+    ///  ],
+    ///  "properties": {
+    ///    "repo": {
+    ///      "$ref": "#/components/schemas/TufRepo"
+    ///    },
+    ///    "status": {
+    ///      "$ref": "#/components/schemas/TufRepoUploadStatus"
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct TufRepoUpload {
+        pub repo: TufRepo,
+        pub status: TufRepoUploadStatus,
+    }
+
+    impl ::std::convert::From<&TufRepoUpload> for TufRepoUpload {
+        fn from(value: &TufRepoUpload) -> Self {
+            value.clone()
+        }
+    }
+
+    impl TufRepoUpload {
+        pub fn builder() -> builder::TufRepoUpload {
+            Default::default()
+        }
+    }
+
+    /// Whether the uploaded TUF repo already existed or was new and had to be
+    /// inserted. Part of `TufRepoUpload`.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Whether the uploaded TUF repo already existed or was
+    /// new and had to be inserted. Part of `TufRepoUpload`.",
+    ///  "oneOf": [
+    ///    {
+    ///      "description": "The repository already existed in the database",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "already_exists"
+    ///      ]
+    ///    },
+    ///    {
+    ///      "description": "The repository did not exist, and was inserted into
+    /// the database",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "inserted"
+    ///      ]
+    ///    }
+    ///  ]
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize,
+        :: serde :: Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        schemars :: JsonSchema,
+    )]
+    pub enum TufRepoUploadStatus {
+        /// The repository already existed in the database
+        #[serde(rename = "already_exists")]
+        AlreadyExists,
+        /// The repository did not exist, and was inserted into the database
+        #[serde(rename = "inserted")]
+        Inserted,
+    }
+
+    impl ::std::convert::From<&Self> for TufRepoUploadStatus {
+        fn from(value: &TufRepoUploadStatus) -> Self {
+            value.clone()
+        }
+    }
+
+    impl ::std::fmt::Display for TufRepoUploadStatus {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::AlreadyExists => f.write_str("already_exists"),
+                Self::Inserted => f.write_str("inserted"),
+            }
+        }
+    }
+
+    impl ::std::str::FromStr for TufRepoUploadStatus {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "already_exists" => Ok(Self::AlreadyExists),
+                "inserted" => Ok(Self::Inserted),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+
+    impl ::std::convert::TryFrom<&str> for TufRepoUploadStatus {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl ::std::convert::TryFrom<&::std::string::String> for TufRepoUploadStatus {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl ::std::convert::TryFrom<::std::string::String> for TufRepoUploadStatus {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
         }
     }
 
@@ -31998,6 +31971,108 @@ pub mod types {
     impl Values {
         pub fn builder() -> builder::Values {
             Default::default()
+        }
+    }
+
+    /// Supported sort modes when scanning by semantic version
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "description": "Supported sort modes when scanning by semantic
+    /// version",
+    ///  "oneOf": [
+    ///    {
+    ///      "description": "Sort in increasing semantic version order (oldest
+    /// first)",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "version_ascending"
+    ///      ]
+    ///    },
+    ///    {
+    ///      "description": "Sort in decreasing semantic version order (newest
+    /// first)",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "version_descending"
+    ///      ]
+    ///    }
+    ///  ]
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize,
+        :: serde :: Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        schemars :: JsonSchema,
+    )]
+    pub enum VersionSortMode {
+        /// Sort in increasing semantic version order (oldest first)
+        #[serde(rename = "version_ascending")]
+        VersionAscending,
+        /// Sort in decreasing semantic version order (newest first)
+        #[serde(rename = "version_descending")]
+        VersionDescending,
+    }
+
+    impl ::std::convert::From<&Self> for VersionSortMode {
+        fn from(value: &VersionSortMode) -> Self {
+            value.clone()
+        }
+    }
+
+    impl ::std::fmt::Display for VersionSortMode {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::VersionAscending => f.write_str("version_ascending"),
+                Self::VersionDescending => f.write_str("version_descending"),
+            }
+        }
+    }
+
+    impl ::std::str::FromStr for VersionSortMode {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "version_ascending" => Ok(Self::VersionAscending),
+                "version_descending" => Ok(Self::VersionDescending),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+
+    impl ::std::convert::TryFrom<&str> for VersionSortMode {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl ::std::convert::TryFrom<&::std::string::String> for VersionSortMode {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+
+    impl ::std::convert::TryFrom<::std::string::String> for VersionSortMode {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
         }
     }
 
@@ -37514,79 +37589,6 @@ pub mod types {
                 Self {
                     description: Ok(value.description),
                     name: Ok(value.name),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct ArtifactId {
-            kind: ::std::result::Result<::std::string::String, ::std::string::String>,
-            name: ::std::result::Result<::std::string::String, ::std::string::String>,
-            version: ::std::result::Result<::std::string::String, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for ArtifactId {
-            fn default() -> Self {
-                Self {
-                    kind: Err("no value supplied for kind".to_string()),
-                    name: Err("no value supplied for name".to_string()),
-                    version: Err("no value supplied for version".to_string()),
-                }
-            }
-        }
-
-        impl ArtifactId {
-            pub fn kind<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::string::String>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.kind = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
-                self
-            }
-            pub fn name<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::string::String>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.name = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
-                self
-            }
-            pub fn version<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::string::String>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.version = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for version: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<ArtifactId> for super::ArtifactId {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: ArtifactId,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    kind: value.kind?,
-                    name: value.name?,
-                    version: value.version?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::ArtifactId> for ArtifactId {
-            fn from(value: super::ArtifactId) -> Self {
-                Self {
-                    kind: Ok(value.kind),
-                    name: Ok(value.name),
-                    version: Ok(value.version),
                 }
             }
         }
@@ -47490,6 +47492,124 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
+        pub struct IoCount {
+            bytes: ::std::result::Result<u64, ::std::string::String>,
+            rows: ::std::result::Result<u64, ::std::string::String>,
+        }
+
+        impl ::std::default::Default for IoCount {
+            fn default() -> Self {
+                Self {
+                    bytes: Err("no value supplied for bytes".to_string()),
+                    rows: Err("no value supplied for rows".to_string()),
+                }
+            }
+        }
+
+        impl IoCount {
+            pub fn bytes<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.bytes = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for bytes: {}", e));
+                self
+            }
+            pub fn rows<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.rows = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for rows: {}", e));
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<IoCount> for super::IoCount {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: IoCount,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    bytes: value.bytes?,
+                    rows: value.rows?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::IoCount> for IoCount {
+            fn from(value: super::IoCount) -> Self {
+                Self {
+                    bytes: Ok(value.bytes),
+                    rows: Ok(value.rows),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct IoSummary {
+            read: ::std::result::Result<super::IoCount, ::std::string::String>,
+            written: ::std::result::Result<super::IoCount, ::std::string::String>,
+        }
+
+        impl ::std::default::Default for IoSummary {
+            fn default() -> Self {
+                Self {
+                    read: Err("no value supplied for read".to_string()),
+                    written: Err("no value supplied for written".to_string()),
+                }
+            }
+        }
+
+        impl IoSummary {
+            pub fn read<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::IoCount>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.read = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for read: {}", e));
+                self
+            }
+            pub fn written<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::IoCount>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.written = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for written: {}", e));
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<IoSummary> for super::IoSummary {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: IoSummary,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    read: value.read?,
+                    written: value.written?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::IoSummary> for IoSummary {
+            fn from(value: super::IoSummary) -> Self {
+                Self {
+                    read: Ok(value.read),
+                    written: Ok(value.written),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
         pub struct IpPool {
             description: ::std::result::Result<::std::string::String, ::std::string::String>,
             id: ::std::result::Result<::uuid::Uuid, ::std::string::String>,
@@ -49801,18 +49921,35 @@ pub mod types {
 
         #[derive(Clone, Debug)]
         pub struct OxqlQueryResult {
+            query_summaries: ::std::result::Result<
+                ::std::option::Option<::std::vec::Vec<super::OxqlQuerySummary>>,
+                ::std::string::String,
+            >,
             tables: ::std::result::Result<::std::vec::Vec<super::OxqlTable>, ::std::string::String>,
         }
 
         impl ::std::default::Default for OxqlQueryResult {
             fn default() -> Self {
                 Self {
+                    query_summaries: Ok(Default::default()),
                     tables: Err("no value supplied for tables".to_string()),
                 }
             }
         }
 
         impl OxqlQueryResult {
+            pub fn query_summaries<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<::std::vec::Vec<super::OxqlQuerySummary>>,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.query_summaries = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for query_summaries: {}", e)
+                });
+                self
+            }
             pub fn tables<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::vec::Vec<super::OxqlTable>>,
@@ -49831,6 +49968,7 @@ pub mod types {
                 value: OxqlQueryResult,
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
+                    query_summaries: value.query_summaries?,
                     tables: value.tables?,
                 })
             }
@@ -49839,7 +49977,95 @@ pub mod types {
         impl ::std::convert::From<super::OxqlQueryResult> for OxqlQueryResult {
             fn from(value: super::OxqlQueryResult) -> Self {
                 Self {
+                    query_summaries: Ok(value.query_summaries),
                     tables: Ok(value.tables),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct OxqlQuerySummary {
+            elapsed_ms: ::std::result::Result<u32, ::std::string::String>,
+            id: ::std::result::Result<::uuid::Uuid, ::std::string::String>,
+            io_summary: ::std::result::Result<super::IoSummary, ::std::string::String>,
+            query: ::std::result::Result<::std::string::String, ::std::string::String>,
+        }
+
+        impl ::std::default::Default for OxqlQuerySummary {
+            fn default() -> Self {
+                Self {
+                    elapsed_ms: Err("no value supplied for elapsed_ms".to_string()),
+                    id: Err("no value supplied for id".to_string()),
+                    io_summary: Err("no value supplied for io_summary".to_string()),
+                    query: Err("no value supplied for query".to_string()),
+                }
+            }
+        }
+
+        impl OxqlQuerySummary {
+            pub fn elapsed_ms<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u32>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.elapsed_ms = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for elapsed_ms: {}", e));
+                self
+            }
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::uuid::Uuid>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                self
+            }
+            pub fn io_summary<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::IoSummary>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.io_summary = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for io_summary: {}", e));
+                self
+            }
+            pub fn query<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.query = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for query: {}", e));
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<OxqlQuerySummary> for super::OxqlQuerySummary {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: OxqlQuerySummary,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    elapsed_ms: value.elapsed_ms?,
+                    id: value.id?,
+                    io_summary: value.io_summary?,
+                    query: value.query?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::OxqlQuerySummary> for OxqlQuerySummary {
+            fn from(value: super::OxqlQuerySummary) -> Self {
+                Self {
+                    elapsed_ms: Ok(value.elapsed_ms),
+                    id: Ok(value.id),
+                    io_summary: Ok(value.io_summary),
+                    query: Ok(value.query),
                 }
             }
         }
@@ -57267,18 +57493,33 @@ pub mod types {
 
         #[derive(Clone, Debug)]
         pub struct TimeseriesQuery {
+            include_summaries: ::std::result::Result<bool, ::std::string::String>,
             query: ::std::result::Result<::std::string::String, ::std::string::String>,
         }
 
         impl ::std::default::Default for TimeseriesQuery {
             fn default() -> Self {
                 Self {
+                    include_summaries: Ok(Default::default()),
                     query: Err("no value supplied for query".to_string()),
                 }
             }
         }
 
         impl TimeseriesQuery {
+            pub fn include_summaries<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<bool>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.include_summaries = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for include_summaries: {}",
+                        e
+                    )
+                });
+                self
+            }
             pub fn query<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::string::String>,
@@ -57297,6 +57538,7 @@ pub mod types {
                 value: TimeseriesQuery,
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
+                    include_summaries: value.include_summaries?,
                     query: value.query?,
                 })
             }
@@ -57305,6 +57547,7 @@ pub mod types {
         impl ::std::convert::From<super::TimeseriesQuery> for TimeseriesQuery {
             fn from(value: super::TimeseriesQuery) -> Self {
                 Self {
+                    include_summaries: Ok(value.include_summaries),
                     query: Ok(value.query),
                 }
             }
@@ -57522,306 +57765,29 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
-        pub struct TufArtifactMeta {
-            board: ::std::result::Result<
-                ::std::option::Option<::std::string::String>,
-                ::std::string::String,
-            >,
-            hash: ::std::result::Result<::std::string::String, ::std::string::String>,
-            id: ::std::result::Result<super::ArtifactId, ::std::string::String>,
-            sign: ::std::result::Result<
-                ::std::option::Option<::std::vec::Vec<u8>>,
-                ::std::string::String,
-            >,
-            size: ::std::result::Result<u64, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for TufArtifactMeta {
-            fn default() -> Self {
-                Self {
-                    board: Ok(Default::default()),
-                    hash: Err("no value supplied for hash".to_string()),
-                    id: Err("no value supplied for id".to_string()),
-                    sign: Ok(Default::default()),
-                    size: Err("no value supplied for size".to_string()),
-                }
-            }
-        }
-
-        impl TufArtifactMeta {
-            pub fn board<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.board = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for board: {}", e));
-                self
-            }
-            pub fn hash<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::string::String>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.hash = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for hash: {}", e));
-                self
-            }
-            pub fn id<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<super::ArtifactId>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.id = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
-                self
-            }
-            pub fn sign<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::option::Option<::std::vec::Vec<u8>>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.sign = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for sign: {}", e));
-                self
-            }
-            pub fn size<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<u64>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.size = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for size: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<TufArtifactMeta> for super::TufArtifactMeta {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: TufArtifactMeta,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    board: value.board?,
-                    hash: value.hash?,
-                    id: value.id?,
-                    sign: value.sign?,
-                    size: value.size?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::TufArtifactMeta> for TufArtifactMeta {
-            fn from(value: super::TufArtifactMeta) -> Self {
-                Self {
-                    board: Ok(value.board),
-                    hash: Ok(value.hash),
-                    id: Ok(value.id),
-                    sign: Ok(value.sign),
-                    size: Ok(value.size),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct TufRepoDescription {
-            artifacts: ::std::result::Result<
-                ::std::vec::Vec<super::TufArtifactMeta>,
-                ::std::string::String,
-            >,
-            repo: ::std::result::Result<super::TufRepoMeta, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for TufRepoDescription {
-            fn default() -> Self {
-                Self {
-                    artifacts: Err("no value supplied for artifacts".to_string()),
-                    repo: Err("no value supplied for repo".to_string()),
-                }
-            }
-        }
-
-        impl TufRepoDescription {
-            pub fn artifacts<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::TufArtifactMeta>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.artifacts = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for artifacts: {}", e));
-                self
-            }
-            pub fn repo<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<super::TufRepoMeta>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.repo = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for repo: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<TufRepoDescription> for super::TufRepoDescription {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: TufRepoDescription,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    artifacts: value.artifacts?,
-                    repo: value.repo?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::TufRepoDescription> for TufRepoDescription {
-            fn from(value: super::TufRepoDescription) -> Self {
-                Self {
-                    artifacts: Ok(value.artifacts),
-                    repo: Ok(value.repo),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct TufRepoGetResponse {
-            description: ::std::result::Result<super::TufRepoDescription, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for TufRepoGetResponse {
-            fn default() -> Self {
-                Self {
-                    description: Err("no value supplied for description".to_string()),
-                }
-            }
-        }
-
-        impl TufRepoGetResponse {
-            pub fn description<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<super::TufRepoDescription>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.description = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<TufRepoGetResponse> for super::TufRepoGetResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: TufRepoGetResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    description: value.description?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::TufRepoGetResponse> for TufRepoGetResponse {
-            fn from(value: super::TufRepoGetResponse) -> Self {
-                Self {
-                    description: Ok(value.description),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct TufRepoInsertResponse {
-            recorded: ::std::result::Result<super::TufRepoDescription, ::std::string::String>,
-            status: ::std::result::Result<super::TufRepoInsertStatus, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for TufRepoInsertResponse {
-            fn default() -> Self {
-                Self {
-                    recorded: Err("no value supplied for recorded".to_string()),
-                    status: Err("no value supplied for status".to_string()),
-                }
-            }
-        }
-
-        impl TufRepoInsertResponse {
-            pub fn recorded<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<super::TufRepoDescription>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.recorded = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for recorded: {}", e));
-                self
-            }
-            pub fn status<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<super::TufRepoInsertStatus>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.status = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for status: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<TufRepoInsertResponse> for super::TufRepoInsertResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: TufRepoInsertResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    recorded: value.recorded?,
-                    status: value.status?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::TufRepoInsertResponse> for TufRepoInsertResponse {
-            fn from(value: super::TufRepoInsertResponse) -> Self {
-                Self {
-                    recorded: Ok(value.recorded),
-                    status: Ok(value.status),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct TufRepoMeta {
+        pub struct TufRepo {
             file_name: ::std::result::Result<::std::string::String, ::std::string::String>,
             hash: ::std::result::Result<::std::string::String, ::std::string::String>,
             system_version:
-                ::std::result::Result<super::TufRepoMetaSystemVersion, ::std::string::String>,
-            targets_role_version: ::std::result::Result<u64, ::std::string::String>,
-            valid_until: ::std::result::Result<
+                ::std::result::Result<super::TufRepoSystemVersion, ::std::string::String>,
+            time_created: ::std::result::Result<
                 ::chrono::DateTime<::chrono::offset::Utc>,
                 ::std::string::String,
             >,
         }
 
-        impl ::std::default::Default for TufRepoMeta {
+        impl ::std::default::Default for TufRepo {
             fn default() -> Self {
                 Self {
                     file_name: Err("no value supplied for file_name".to_string()),
                     hash: Err("no value supplied for hash".to_string()),
                     system_version: Err("no value supplied for system_version".to_string()),
-                    targets_role_version: Err(
-                        "no value supplied for targets_role_version".to_string()
-                    ),
-                    valid_until: Err("no value supplied for valid_until".to_string()),
+                    time_created: Err("no value supplied for time_created".to_string()),
                 }
             }
         }
 
-        impl TufRepoMeta {
+        impl TufRepo {
             pub fn file_name<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::string::String>,
@@ -57844,7 +57810,7 @@ pub mod types {
             }
             pub fn system_version<T>(mut self, value: T) -> Self
             where
-                T: ::std::convert::TryInto<super::TufRepoMetaSystemVersion>,
+                T: ::std::convert::TryInto<super::TufRepoSystemVersion>,
                 T::Error: ::std::fmt::Display,
             {
                 self.system_version = value.try_into().map_err(|e| {
@@ -57852,54 +57818,160 @@ pub mod types {
                 });
                 self
             }
-            pub fn targets_role_version<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<u64>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.targets_role_version = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for targets_role_version: {}",
-                        e
-                    )
-                });
-                self
-            }
-            pub fn valid_until<T>(mut self, value: T) -> Self
+            pub fn time_created<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.valid_until = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for valid_until: {}", e));
+                self.time_created = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for time_created: {}", e)
+                });
                 self
             }
         }
 
-        impl ::std::convert::TryFrom<TufRepoMeta> for super::TufRepoMeta {
+        impl ::std::convert::TryFrom<TufRepo> for super::TufRepo {
             type Error = super::error::ConversionError;
             fn try_from(
-                value: TufRepoMeta,
+                value: TufRepo,
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
                     file_name: value.file_name?,
                     hash: value.hash?,
                     system_version: value.system_version?,
-                    targets_role_version: value.targets_role_version?,
-                    valid_until: value.valid_until?,
+                    time_created: value.time_created?,
                 })
             }
         }
 
-        impl ::std::convert::From<super::TufRepoMeta> for TufRepoMeta {
-            fn from(value: super::TufRepoMeta) -> Self {
+        impl ::std::convert::From<super::TufRepo> for TufRepo {
+            fn from(value: super::TufRepo) -> Self {
                 Self {
                     file_name: Ok(value.file_name),
                     hash: Ok(value.hash),
                     system_version: Ok(value.system_version),
-                    targets_role_version: Ok(value.targets_role_version),
-                    valid_until: Ok(value.valid_until),
+                    time_created: Ok(value.time_created),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct TufRepoResultsPage {
+            items: ::std::result::Result<::std::vec::Vec<super::TufRepo>, ::std::string::String>,
+            next_page: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+        }
+
+        impl ::std::default::Default for TufRepoResultsPage {
+            fn default() -> Self {
+                Self {
+                    items: Err("no value supplied for items".to_string()),
+                    next_page: Ok(Default::default()),
+                }
+            }
+        }
+
+        impl TufRepoResultsPage {
+            pub fn items<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::TufRepo>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.items = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                self
+            }
+            pub fn next_page<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.next_page = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<TufRepoResultsPage> for super::TufRepoResultsPage {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: TufRepoResultsPage,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    items: value.items?,
+                    next_page: value.next_page?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::TufRepoResultsPage> for TufRepoResultsPage {
+            fn from(value: super::TufRepoResultsPage) -> Self {
+                Self {
+                    items: Ok(value.items),
+                    next_page: Ok(value.next_page),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct TufRepoUpload {
+            repo: ::std::result::Result<super::TufRepo, ::std::string::String>,
+            status: ::std::result::Result<super::TufRepoUploadStatus, ::std::string::String>,
+        }
+
+        impl ::std::default::Default for TufRepoUpload {
+            fn default() -> Self {
+                Self {
+                    repo: Err("no value supplied for repo".to_string()),
+                    status: Err("no value supplied for status".to_string()),
+                }
+            }
+        }
+
+        impl TufRepoUpload {
+            pub fn repo<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::TufRepo>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.repo = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for repo: {}", e));
+                self
+            }
+            pub fn status<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::TufRepoUploadStatus>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.status = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for status: {}", e));
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<TufRepoUpload> for super::TufRepoUpload {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: TufRepoUpload,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    repo: value.repo?,
+                    status: value.status?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::TufRepoUpload> for TufRepoUpload {
+            fn from(value: super::TufRepoUpload) -> Self {
+                Self {
+                    repo: Ok(value.repo),
+                    status: Ok(value.status),
                 }
             }
         }
@@ -61448,7 +61520,7 @@ pub mod types {
 ///
 /// API for interacting with the Oxide control plane
 ///
-/// Version: 20250730.0.0
+/// Version: 20251008.0.0
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -61489,7 +61561,7 @@ impl Client {
 
 impl ClientInfo<()> for Client {
     fn api_version() -> &'static str {
-        "20250730.0.0"
+        "20251008.0.0"
     }
 
     fn baseurl(&self) -> &str {
@@ -66445,36 +66517,58 @@ impl ClientSystemStatusExt for Client {
 
 /// Upload and manage system updates
 pub trait ClientSystemUpdateExt {
+    /// List all TUF repositories
+    ///
+    /// Returns a paginated list of all TUF repositories ordered by system
+    /// version (newest first by default).
+    ///
+    /// Sends a `GET` request to `/v1/system/update/repositories`
+    ///
+    /// Arguments:
+    /// - `limit`: Maximum number of items returned by a single call
+    /// - `page_token`: Token returned by previous call to retrieve the
+    ///   subsequent page
+    /// - `sort_by`
+    /// ```ignore
+    /// let response = client.system_update_repository_list()
+    ///    .limit(limit)
+    ///    .page_token(page_token)
+    ///    .sort_by(sort_by)
+    ///    .send()
+    ///    .await;
+    /// ```
+    fn system_update_repository_list(&self) -> builder::SystemUpdateRepositoryList<'_>;
     /// Upload system release repository
     ///
     /// System release repositories are verified by the updates trust store.
     ///
-    /// Sends a `PUT` request to `/v1/system/update/repository`
+    /// Sends a `PUT` request to `/v1/system/update/repositories`
     ///
     /// Arguments:
     /// - `file_name`: The name of the uploaded file.
     /// - `body`
     /// ```ignore
-    /// let response = client.system_update_put_repository()
+    /// let response = client.system_update_repository_upload()
     ///    .file_name(file_name)
     ///    .body(body)
     ///    .send()
     ///    .await;
     /// ```
-    fn system_update_put_repository(&self) -> builder::SystemUpdatePutRepository<'_>;
+    fn system_update_repository_upload(&self) -> builder::SystemUpdateRepositoryUpload<'_>;
     /// Fetch system release repository description by version
     ///
-    /// Sends a `GET` request to `/v1/system/update/repository/{system_version}`
+    /// Sends a `GET` request to
+    /// `/v1/system/update/repositories/{system_version}`
     ///
     /// Arguments:
     /// - `system_version`: The version to get.
     /// ```ignore
-    /// let response = client.system_update_get_repository()
+    /// let response = client.system_update_repository_view()
     ///    .system_version(system_version)
     ///    .send()
     ///    .await;
     /// ```
-    fn system_update_get_repository(&self) -> builder::SystemUpdateGetRepository<'_>;
+    fn system_update_repository_view(&self) -> builder::SystemUpdateRepositoryView<'_>;
     /// Get the current target release of the rack's system software
     ///
     /// This may not correspond to the actual software running on the rack at
@@ -66574,12 +66668,16 @@ pub trait ClientSystemUpdateExt {
 }
 
 impl ClientSystemUpdateExt for Client {
-    fn system_update_put_repository(&self) -> builder::SystemUpdatePutRepository<'_> {
-        builder::SystemUpdatePutRepository::new(self)
+    fn system_update_repository_list(&self) -> builder::SystemUpdateRepositoryList<'_> {
+        builder::SystemUpdateRepositoryList::new(self)
     }
 
-    fn system_update_get_repository(&self) -> builder::SystemUpdateGetRepository<'_> {
-        builder::SystemUpdateGetRepository::new(self)
+    fn system_update_repository_upload(&self) -> builder::SystemUpdateRepositoryUpload<'_> {
+        builder::SystemUpdateRepositoryUpload::new(self)
+    }
+
+    fn system_update_repository_view(&self) -> builder::SystemUpdateRepositoryView<'_> {
+        builder::SystemUpdateRepositoryView::new(self)
     }
 
     fn target_release_view(&self) -> builder::TargetReleaseView<'_> {
@@ -92179,17 +92277,170 @@ pub mod builder {
         }
     }
 
-    /// Builder for [`ClientSystemUpdateExt::system_update_put_repository`]
+    /// Builder for [`ClientSystemUpdateExt::system_update_repository_list`]
     ///
-    /// [`ClientSystemUpdateExt::system_update_put_repository`]: super::ClientSystemUpdateExt::system_update_put_repository
+    /// [`ClientSystemUpdateExt::system_update_repository_list`]: super::ClientSystemUpdateExt::system_update_repository_list
+    #[derive(Debug, Clone)]
+    pub struct SystemUpdateRepositoryList<'a> {
+        client: &'a super::Client,
+        limit: Result<Option<::std::num::NonZeroU32>, String>,
+        page_token: Result<Option<::std::string::String>, String>,
+        sort_by: Result<Option<types::VersionSortMode>, String>,
+    }
+
+    impl<'a> SystemUpdateRepositoryList<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
+            }
+        }
+
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: num :: NonZeroU32` for limit failed".to_string()
+            });
+            self
+        }
+
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.page_token = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for page_token failed".to_string()
+            });
+            self
+        }
+
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::VersionSortMode>,
+        {
+            self.sort_by = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `VersionSortMode` for sort_by failed".to_string());
+            self
+        }
+
+        /// Sends a `GET` request to `/v1/system/update/repositories`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<types::TufRepoResultsPage>, Error<types::Error>> {
+            let Self {
+                client,
+                limit,
+                page_token,
+                sort_by,
+            } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/v1/system/update/repositories", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "system_update_repository_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                400u16..=499u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                500u16..=599u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+
+        /// Streams `GET` requests to `/v1/system/update/repositories`
+        pub fn stream(
+            self,
+        ) -> impl futures::Stream<Item = Result<types::TufRepo, Error<types::Error>>> + Unpin + 'a
+        {
+            use ::futures::StreamExt;
+            use ::futures::TryFutureExt;
+            use ::futures::TryStreamExt;
+            let next = Self {
+                page_token: Ok(None),
+                sort_by: Ok(None),
+                ..self.clone()
+            };
+            self.send()
+                .map_ok(move |page| {
+                    let page = page.into_inner();
+                    let first = futures::stream::iter(page.items).map(Ok);
+                    let rest = futures::stream::try_unfold(
+                        (page.next_page, next),
+                        |(next_page, next)| async {
+                            if next_page.is_none() {
+                                Ok(None)
+                            } else {
+                                Self {
+                                    page_token: Ok(next_page),
+                                    ..next.clone()
+                                }
+                                .send()
+                                .map_ok(|page| {
+                                    let page = page.into_inner();
+                                    Some((
+                                        futures::stream::iter(page.items).map(Ok),
+                                        (page.next_page, next),
+                                    ))
+                                })
+                                .await
+                            }
+                        },
+                    )
+                    .try_flatten();
+                    first.chain(rest)
+                })
+                .try_flatten_stream()
+                .boxed()
+        }
+    }
+
+    /// Builder for [`ClientSystemUpdateExt::system_update_repository_upload`]
+    ///
+    /// [`ClientSystemUpdateExt::system_update_repository_upload`]: super::ClientSystemUpdateExt::system_update_repository_upload
     #[derive(Debug)]
-    pub struct SystemUpdatePutRepository<'a> {
+    pub struct SystemUpdateRepositoryUpload<'a> {
         client: &'a super::Client,
         file_name: Result<::std::string::String, String>,
         body: Result<reqwest::Body, String>,
     }
 
-    impl<'a> SystemUpdatePutRepository<'a> {
+    impl<'a> SystemUpdateRepositoryUpload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -92218,10 +92469,10 @@ pub mod builder {
             self
         }
 
-        /// Sends a `PUT` request to `/v1/system/update/repository`
+        /// Sends a `PUT` request to `/v1/system/update/repositories`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::TufRepoInsertResponse>, Error<types::Error>> {
+        ) -> Result<ResponseValue<types::TufRepoUpload>, Error<types::Error>> {
             let Self {
                 client,
                 file_name,
@@ -92229,7 +92480,7 @@ pub mod builder {
             } = self;
             let file_name = file_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/repository", client.baseurl,);
+            let url = format!("{}/v1/system/update/repositories", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -92252,7 +92503,7 @@ pub mod builder {
                 .headers(header_map)
                 .build()?;
             let info = OperationInfo {
-                operation_id: "system_update_put_repository",
+                operation_id: "system_update_repository_upload",
             };
             client.pre(&mut request, &info).await?;
             let result = client.exec(request, &info).await;
@@ -92271,16 +92522,16 @@ pub mod builder {
         }
     }
 
-    /// Builder for [`ClientSystemUpdateExt::system_update_get_repository`]
+    /// Builder for [`ClientSystemUpdateExt::system_update_repository_view`]
     ///
-    /// [`ClientSystemUpdateExt::system_update_get_repository`]: super::ClientSystemUpdateExt::system_update_get_repository
+    /// [`ClientSystemUpdateExt::system_update_repository_view`]: super::ClientSystemUpdateExt::system_update_repository_view
     #[derive(Debug, Clone)]
-    pub struct SystemUpdateGetRepository<'a> {
+    pub struct SystemUpdateRepositoryView<'a> {
         client: &'a super::Client,
-        system_version: Result<types::SystemUpdateGetRepositorySystemVersion, String>,
+        system_version: Result<types::SystemUpdateRepositoryViewSystemVersion, String>,
     }
 
-    impl<'a> SystemUpdateGetRepository<'a> {
+    impl<'a> SystemUpdateRepositoryView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -92290,27 +92541,25 @@ pub mod builder {
 
         pub fn system_version<V>(mut self, value: V) -> Self
         where
-            V: std::convert::TryInto<types::SystemUpdateGetRepositorySystemVersion>,
+            V: std::convert::TryInto<types::SystemUpdateRepositoryViewSystemVersion>,
         {
             self.system_version = value.try_into().map_err(|_| {
-                "conversion to `SystemUpdateGetRepositorySystemVersion` for system_version failed"
+                "conversion to `SystemUpdateRepositoryViewSystemVersion` for system_version failed"
                     .to_string()
             });
             self
         }
 
         /// Sends a `GET` request to
-        /// `/v1/system/update/repository/{system_version}`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::TufRepoGetResponse>, Error<types::Error>> {
+        /// `/v1/system/update/repositories/{system_version}`
+        pub async fn send(self) -> Result<ResponseValue<types::TufRepo>, Error<types::Error>> {
             let Self {
                 client,
                 system_version,
             } = self;
             let system_version = system_version.map_err(Error::InvalidRequest)?;
             let url = format!(
-                "{}/v1/system/update/repository/{}",
+                "{}/v1/system/update/repositories/{}",
                 client.baseurl,
                 encode_path(&system_version.to_string()),
             );
@@ -92330,7 +92579,7 @@ pub mod builder {
                 .headers(header_map)
                 .build()?;
             let info = OperationInfo {
-                operation_id: "system_update_get_repository",
+                operation_id: "system_update_repository_view",
             };
             client.pre(&mut request, &info).await?;
             let result = client.exec(request, &info).await;

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -29346,37 +29346,32 @@ pub mod types {
         }
     }
 
-    /// View of a system software target release.
+    /// View of a system software target release
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     /// {
-    ///  "description": "View of a system software target release.",
+    ///  "description": "View of a system software target release",
     ///  "type": "object",
     ///  "required": [
-    ///    "generation",
-    ///    "release_source",
-    ///    "time_requested"
+    ///    "time_requested",
+    ///    "version"
     ///  ],
     ///  "properties": {
-    ///    "generation": {
-    ///      "description": "The target-release generation number.",
-    ///      "type": "integer",
-    ///      "format": "int64"
-    ///    },
-    ///    "release_source": {
-    ///      "description": "The source of the target release.",
-    ///      "allOf": [
-    ///        {
-    ///          "$ref": "#/components/schemas/TargetReleaseSource"
-    ///        }
-    ///      ]
-    ///    },
     ///    "time_requested": {
-    ///      "description": "The time it was set as the target release.",
+    ///      "description": "Time this was set as the target release",
     ///      "type": "string",
     ///      "format": "date-time"
+    ///    },
+    ///    "version": {
+    ///      "description": "The specified release of the rack's system
+    /// software",
+    ///      "type": "string",
+    ///      "pattern":
+    /// "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*
+    /// [a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*
+    /// ))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     ///    }
     ///  }
     /// }
@@ -29386,12 +29381,10 @@ pub mod types {
         :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
     )]
     pub struct TargetRelease {
-        /// The target-release generation number.
-        pub generation: i64,
-        /// The source of the target release.
-        pub release_source: TargetReleaseSource,
-        /// The time it was set as the target release.
+        /// Time this was set as the target release
         pub time_requested: ::chrono::DateTime<::chrono::offset::Utc>,
+        /// The specified release of the rack's system software
+        pub version: TargetReleaseVersion,
     }
 
     impl ::std::convert::From<&TargetRelease> for TargetRelease {
@@ -29406,87 +29399,13 @@ pub mod types {
         }
     }
 
-    /// Source of a system software target release.
+    /// The specified release of the rack's system software
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     /// {
-    ///  "description": "Source of a system software target release.",
-    ///  "oneOf": [
-    ///    {
-    ///      "description": "Unspecified or unknown source (probably MUPdate).",
-    ///      "type": "object",
-    ///      "required": [
-    ///        "type"
-    ///      ],
-    ///      "properties": {
-    ///        "type": {
-    ///          "type": "string",
-    ///          "enum": [
-    ///            "unspecified"
-    ///          ]
-    ///        }
-    ///      }
-    ///    },
-    ///    {
-    ///      "description": "The specified release of the rack's system
-    /// software.",
-    ///      "type": "object",
-    ///      "required": [
-    ///        "type",
-    ///        "version"
-    ///      ],
-    ///      "properties": {
-    ///        "type": {
-    ///          "type": "string",
-    ///          "enum": [
-    ///            "system_version"
-    ///          ]
-    ///        },
-    ///        "version": {
-    ///          "type": "string",
-    ///          "pattern":
-    /// "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*
-    /// [a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*
-    /// ))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-    ///        }
-    ///      }
-    ///    }
-    ///  ]
-    /// }
-    /// ```
-    /// </details>
-    #[derive(
-        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
-    )]
-    #[serde(tag = "type", content = "version")]
-    pub enum TargetReleaseSource {
-        #[serde(rename = "unspecified")]
-        Unspecified,
-        /// The specified release of the rack's system software.
-        #[serde(rename = "system_version")]
-        SystemVersion(TargetReleaseSourceVersion),
-    }
-
-    impl ::std::convert::From<&Self> for TargetReleaseSource {
-        fn from(value: &TargetReleaseSource) -> Self {
-            value.clone()
-        }
-    }
-
-    impl ::std::convert::From<TargetReleaseSourceVersion> for TargetReleaseSource {
-        fn from(value: TargetReleaseSourceVersion) -> Self {
-            Self::SystemVersion(value)
-        }
-    }
-
-    /// `TargetReleaseSourceVersion`
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    /// {
+    ///  "description": "The specified release of the rack's system software",
     ///  "type": "string",
     ///  "pattern":
     /// "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*
@@ -29507,27 +29426,27 @@ pub mod types {
         schemars :: JsonSchema,
     )]
     #[serde(transparent)]
-    pub struct TargetReleaseSourceVersion(::std::string::String);
-    impl ::std::ops::Deref for TargetReleaseSourceVersion {
+    pub struct TargetReleaseVersion(::std::string::String);
+    impl ::std::ops::Deref for TargetReleaseVersion {
         type Target = ::std::string::String;
         fn deref(&self) -> &::std::string::String {
             &self.0
         }
     }
 
-    impl ::std::convert::From<TargetReleaseSourceVersion> for ::std::string::String {
-        fn from(value: TargetReleaseSourceVersion) -> Self {
+    impl ::std::convert::From<TargetReleaseVersion> for ::std::string::String {
+        fn from(value: TargetReleaseVersion) -> Self {
             value.0
         }
     }
 
-    impl ::std::convert::From<&TargetReleaseSourceVersion> for TargetReleaseSourceVersion {
-        fn from(value: &TargetReleaseSourceVersion) -> Self {
+    impl ::std::convert::From<&TargetReleaseVersion> for TargetReleaseVersion {
+        fn from(value: &TargetReleaseVersion) -> Self {
             value.clone()
         }
     }
 
-    impl ::std::str::FromStr for TargetReleaseSourceVersion {
+    impl ::std::str::FromStr for TargetReleaseVersion {
         type Err = self::error::ConversionError;
         fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
             static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
@@ -29551,14 +29470,14 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::TryFrom<&str> for TargetReleaseSourceVersion {
+    impl ::std::convert::TryFrom<&str> for TargetReleaseVersion {
         type Error = self::error::ConversionError;
         fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
             value.parse()
         }
     }
 
-    impl ::std::convert::TryFrom<&::std::string::String> for TargetReleaseSourceVersion {
+    impl ::std::convert::TryFrom<&::std::string::String> for TargetReleaseVersion {
         type Error = self::error::ConversionError;
         fn try_from(
             value: &::std::string::String,
@@ -29567,7 +29486,7 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::TryFrom<::std::string::String> for TargetReleaseSourceVersion {
+    impl ::std::convert::TryFrom<::std::string::String> for TargetReleaseVersion {
         type Error = self::error::ConversionError;
         fn try_from(
             value: ::std::string::String,
@@ -29576,7 +29495,7 @@ pub mod types {
         }
     }
 
-    impl<'de> ::serde::Deserialize<'de> for TargetReleaseSourceVersion {
+    impl<'de> ::serde::Deserialize<'de> for TargetReleaseVersion {
         fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where
             D: ::serde::Deserializer<'de>,
@@ -30966,6 +30885,110 @@ pub mod types {
             value: ::std::string::String,
         ) -> ::std::result::Result<Self, self::error::ConversionError> {
             value.parse()
+        }
+    }
+
+    /// `UpdateStatus`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    /// {
+    ///  "type": "object",
+    ///  "required": [
+    ///    "components_by_release_version",
+    ///    "paused",
+    ///    "target_release",
+    ///    "time_last_blueprint"
+    ///  ],
+    ///  "properties": {
+    ///    "components_by_release_version": {
+    ///      "description": "Count of components running each release version",
+    ///      "type": "object",
+    ///      "additionalProperties": {
+    ///        "type": "integer",
+    ///        "format": "uint",
+    ///        "minimum": 0.0
+    ///      }
+    ///    },
+    ///    "paused": {
+    ///      "description": "Whether update activity is paused\n\nWhen true, the
+    /// system has stopped attempting to make progress toward the target
+    /// release. This happens after a MUPdate because the system wants to make
+    /// sure of the operator's intent. To resume update, set a new target
+    /// release.",
+    ///      "type": "boolean"
+    ///    },
+    ///    "target_release": {
+    ///      "description": "Current target release of the system software\n\nThis may not correspond to the actual system software running at the time of request; it is instead the release that the system should be moving towards as a goal state. The system asynchronously updates software to match this target release.\n\nWill only be null if a target release has never been set. In that case, the system is not automatically attempting to manage software versions.",
+    ///      "oneOf": [
+    ///        {
+    ///          "type": "null"
+    ///        },
+    ///        {
+    ///          "allOf": [
+    ///            {
+    ///              "$ref": "#/components/schemas/TargetRelease"
+    ///            }
+    ///          ]
+    ///        }
+    ///      ]
+    ///    },
+    ///    "time_last_blueprint": {
+    ///      "description": "Time of most recent update planning
+    /// activity\n\nThis is intended as a rough indicator of the last time
+    /// something happened in the update planner. A blueprint is the update
+    /// system's plan for the next state of the system, so this timestamp
+    /// indicates the last time the update system made a plan.",
+    ///      "type": "string",
+    ///      "format": "date-time"
+    ///    }
+    ///  }
+    /// }
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct UpdateStatus {
+        /// Count of components running each release version
+        pub components_by_release_version: ::std::collections::HashMap<::std::string::String, u32>,
+        /// Whether update activity is paused
+        ///
+        /// When true, the system has stopped attempting to make progress toward
+        /// the target release. This happens after a MUPdate because the system
+        /// wants to make sure of the operator's intent. To resume update, set a
+        /// new target release.
+        pub paused: bool,
+        /// Current target release of the system software
+        ///
+        /// This may not correspond to the actual system software running at the
+        /// time of request; it is instead the release that the system should be
+        /// moving towards as a goal state. The system asynchronously updates
+        /// software to match this target release.
+        ///
+        /// Will only be null if a target release has never been set. In that
+        /// case, the system is not automatically attempting to manage software
+        /// versions.
+        pub target_release: ::std::option::Option<TargetRelease>,
+        /// Time of most recent update planning activity
+        ///
+        /// This is intended as a rough indicator of the last time something
+        /// happened in the update planner. A blueprint is the update system's
+        /// plan for the next state of the system, so this timestamp indicates
+        /// the last time the update system made a plan.
+        pub time_last_blueprint: ::chrono::DateTime<::chrono::offset::Utc>,
+    }
+
+    impl ::std::convert::From<&UpdateStatus> for UpdateStatus {
+        fn from(value: &UpdateStatus) -> Self {
+            value.clone()
+        }
+    }
+
+    impl UpdateStatus {
+        pub fn builder() -> builder::UpdateStatus {
+            Default::default()
         }
     }
 
@@ -57293,46 +57316,23 @@ pub mod types {
 
         #[derive(Clone, Debug)]
         pub struct TargetRelease {
-            generation: ::std::result::Result<i64, ::std::string::String>,
-            release_source:
-                ::std::result::Result<super::TargetReleaseSource, ::std::string::String>,
             time_requested: ::std::result::Result<
                 ::chrono::DateTime<::chrono::offset::Utc>,
                 ::std::string::String,
             >,
+            version: ::std::result::Result<super::TargetReleaseVersion, ::std::string::String>,
         }
 
         impl ::std::default::Default for TargetRelease {
             fn default() -> Self {
                 Self {
-                    generation: Err("no value supplied for generation".to_string()),
-                    release_source: Err("no value supplied for release_source".to_string()),
                     time_requested: Err("no value supplied for time_requested".to_string()),
+                    version: Err("no value supplied for version".to_string()),
                 }
             }
         }
 
         impl TargetRelease {
-            pub fn generation<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<i64>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.generation = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for generation: {}", e));
-                self
-            }
-            pub fn release_source<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<super::TargetReleaseSource>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.release_source = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for release_source: {}", e)
-                });
-                self
-            }
             pub fn time_requested<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
@@ -57343,6 +57343,16 @@ pub mod types {
                 });
                 self
             }
+            pub fn version<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::TargetReleaseVersion>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.version = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for version: {}", e));
+                self
+            }
         }
 
         impl ::std::convert::TryFrom<TargetRelease> for super::TargetRelease {
@@ -57351,9 +57361,8 @@ pub mod types {
                 value: TargetRelease,
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
-                    generation: value.generation?,
-                    release_source: value.release_source?,
                     time_requested: value.time_requested?,
+                    version: value.version?,
                 })
             }
         }
@@ -57361,9 +57370,8 @@ pub mod types {
         impl ::std::convert::From<super::TargetRelease> for TargetRelease {
             fn from(value: super::TargetRelease) -> Self {
                 Self {
-                    generation: Ok(value.generation),
-                    release_source: Ok(value.release_source),
                     time_requested: Ok(value.time_requested),
+                    version: Ok(value.version),
                 }
             }
         }
@@ -58371,6 +58379,112 @@ pub mod types {
                 Self {
                     items: Ok(value.items),
                     next_page: Ok(value.next_page),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct UpdateStatus {
+            components_by_release_version: ::std::result::Result<
+                ::std::collections::HashMap<::std::string::String, u32>,
+                ::std::string::String,
+            >,
+            paused: ::std::result::Result<bool, ::std::string::String>,
+            target_release: ::std::result::Result<
+                ::std::option::Option<super::TargetRelease>,
+                ::std::string::String,
+            >,
+            time_last_blueprint: ::std::result::Result<
+                ::chrono::DateTime<::chrono::offset::Utc>,
+                ::std::string::String,
+            >,
+        }
+
+        impl ::std::default::Default for UpdateStatus {
+            fn default() -> Self {
+                Self {
+                    components_by_release_version: Err("no value supplied for \
+                                                        components_by_release_version"
+                        .to_string()),
+                    paused: Err("no value supplied for paused".to_string()),
+                    target_release: Err("no value supplied for target_release".to_string()),
+                    time_last_blueprint: Err(
+                        "no value supplied for time_last_blueprint".to_string()
+                    ),
+                }
+            }
+        }
+
+        impl UpdateStatus {
+            pub fn components_by_release_version<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::collections::HashMap<::std::string::String, u32>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.components_by_release_version = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for components_by_release_version: {}",
+                        e
+                    )
+                });
+                self
+            }
+            pub fn paused<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<bool>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.paused = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for paused: {}", e));
+                self
+            }
+            pub fn target_release<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::TargetRelease>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.target_release = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for target_release: {}", e)
+                });
+                self
+            }
+            pub fn time_last_blueprint<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.time_last_blueprint = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for time_last_blueprint: {}",
+                        e
+                    )
+                });
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<UpdateStatus> for super::UpdateStatus {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: UpdateStatus,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    components_by_release_version: value.components_by_release_version?,
+                    paused: value.paused?,
+                    target_release: value.target_release?,
+                    time_last_blueprint: value.time_last_blueprint?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::UpdateStatus> for UpdateStatus {
+            fn from(value: super::UpdateStatus) -> Self {
+                Self {
+                    components_by_release_version: Ok(value.components_by_release_version),
+                    paused: Ok(value.paused),
+                    target_release: Ok(value.target_release),
+                    time_last_blueprint: Ok(value.time_last_blueprint),
                 }
             }
         }
@@ -66569,27 +66683,26 @@ pub trait ClientSystemUpdateExt {
     ///    .await;
     /// ```
     fn system_update_repository_view(&self) -> builder::SystemUpdateRepositoryView<'_>;
-    /// Get the current target release of the rack's system software
+    /// Fetch system update status
     ///
-    /// This may not correspond to the actual software running on the rack at
-    /// the time of request; it is instead the release that the rack
-    /// reconfigurator should be moving towards as a goal state. After some
-    /// number of planning and execution phases, the software running on the
-    /// rack should eventually correspond to the release described here.
+    /// Returns information about the current target release and the progress of
+    /// system software updates.
     ///
-    /// Sends a `GET` request to `/v1/system/update/target-release`
+    /// Sends a `GET` request to `/v1/system/update/status`
     ///
     /// ```ignore
-    /// let response = client.target_release_view()
+    /// let response = client.system_update_status()
     ///    .send()
     ///    .await;
     /// ```
-    fn target_release_view(&self) -> builder::TargetReleaseView<'_>;
-    /// Set the current target release of the rack's system software
+    fn system_update_status(&self) -> builder::SystemUpdateStatus<'_>;
+    /// Set target release
     ///
-    /// The rack reconfigurator will treat the software specified here as a goal
-    /// state for the rack's software, and attempt to asynchronously update to
-    /// that release.
+    /// Set the current target release of the rack's system software. The rack
+    /// reconfigurator will treat the software specified here as a goal state
+    /// for the rack's software, and attempt to asynchronously update to that
+    /// release. Use the update status endpoint to view the current target
+    /// release.
     ///
     /// Sends a `PUT` request to `/v1/system/update/target-release`
     ///
@@ -66680,8 +66793,8 @@ impl ClientSystemUpdateExt for Client {
         builder::SystemUpdateRepositoryView::new(self)
     }
 
-    fn target_release_view(&self) -> builder::TargetReleaseView<'_> {
-        builder::TargetReleaseView::new(self)
+    fn system_update_status(&self) -> builder::SystemUpdateStatus<'_> {
+        builder::SystemUpdateStatus::new(self)
     }
 
     fn target_release_update(&self) -> builder::TargetReleaseUpdate<'_> {
@@ -92598,25 +92711,23 @@ pub mod builder {
         }
     }
 
-    /// Builder for [`ClientSystemUpdateExt::target_release_view`]
+    /// Builder for [`ClientSystemUpdateExt::system_update_status`]
     ///
-    /// [`ClientSystemUpdateExt::target_release_view`]: super::ClientSystemUpdateExt::target_release_view
+    /// [`ClientSystemUpdateExt::system_update_status`]: super::ClientSystemUpdateExt::system_update_status
     #[derive(Debug, Clone)]
-    pub struct TargetReleaseView<'a> {
+    pub struct SystemUpdateStatus<'a> {
         client: &'a super::Client,
     }
 
-    impl<'a> TargetReleaseView<'a> {
+    impl<'a> SystemUpdateStatus<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
 
-        /// Sends a `GET` request to `/v1/system/update/target-release`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::TargetRelease>, Error<types::Error>> {
+        /// Sends a `GET` request to `/v1/system/update/status`
+        pub async fn send(self) -> Result<ResponseValue<types::UpdateStatus>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/target-release", client.baseurl,);
+            let url = format!("{}/v1/system/update/status", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -92633,7 +92744,7 @@ pub mod builder {
                 .headers(header_map)
                 .build()?;
             let info = OperationInfo {
-                operation_id: "target_release_view",
+                operation_id: "system_update_status",
             };
             client.pre(&mut request, &info).await?;
             let result = client.exec(request, &info).await;
@@ -92694,9 +92805,7 @@ pub mod builder {
         }
 
         /// Sends a `PUT` request to `/v1/system/update/target-release`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::TargetRelease>, Error<types::Error>> {
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
                 .and_then(|v| types::SetTargetReleaseParams::try_from(v).map_err(|e| e.to_string()))
@@ -92726,7 +92835,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),


### PR DESCRIPTION
This integrates the API spec from https://github.com/oxidecomputer/omicron/pull/9106 (TUF repo list), which is built on https://github.com/oxidecomputer/omicron/pull/8897 (update status), so it includes both.

Posting this already because I want to minimize the amount of time after https://github.com/oxidecomputer/omicron/pull/9106 is merged in which the CLI is unusable for update dev work.

This moves the commands for CRUD on trust roots out of experimental, as well as moving repo list, repo view, and set target release (upload was already at `oxide system update repo upload`). That gives us:

```
system update repo list
system update repo upload
system update repo view
system update status
system update target-release update
system update trust-root create
system update trust-root delete
system update trust-root list
system update trust-root view
```

Viewing the current target release is rolled into status.
