### PR TITLE
ci/cd: update nexus openapi spec file path

### DIFF
--- a/.github/reflector/integrate.toml
+++ b/.github/reflector/integrate.toml
@@ -9,7 +9,7 @@ branch = "main"
 
 requires_token = true
 
-# Listen for pushes to the nexus.json file in oxidecomputer/omicron and multiple source paths in
+# Listen for pushes to the nexus-latest.json file in oxidecomputer/omicron and multiple source paths in
 # oxidecomputer/progenitor (on each repository's respective default branch).
 
 # Debounce values are used to batch together multiple pushes that occur in a relatively short
@@ -18,7 +18,7 @@ requires_token = true
 [[on]]
 repository = "oxidecomputer/omicron"
 paths = [
-  "openapi/nexus.json",
+  "openapi/nexus/nexus-latest.json",
 ]
 debounce = 60
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -103,9 +103,8 @@ jobs:
 
       - name: Update schema
         run: |
-          curl -s https://raw.githubusercontent.com/oxidecomputer/omicron/main/openapi/nexus.json --output oxide.json
-
-          SHA=$(curl -s "https://api.github.com/repos/oxidecomputer/omicron/commits?path=openapi/nexus.json&per_page=1" | jq -r '.[].sha')
+          openapi_spec_file=$(curl -s https://raw.githubusercontent.com/oxidecomputer/omicron/main/openapi/nexus/nexus-latest.json)
+          SHA=$(curl -s "https://api.github.com/repos/oxidecomputer/omicron/commits?path=openapi/nexus/${openapi_spec_file}&per_page=1" | jq -r '.[].sha')
           echo "full=${SHA}" >> $GITHUB_OUTPUT
           echo "short=${SHA:0:8}" >> $GITHUB_OUTPUT
         id: schema_sha
@@ -215,8 +214,8 @@ jobs:
               if [ title != "" ]; then title+=","; fi
               title+=" oxide.json to omicron:${{ steps.schema_sha.outputs.short }}"
 
-              schemaLabel="nexus.json \`${{ steps.schema_sha.outputs.short }}\`"
-              schemaUrl="https://github.com/oxidecomputer/omicron/blob/${{ steps.schema_sha.outputs.full }}/openapi/nexus.json"
+              schemaLabel="nexus-latest.json \`${{ steps.schema_sha.outputs.short }}\`"
+              schemaUrl="https://github.com/oxidecomputer/omicron/blob/${{ steps.schema_sha.outputs.full }}/openapi/nexus/nexus-latest.json"
 
               echo "Generated code against [$schemaLabel]($schemaUrl)" >> body
               echo "" >> body

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           openapi_spec_file=$(curl -s https://raw.githubusercontent.com/oxidecomputer/omicron/main/openapi/nexus/nexus-latest.json)
           SHA=$(curl -s "https://api.github.com/repos/oxidecomputer/omicron/commits?path=openapi/nexus/${openapi_spec_file}&per_page=1" | jq -r '.[].sha')
+          echo "file=${openapi_spec_file}" >> $GITHUB_OUTPUT
           echo "full=${SHA}" >> $GITHUB_OUTPUT
           echo "short=${SHA:0:8}" >> $GITHUB_OUTPUT
         id: schema_sha
@@ -214,8 +215,8 @@ jobs:
               if [ title != "" ]; then title+=","; fi
               title+=" oxide.json to omicron:${{ steps.schema_sha.outputs.short }}"
 
-              schemaLabel="nexus-latest.json \`${{ steps.schema_sha.outputs.short }}\`"
-              schemaUrl="https://github.com/oxidecomputer/omicron/blob/${{ steps.schema_sha.outputs.full }}/openapi/nexus/nexus-latest.json"
+              schemaLabel="${{ steps.schema_sha.outputs.file }} \`${{ steps.schema_sha.outputs.short }}\`"
+              schemaUrl="https://github.com/oxidecomputer/omicron/blob/${{ steps.schema_sha.outputs.full }}/openapi/nexus/${{ steps.schema_sha.outputs.file }}"
 
               echo "Generated code against [$schemaLabel]($schemaUrl)" >> body
               echo "" >> body


### PR DESCRIPTION
Updated the Nexus OpenAPI specification file path from `nexus.json` to `nexus-latest.json`, accounting for the fact that `nexus-latest.json` is a symbolic link to the actual OpenAPI specification file.