### PR TITLE
Read certificate files directly

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -823,7 +823,7 @@
           "args": [
             {
               "long": "cert",
-              "help": "path to PEM-formatted string containing public certificate chain"
+              "help": "path to a PEM-formatted file containing a public certificate chain"
             },
             {
               "long": "description"
@@ -838,7 +838,7 @@
             },
             {
               "long": "key",
-              "help": "path to PEM-formatted string containing public certificate chain"
+              "help": "path to a PEM-formatted file containing a private key"
             },
             {
               "long": "name"

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -823,7 +823,7 @@
           "args": [
             {
               "long": "cert",
-              "help": "PEM-formatted string containing public certificate chain"
+              "help": "path to PEM-formatted string containing public certificate chain"
             },
             {
               "long": "description"
@@ -838,7 +838,7 @@
             },
             {
               "long": "key",
-              "help": "PEM-formatted string containing private key"
+              "help": "path to PEM-formatted string containing public certificate chain"
             },
             {
               "long": "name"

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -135,6 +135,9 @@ impl Default for NewCli<'_> {
                             .value_parser(clap::value_parser!(std::net::IpAddr)),
                     ),
 
+                // We'd like users to provide a file rather than an inline string value for ease of use.
+                // Update the help string to note we want a file and add a name for the value being
+                // passed
                 CliCommand::CertificateCreate => cmd
                     .mut_arg("cert", |arg| {
                         arg.value_name("CERT-FILE")

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -134,6 +134,15 @@ impl Default for NewCli<'_> {
                             .required(true)
                             .value_parser(clap::value_parser!(std::net::IpAddr)),
                     ),
+                CliCommand::CertificateCreate => cmd
+                    .mut_arg("cert", |arg| {
+                        arg.value_name("cert-file")
+                            .help("path to PEM-formatted string containing public certificate chain")
+                    })
+                    .mut_arg("key", |arg| {
+                        arg.value_name("key-file")
+                            .help("path to PEM-formatted string containing public certificate chain")
+                    }),
 
                 CliCommand::SamlIdentityProviderCreate => cmd
                     .mut_arg("json-body", |arg| arg.required(false))

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -137,7 +137,7 @@ impl Default for NewCli<'_> {
                 CliCommand::CertificateCreate => cmd
                     .mut_arg("cert", |arg| {
                         arg.value_name("cert-file")
-                            .help("path to PEM-formatted string containing public certificate chain")
+                            .help("path to a PEM-formatted file containing a public certificate chain")
                     })
                     .mut_arg("key", |arg| {
                         arg.value_name("key-file")

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -123,24 +123,25 @@ impl Default for NewCli<'_> {
                     .arg(
                         clap::Arg::new("first")
                             .long("first")
-                            .value_name("ip-addr")
+                            .value_name("IP-ADDR")
                             .required(true)
                             .value_parser(clap::value_parser!(std::net::IpAddr)),
                     )
                     .arg(
                         clap::Arg::new("last")
                             .long("last")
-                            .value_name("ip-addr")
+                            .value_name("IP-ADDR")
                             .required(true)
                             .value_parser(clap::value_parser!(std::net::IpAddr)),
                     ),
+
                 CliCommand::CertificateCreate => cmd
                     .mut_arg("cert", |arg| {
-                        arg.value_name("cert-file")
+                        arg.value_name("CERT-FILE")
                             .help("path to a PEM-formatted file containing a public certificate chain")
                     })
                     .mut_arg("key", |arg| {
-                        arg.value_name("key-file")
+                        arg.value_name("KEY-FILE")
                             .help("path to a PEM-formatted file containing a private key")
                     }),
 
@@ -163,14 +164,14 @@ impl Default for NewCli<'_> {
                     .arg(
                         clap::Arg::new("private-key")
                             .long("private-key")
-                            .value_name("key-file")
+                            .value_name("KEY-FILE")
                             .value_parser(clap::value_parser!(PathBuf))
                             .help("path to the request signing RSA private key in PKCS#1 DER format"),
                     )
                     .arg(
                         clap::Arg::new("public-cert")
                             .long("public-cert")
-                            .value_name("cert-file")
+                            .value_name("CERT-FILE")
                             .value_parser(clap::value_parser!(PathBuf))
                             .help("path to the request signing public certificate in DER format"),
                     )

--- a/cli/src/cli_builder.rs
+++ b/cli/src/cli_builder.rs
@@ -141,7 +141,7 @@ impl Default for NewCli<'_> {
                     })
                     .mut_arg("key", |arg| {
                         arg.value_name("key-file")
-                            .help("path to PEM-formatted string containing public certificate chain")
+                            .help("path to a PEM-formatted file containing a private key")
                     }),
 
                 CliCommand::SamlIdentityProviderCreate => cmd

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -255,6 +255,25 @@ impl CliConfig for OxideOverride {
         Ok(())
     }
 
+    fn execute_certificate_create(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut oxide::builder::CertificateCreate,
+    ) -> anyhow::Result<()> {
+        let key_path = matches.get_one::<String>("key").unwrap();
+        let key_bytes = std::fs::read(key_path)
+            .with_context(|| format!("failed to read key file {key_path}"))?;
+
+        let cert_path = matches.get_one::<String>("cert").unwrap();
+        let cert_bytes = std::fs::read(cert_path)
+            .with_context(|| format!("failed to read cert file {cert_path}"))?;
+
+        *request = request
+            .to_owned()
+            .body_map(|body| body.key(key_bytes).cert(cert_bytes));
+        Ok(())
+    }
+
     fn execute_saml_identity_provider_create(
         &self,
         matches: &clap::ArgMatches,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -268,6 +268,8 @@ impl CliConfig for OxideOverride {
         let cert_bytes = std::fs::read(cert_path)
             .with_context(|| format!("failed to read cert file {cert_path}"))?;
 
+        // Note that key and cert will already be set by the generated code,
+        // but to the path of the files rather than to their contents.
         *request = request
             .to_owned()
             .body_map(|body| body.key(key_bytes).cert(cert_bytes));


### PR DESCRIPTION
Customers have found it inconvenient and error-prone to pass in the contents of certs and keys to the `certificate create` subcommand. To make this command easier to use, update its `key` and `cert` arguments to be treated as the path to their respective files, rather than their contents.

We previously updated the SAML IdP creation command the same way with 11fe44b (Take paths instead of base64 for SAML creation (#1112), 2025-05-28).