### PR TITLE
Enable version-specific Homebrew formulas

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/v1.0.7/dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/v1.0.14/dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -318,17 +318,18 @@ jobs:
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
 
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
-            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
-            name=$(echo "$filename" | sed "s/\.rb$//")
-            version=$(echo "$release" | jq .app_version --raw-output)
+            for filename in $(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output); do
+              name=$(echo "$filename" | sed "s/\.rb$//")
+              version=$(echo "$release" | jq .app_version --raw-output)
 
-            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-            brew update
-            # We avoid reformatting user-provided data such as the app description and homepage.
-            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+              export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+              brew update
+              # We avoid reformatting user-provided data such as the app description and homepage.
+              brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
 
-            git add "Formula/${filename}"
-            git commit -m "${name} ${version}"
+              git add "Formula/${filename}"
+              git commit -m "${name} ${version}"
+            done
           done
           git push
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "1.0.7"
+cargo-dist-version = "1.0.14"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -21,6 +21,8 @@ macos-sign = true
 ssldotcom-windows-sign = "prod"
 # A GitHub repo to push Homebrew formulas to
 tap = "oxidecomputer/homebrew-tap"
+# Create versioned Homebrew forumlas
+version-formulas = true
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 


### PR DESCRIPTION
The Oxide control plane is in the process of adding backwards
compatibility for clients on older versions. It will be better for a
client to remain on an older version than be ahead of the server.

Homebrew generally uses a "live at head" approach to versioning, which
creates a risk that users will inadvertently update themselves to a
version incompatible with their rack(s). To mitigate this, enable the
newly added `version-formulas` feature in our `dist` fork, which will
create a new formula in our tap for each minor version released.

Users can have multiple versions installed simultaneously, though only
one can be linked to `$HOMEBREW_PREFIX/bin`, the others can be accessed
via `$HOMEBREW_PREFIX/opt/oxide-cli@<VERSION>/bin`.