### PR TITLE
refactor!: update progenitor to remove "From<&Self> for Self" implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4263,9 +4263,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4534,8 +4534,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "typify"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5bcc6f62eb1fa8aa4098f39b29f93dcb914e17158b76c50360911257aa629"
+source = "git+https://github.com/danieleades/typify?branch=refactor#75bb6c338d1a4fd531c388bfbeb755894b5b1c76"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -4544,8 +4543,7 @@ dependencies = [
 [[package]]
 name = "typify-impl"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1eb359f7ffa4f9ebe947fa11a1b2da054564502968db5f317b7e37693cb2240"
+source = "git+https://github.com/danieleades/typify?branch=refactor#75bb6c338d1a4fd531c388bfbeb755894b5b1c76"
 dependencies = [
  "heck",
  "log",
@@ -4564,8 +4562,7 @@ dependencies = [
 [[package]]
 name = "typify-macro"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911c32f3c8514b048c1b228361bebb5e6d73aeec01696e8cc0e82e2ffef8ab7a"
+source = "git+https://github.com/danieleades/typify?branch=refactor#75bb6c338d1a4fd531c388bfbeb755894b5b1c76"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,8 +2826,7 @@ dependencies = [
 [[package]]
 name = "progenitor-client"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a0beb939758f229cbae70a4889c7c76a4ac0e90f0b1e7ae9b4636a927d1018"
+source = "git+https://github.com/danieleades/progenitor?branch=refactor#2fda9d4cca8b158f2239df2b85d82d99462f1e5b"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -64,22 +64,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -90,9 +90,9 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -121,7 +121,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
  "synstructure",
 ]
 
@@ -133,7 +133,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -201,7 +201,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -212,7 +212,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
@@ -338,21 +338,11 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -372,19 +362,20 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -392,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -413,14 +404,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -428,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -441,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.63"
+version = "4.5.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ef1fcbbf16b486489d0df91725ccc653c07115dd61f46363162535b74c6bc3"
+checksum = "4c0da80818b2d95eca9aa614a30783e42f62bf5fdfee24e68cfb960b071ba8d1"
 dependencies = [
  "clap",
 ]
@@ -457,14 +448,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
@@ -533,22 +524,22 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width 0.2.0",
- "windows-sys 0.60.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -580,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -649,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -669,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -679,27 +670,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -736,43 +726,44 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "rustc_version",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -781,7 +772,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.16.0",
+ "console 0.16.2",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -836,8 +827,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
- "windows-sys 0.61.1",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -859,14 +850,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -933,14 +924,14 @@ dependencies = [
  "semver",
  "serde",
  "serde_tokenstream",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -965,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
@@ -1003,12 +994,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1022,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1085,6 +1076,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,9 +1095,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -1226,7 +1223,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1284,29 +1281,29 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "git2"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
+checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -1317,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1336,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1400,11 +1397,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1426,7 +1423,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -1557,10 +1554,10 @@ dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
- "rustls 0.23.27",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
 ]
@@ -1599,7 +1596,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -1610,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1634,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1647,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1660,11 +1657,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1675,42 +1671,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1763,7 +1755,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console 0.16.0",
+ "console 0.16.2",
  "portable-atomic",
  "unicode-width 0.2.0",
  "unit-prefix",
@@ -1772,21 +1764,24 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1817,9 +1812,9 @@ checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1836,13 +1831,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1857,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1881,49 +1876,49 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "a87d9b8105c23642f50cbbae03d1f75d8422c5cb98ce7ee9271f7ff7505be6b8"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "b787bebb543f8969132630c51fd0afab173a86c6abae56ff3b9e5e3e3f9f6e58"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1953,16 +1948,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "libbz2-rs-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
+name = "libc"
+version = "0.2.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.1+1.9.0"
+version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
@@ -1972,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -1982,18 +1983,18 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
 dependencies = [
  "zlib-rs",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "libc",
@@ -2024,23 +2025,22 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -2056,7 +2056,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2107,9 +2107,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmem"
@@ -2145,18 +2145,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2246,11 +2247,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2277,7 +2278,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2344,9 +2345,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -2372,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -2393,7 +2394,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2404,18 +2405,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -2555,9 +2556,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2565,15 +2566,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2599,12 +2600,12 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2615,9 +2616,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.4"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
+checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2625,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.4"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f"
+checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2635,22 +2636,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.4"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625"
+checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.4"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
+checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
  "sha2",
@@ -2696,7 +2697,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2728,9 +2729,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2743,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2807,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2817,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "progenitor"
 version = "0.11.2"
-source = "git+https://github.com/oxidecomputer/progenitor#4c06c8c01e23f5092c97ab95b8359ae2511316a2"
+source = "git+https://github.com/danieleades/progenitor?branch=refactor#2fda9d4cca8b158f2239df2b85d82d99462f1e5b"
 dependencies = [
  "progenitor-impl",
 ]
@@ -2840,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "progenitor-impl"
 version = "0.11.2"
-source = "git+https://github.com/oxidecomputer/progenitor#4c06c8c01e23f5092c97ab95b8359ae2511316a2"
+source = "git+https://github.com/danieleades/progenitor?branch=refactor#2fda9d4cca8b158f2239df2b85d82d99462f1e5b"
 dependencies = [
  "heck",
  "http 1.4.0",
@@ -2852,7 +2853,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "syn 2.0.111",
+ "syn 2.0.113",
  "thiserror 2.0.17",
  "typify",
  "unicode-ident",
@@ -2860,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2870,8 +2871,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.27",
- "socket2 0.5.10",
+ "rustls 0.23.35",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2880,17 +2881,17 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.27",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -2901,16 +2902,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2924,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -2984,7 +2985,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3109,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3129,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -3163,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regress"
@@ -3203,7 +3204,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.27",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3211,7 +3212,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.2",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3298,7 +3299,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3317,14 +3318,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.8",
  "subtle",
  "zeroize",
 ]
@@ -3340,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3361,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3372,15 +3373,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -3393,11 +3394,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3423,7 +3424,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3447,9 +3448,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3492,7 +3493,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3503,7 +3504,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3567,7 +3568,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3615,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3637,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -3648,18 +3649,19 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -3675,12 +3677,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slog"
@@ -3739,7 +3738,7 @@ dependencies = [
  "chrono",
  "is-terminal",
  "slog",
- "term 1.1.0",
+ "term 1.2.1",
  "thread_local",
  "time",
 ]
@@ -3752,22 +3751,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3781,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -3831,7 +3820,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3843,7 +3832,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3881,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3907,7 +3896,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3953,10 +3942,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3972,21 +3961,21 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43bddab41f8626c7bdaab872bbba75f8df5847b516d77c569c746e2ae5eb746"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4105,7 +4094,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4116,7 +4105,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4137,19 +4126,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -4164,15 +4152,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4180,9 +4168,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4190,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4205,9 +4193,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -4215,9 +4203,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4228,7 +4216,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4254,11 +4242,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.27",
+ "rustls 0.23.35",
  "tokio",
 ]
 
@@ -4458,7 +4446,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4540,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typify"
@@ -4569,7 +4557,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn 2.0.111",
+ "syn 2.0.113",
  "thiserror 2.0.17",
  "unicode-ident",
 ]
@@ -4587,7 +4575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.111",
+ "syn 2.0.113",
  "typify-impl",
 ]
 
@@ -4645,9 +4633,9 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unit-prefix"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -4692,7 +4680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "atomic",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4769,45 +4757,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4818,9 +4793,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4828,22 +4803,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
- "wasm-bindgen-backend",
+ "syn 2.0.113",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
@@ -4863,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4883,9 +4858,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4906,7 +4881,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "mac_address",
  "sha2",
  "thiserror 1.0.69",
@@ -4980,11 +4955,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4995,78 +4970,72 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.2",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3bfe459f85da17560875b8bf1423d6f113b7a87a5d942e7da0ac71be7c61f8b"
-
-[[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.2",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -5089,20 +5058,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.1"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36e9ed89376c545e20cbf5a13c306b49106b21b9d1d4f9cb9a1cb6b1e9ee06a"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.1",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -5123,18 +5092,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.1"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30357ec391cde730f8fbfcdc29adc47518b06504528df977ab5af02ef23fdee9"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5145,9 +5115,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5157,9 +5127,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5169,9 +5139,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -5181,9 +5151,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5193,9 +5163,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5205,9 +5175,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5217,9 +5187,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5229,33 +5199,30 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.10.0",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x509-parser"
@@ -5306,11 +5273,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -5318,34 +5284,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -5365,21 +5331,21 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5388,9 +5354,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5399,20 +5365,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "zip"
-version = "4.0.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153a6fff49d264c4babdcfa6b4d534747f520e56e8f0f384f3b808c4b64cc1fd"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "bzip2",
@@ -5425,21 +5391,21 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.2"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
+checksum = "30e0d8dffbae3d840f64bda38e28391faef673a7b5a6017840f2a106c8145868"
 
 [[package]]
 name = "zopfli"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ oxide-httpmock = { path = "sdk-httpmock", version = "0.14.0" }
 oxnet = "0.1.4"
 predicates = "3.1.3"
 pretty_assertions = "1.4.1"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor", default-features = false }
+progenitor = { git = "https://github.com/danieleades/progenitor", branch = "refactor", default-features = false }
 progenitor-client = "0.11.2"
 rand = "0.9.2"
 ratatui = "0.30.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,4 @@ lto = "thin"
 
 [patch.crates-io]
 progenitor-client = { git = "https://github.com/danieleades/progenitor", branch = "refactor" }
+typify = { git = "https://github.com/danieleades/typify", branch = "refactor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,6 @@ lto = "thin"
 #progenitor = { path = "../progenitor/progenitor" }
 #[patch."https://github.com/oxidecomputer/typify"]
 #typify = { path = "../typify/typify" }
+
+[patch.crates-io]
+progenitor-client = { git = "https://github.com/danieleades/progenitor", branch = "refactor" }

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -254,16 +254,16 @@ pub struct CmdInstanceFromImage {
 impl crate::AuthenticatedCmd for CmdInstanceFromImage {
     async fn run(&self, client: &Client) -> Result<()> {
         // Validate the image and get its ID (if specified by name).
-        let mut image_request = client.image_view().image(&self.image);
+        let mut image_request = client.image_view().image(self.image.clone());
         // We only need the project if the image is specified by name.
         if let NameOrId::Name(_) = &self.image {
-            image_request = image_request.project(&self.project);
+            image_request = image_request.project(self.project.clone());
         };
         let image_view = image_request.send().await?;
 
         let instance = client
             .instance_create()
-            .project(&self.project)
+            .project(self.project.clone())
             .body_map(|body| {
                 body.name(self.name.clone())
                     .description(self.description.clone())

--- a/cli/src/cmd_net.rs
+++ b/cli/src/cmd_net.rs
@@ -1574,7 +1574,7 @@ impl CmdPortStatus {
         for p in ports {
             let status = c
                 .networking_switch_port_status()
-                .port(&p.port_name)
+                .port(p.port_name.clone())
                 .rack_id(p.rack_id)
                 .switch_location(sw)
                 .send()

--- a/sdk/src/extras/disk.rs
+++ b/sdk/src/extras/disk.rs
@@ -505,7 +505,7 @@ pub mod types {
             let snapshot_id = self
                 .client
                 .snapshot_view()
-                .project(&self.project)
+                .project(self.project.clone())
                 .snapshot(image_info.snapshot.clone())
                 .send()
                 .await
@@ -513,7 +513,7 @@ pub mod types {
 
             self.client
                 .image_create()
-                .project(&self.project)
+                .project(self.project.clone())
                 .body(ImageCreate {
                     name: image_info.image.clone(),
                     description: image_info.image_description.clone(),
@@ -570,7 +570,7 @@ pub mod types {
                 format!("disk \"{}\" exists already", &*self.disk),
                 self.client
                     .disk_view()
-                    .project(&self.project)
+                    .project(self.project.clone())
                     .disk(self.disk.clone())
                     .send()
                     .await,
@@ -581,7 +581,7 @@ pub mod types {
                     format!("snapshot \"{}\" exists already", &*image_info.snapshot),
                     self.client
                         .snapshot_view()
-                        .project(&self.project)
+                        .project(self.project.clone())
                         .snapshot(image_info.snapshot.clone())
                         .send()
                         .await,
@@ -591,7 +591,7 @@ pub mod types {
                     format!("image \"{}\" exists already", &*image_info.image),
                     self.client
                         .image_view()
-                        .project(&self.project)
+                        .project(self.project.clone())
                         .image(image_info.image.clone())
                         .send()
                         .await,
@@ -605,7 +605,7 @@ pub mod types {
             let response = self
                 .client
                 .disk_view()
-                .project(&self.project)
+                .project(self.project.clone())
                 .disk(self.disk.clone())
                 .send()
                 .await?;
@@ -639,7 +639,7 @@ pub mod types {
         async fn unwind_disk_delete(&self) -> Result<(), DiskImportError> {
             self.client
                 .disk_delete()
-                .project(&self.project)
+                .project(self.project.clone())
                 .disk(self.disk.clone())
                 .send()
                 .await
@@ -656,7 +656,7 @@ pub mod types {
         async fn unwind_disk_finalize(&self) -> Result<(), DiskImportError> {
             self.client
                 .disk_finalize_import()
-                .project(&self.project)
+                .project(self.project.clone())
                 .disk(self.disk.clone())
                 .send()
                 .await
@@ -673,7 +673,7 @@ pub mod types {
         async fn unwind_disk_bulk_write_stop(&self) -> Result<(), DiskImportError> {
             self.client
                 .disk_bulk_write_import_stop()
-                .project(&self.project)
+                .project(self.project.clone())
                 .disk(self.disk.clone())
                 .send()
                 .await
@@ -822,7 +822,7 @@ pub mod types {
             self.client
                 .disk_bulk_write_import()
                 .disk(&*self.disk)
-                .project(&self.project)
+                .project(self.project.clone())
                 .body(ImportBlocksBulkWrite {
                     offset: chunk.offset,
                     base64_encoded_data,

--- a/sdk/src/generated_sdk.rs
+++ b/sdk/src/generated_sdk.rs
@@ -92,12 +92,6 @@ pub mod types {
         pub vlan_id: ::std::option::Option<u16>,
     }
 
-    impl ::std::convert::From<&Address> for Address {
-        fn from(value: &Address) -> Self {
-            value.clone()
-        }
-    }
-
     impl Address {
         pub fn builder() -> builder::Address {
             Default::default()
@@ -150,12 +144,6 @@ pub mod types {
         /// this is always phy0. On a 2x breakout the options are phy0 and phy1,
         /// on 4x phy0-phy3, etc.
         pub link_name: Name,
-    }
-
-    impl ::std::convert::From<&AddressConfig> for AddressConfig {
-        fn from(value: &AddressConfig) -> Self {
-            value.clone()
-        }
     }
 
     impl AddressConfig {
@@ -242,12 +230,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&AddressLot> for AddressLot {
-        fn from(value: &AddressLot) -> Self {
-            value.clone()
-        }
-    }
-
     impl AddressLot {
         pub fn builder() -> builder::AddressLot {
             Default::default()
@@ -301,12 +283,6 @@ pub mod types {
         pub last_address: ::std::net::IpAddr,
     }
 
-    impl ::std::convert::From<&AddressLotBlock> for AddressLotBlock {
-        fn from(value: &AddressLotBlock) -> Self {
-            value.clone()
-        }
-    }
-
     impl AddressLotBlock {
         pub fn builder() -> builder::AddressLotBlock {
             Default::default()
@@ -350,12 +326,6 @@ pub mod types {
         pub first_address: ::std::net::IpAddr,
         /// The last address in the lot (inclusive).
         pub last_address: ::std::net::IpAddr,
-    }
-
-    impl ::std::convert::From<&AddressLotBlockCreate> for AddressLotBlockCreate {
-        fn from(value: &AddressLotBlockCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl AddressLotBlockCreate {
@@ -404,12 +374,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&AddressLotBlockResultsPage> for AddressLotBlockResultsPage {
-        fn from(value: &AddressLotBlockResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl AddressLotBlockResultsPage {
@@ -470,12 +434,6 @@ pub mod types {
         pub name: Name,
     }
 
-    impl ::std::convert::From<&AddressLotCreate> for AddressLotCreate {
-        fn from(value: &AddressLotCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl AddressLotCreate {
         pub fn builder() -> builder::AddressLotCreate {
             Default::default()
@@ -524,12 +482,6 @@ pub mod types {
         pub blocks: ::std::vec::Vec<AddressLotBlock>,
         /// The address lot that was created.
         pub lot: AddressLot,
-    }
-
-    impl ::std::convert::From<&AddressLotCreateResponse> for AddressLotCreateResponse {
-        fn from(value: &AddressLotCreateResponse) -> Self {
-            value.clone()
-        }
     }
 
     impl AddressLotCreateResponse {
@@ -586,12 +538,6 @@ pub mod types {
         /// Pool address lots are used by IP pools.
         #[serde(rename = "pool")]
         Pool,
-    }
-
-    impl ::std::convert::From<&Self> for AddressLotKind {
-        fn from(value: &AddressLotKind) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for AddressLotKind {
@@ -681,12 +627,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&AddressLotResultsPage> for AddressLotResultsPage {
-        fn from(value: &AddressLotResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl AddressLotResultsPage {
         pub fn builder() -> builder::AddressLotResultsPage {
             Default::default()
@@ -735,12 +675,6 @@ pub mod types {
         pub blocks: ::std::vec::Vec<AddressLotBlock>,
         /// The address lot.
         pub lot: AddressLot,
-    }
-
-    impl ::std::convert::From<&AddressLotViewResponse> for AddressLotViewResponse {
-        fn from(value: &AddressLotViewResponse) -> Self {
-            value.clone()
-        }
     }
 
     impl AddressLotViewResponse {
@@ -830,12 +764,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&AffinityGroup> for AffinityGroup {
-        fn from(value: &AffinityGroup) -> Self {
-            value.clone()
-        }
-    }
-
     impl AffinityGroup {
         pub fn builder() -> builder::AffinityGroup {
             Default::default()
@@ -881,12 +809,6 @@ pub mod types {
         pub failure_domain: FailureDomain,
         pub name: Name,
         pub policy: AffinityPolicy,
-    }
-
-    impl ::std::convert::From<&AffinityGroupCreate> for AffinityGroupCreate {
-        fn from(value: &AffinityGroupCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl AffinityGroupCreate {
@@ -965,12 +887,6 @@ pub mod types {
         },
     }
 
-    impl ::std::convert::From<&Self> for AffinityGroupMember {
-        fn from(value: &AffinityGroupMember) -> Self {
-            value.clone()
-        }
-    }
-
     /// A single page of results
     ///
     /// <details><summary>JSON schema</summary>
@@ -1011,12 +927,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&AffinityGroupMemberResultsPage> for AffinityGroupMemberResultsPage {
-        fn from(value: &AffinityGroupMemberResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl AffinityGroupMemberResultsPage {
@@ -1067,12 +977,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&AffinityGroupResultsPage> for AffinityGroupResultsPage {
-        fn from(value: &AffinityGroupResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl AffinityGroupResultsPage {
         pub fn builder() -> builder::AffinityGroupResultsPage {
             Default::default()
@@ -1120,12 +1024,6 @@ pub mod types {
         pub description: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&AffinityGroupUpdate> for AffinityGroupUpdate {
-        fn from(value: &AffinityGroupUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for AffinityGroupUpdate {
@@ -1199,12 +1097,6 @@ pub mod types {
         /// If the affinity request cannot be satisfied, fail explicitly.
         #[serde(rename = "fail")]
         Fail,
-    }
-
-    impl ::std::convert::From<&Self> for AffinityPolicy {
-        fn from(value: &AffinityPolicy) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for AffinityPolicy {
@@ -1283,12 +1175,6 @@ pub mod types {
         pub switch_histories: ::std::vec::Vec<SwitchBgpHistory>,
     }
 
-    impl ::std::convert::From<&AggregateBgpMessageHistory> for AggregateBgpMessageHistory {
-        fn from(value: &AggregateBgpMessageHistory) -> Self {
-            value.clone()
-        }
-    }
-
     impl AggregateBgpMessageHistory {
         pub fn builder() -> builder::AggregateBgpMessageHistory {
             Default::default()
@@ -1329,12 +1215,6 @@ pub mod types {
         pub description: ::std::string::String,
         /// The name of the alert class.
         pub name: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&AlertClass> for AlertClass {
-        fn from(value: &AlertClass) -> Self {
-            value.clone()
-        }
     }
 
     impl AlertClass {
@@ -1383,12 +1263,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&AlertClassResultsPage> for AlertClassResultsPage {
-        fn from(value: &AlertClassResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl AlertClassResultsPage {
@@ -1495,12 +1369,6 @@ pub mod types {
         pub trigger: AlertDeliveryTrigger,
     }
 
-    impl ::std::convert::From<&AlertDelivery> for AlertDelivery {
-        fn from(value: &AlertDelivery) -> Self {
-            value.clone()
-        }
-    }
-
     impl AlertDelivery {
         pub fn builder() -> builder::AlertDelivery {
             Default::default()
@@ -1554,12 +1422,6 @@ pub mod types {
         Webhook(::std::vec::Vec<WebhookDeliveryAttempt>),
     }
 
-    impl ::std::convert::From<&Self> for AlertDeliveryAttempts {
-        fn from(value: &AlertDeliveryAttempts) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::vec::Vec<WebhookDeliveryAttempt>> for AlertDeliveryAttempts {
         fn from(value: ::std::vec::Vec<WebhookDeliveryAttempt>) -> Self {
             Self::Webhook(value)
@@ -1590,12 +1452,6 @@ pub mod types {
     )]
     pub struct AlertDeliveryId {
         pub delivery_id: ::uuid::Uuid,
-    }
-
-    impl ::std::convert::From<&AlertDeliveryId> for AlertDeliveryId {
-        fn from(value: &AlertDeliveryId) -> Self {
-            value.clone()
-        }
     }
 
     impl AlertDeliveryId {
@@ -1644,12 +1500,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&AlertDeliveryResultsPage> for AlertDeliveryResultsPage {
-        fn from(value: &AlertDeliveryResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl AlertDeliveryResultsPage {
@@ -1722,12 +1572,6 @@ pub mod types {
         /// retried again.
         #[serde(rename = "failed")]
         Failed,
-    }
-
-    impl ::std::convert::From<&Self> for AlertDeliveryState {
-        fn from(value: &AlertDeliveryState) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for AlertDeliveryState {
@@ -1836,12 +1680,6 @@ pub mod types {
         Probe,
     }
 
-    impl ::std::convert::From<&Self> for AlertDeliveryTrigger {
-        fn from(value: &AlertDeliveryTrigger) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for AlertDeliveryTrigger {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -1945,12 +1783,6 @@ pub mod types {
         pub resends_started: ::std::option::Option<u32>,
     }
 
-    impl ::std::convert::From<&AlertProbeResult> for AlertProbeResult {
-        fn from(value: &AlertProbeResult) -> Self {
-            value.clone()
-        }
-    }
-
     impl AlertProbeResult {
         pub fn builder() -> builder::AlertProbeResult {
             Default::default()
@@ -2045,12 +1877,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&AlertReceiver> for AlertReceiver {
-        fn from(value: &AlertReceiver) -> Self {
-            value.clone()
-        }
-    }
-
     impl AlertReceiver {
         pub fn builder() -> builder::AlertReceiver {
             Default::default()
@@ -2113,12 +1939,6 @@ pub mod types {
         },
     }
 
-    impl ::std::convert::From<&Self> for AlertReceiverKind {
-        fn from(value: &AlertReceiverKind) -> Self {
-            value.clone()
-        }
-    }
-
     /// A single page of results
     ///
     /// <details><summary>JSON schema</summary>
@@ -2159,12 +1979,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&AlertReceiverResultsPage> for AlertReceiverResultsPage {
-        fn from(value: &AlertReceiverResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl AlertReceiverResultsPage {
@@ -2214,12 +2028,6 @@ pub mod types {
     impl ::std::convert::From<AlertSubscription> for ::std::string::String {
         fn from(value: AlertSubscription) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&AlertSubscription> for AlertSubscription {
-        fn from(value: &AlertSubscription) -> Self {
-            value.clone()
         }
     }
 
@@ -2311,12 +2119,6 @@ pub mod types {
         pub subscription: AlertSubscription,
     }
 
-    impl ::std::convert::From<&AlertSubscriptionCreate> for AlertSubscriptionCreate {
-        fn from(value: &AlertSubscriptionCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl AlertSubscriptionCreate {
         pub fn builder() -> builder::AlertSubscriptionCreate {
             Default::default()
@@ -2352,12 +2154,6 @@ pub mod types {
     pub struct AlertSubscriptionCreated {
         /// The new subscription added to the receiver.
         pub subscription: AlertSubscription,
-    }
-
-    impl ::std::convert::From<&AlertSubscriptionCreated> for AlertSubscriptionCreated {
-        fn from(value: &AlertSubscriptionCreated) -> Self {
-            value.clone()
-        }
     }
 
     impl AlertSubscriptionCreated {
@@ -2416,12 +2212,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&AllowList> for AllowList {
-        fn from(value: &AllowList) -> Self {
-            value.clone()
-        }
-    }
-
     impl AllowList {
         pub fn builder() -> builder::AllowList {
             Default::default()
@@ -2458,12 +2248,6 @@ pub mod types {
     pub struct AllowListUpdate {
         /// The new list of allowed source IPs.
         pub allowed_ips: AllowedSourceIps,
-    }
-
-    impl ::std::convert::From<&AllowListUpdate> for AllowListUpdate {
-        fn from(value: &AllowListUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl AllowListUpdate {
@@ -2536,12 +2320,6 @@ pub mod types {
         /// All others are prevented from reaching rack services.
         #[serde(rename = "list")]
         List(::std::vec::Vec<IpNet>),
-    }
-
-    impl ::std::convert::From<&Self> for AllowedSourceIps {
-        fn from(value: &AllowedSourceIps) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::convert::From<::std::vec::Vec<IpNet>> for AllowedSourceIps {
@@ -2631,12 +2409,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&AntiAffinityGroup> for AntiAffinityGroup {
-        fn from(value: &AntiAffinityGroup) -> Self {
-            value.clone()
-        }
-    }
-
     impl AntiAffinityGroup {
         pub fn builder() -> builder::AntiAffinityGroup {
             Default::default()
@@ -2682,12 +2454,6 @@ pub mod types {
         pub failure_domain: FailureDomain,
         pub name: Name,
         pub policy: AffinityPolicy,
-    }
-
-    impl ::std::convert::From<&AntiAffinityGroupCreate> for AntiAffinityGroupCreate {
-        fn from(value: &AntiAffinityGroupCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl AntiAffinityGroupCreate {
@@ -2769,12 +2535,6 @@ pub mod types {
         },
     }
 
-    impl ::std::convert::From<&Self> for AntiAffinityGroupMember {
-        fn from(value: &AntiAffinityGroupMember) -> Self {
-            value.clone()
-        }
-    }
-
     /// A single page of results
     ///
     /// <details><summary>JSON schema</summary>
@@ -2815,14 +2575,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&AntiAffinityGroupMemberResultsPage>
-        for AntiAffinityGroupMemberResultsPage
-    {
-        fn from(value: &AntiAffinityGroupMemberResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl AntiAffinityGroupMemberResultsPage {
@@ -2873,12 +2625,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&AntiAffinityGroupResultsPage> for AntiAffinityGroupResultsPage {
-        fn from(value: &AntiAffinityGroupResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl AntiAffinityGroupResultsPage {
         pub fn builder() -> builder::AntiAffinityGroupResultsPage {
             Default::default()
@@ -2926,12 +2672,6 @@ pub mod types {
         pub description: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&AntiAffinityGroupUpdate> for AntiAffinityGroupUpdate {
-        fn from(value: &AntiAffinityGroupUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for AntiAffinityGroupUpdate {
@@ -3067,12 +2807,6 @@ pub mod types {
         pub user_agent: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&AuditLogEntry> for AuditLogEntry {
-        fn from(value: &AuditLogEntry) -> Self {
-            value.clone()
-        }
-    }
-
     impl AuditLogEntry {
         pub fn builder() -> builder::AuditLogEntry {
             Default::default()
@@ -3184,12 +2918,6 @@ pub mod types {
         Unauthenticated,
     }
 
-    impl ::std::convert::From<&Self> for AuditLogEntryActor {
-        fn from(value: &AuditLogEntryActor) -> Self {
-            value.clone()
-        }
-    }
-
     /// Result of an audit log entry
     ///
     /// <details><summary>JSON schema</summary>
@@ -3299,12 +3027,6 @@ pub mod types {
         Unknown,
     }
 
-    impl ::std::convert::From<&Self> for AuditLogEntryResult {
-        fn from(value: &AuditLogEntryResult) -> Self {
-            value.clone()
-        }
-    }
-
     /// A single page of results
     ///
     /// <details><summary>JSON schema</summary>
@@ -3345,12 +3067,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&AuditLogEntryResultsPage> for AuditLogEntryResultsPage {
-        fn from(value: &AuditLogEntryResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl AuditLogEntryResultsPage {
@@ -3441,12 +3157,6 @@ pub mod types {
         ViewableToAll,
     }
 
-    impl ::std::convert::From<&Self> for AuthzScope {
-        fn from(value: &AuthzScope) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for AuthzScope {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -3535,12 +3245,6 @@ pub mod types {
         pub serial: ::std::string::String,
     }
 
-    impl ::std::convert::From<&Baseboard> for Baseboard {
-        fn from(value: &Baseboard) -> Self {
-            value.clone()
-        }
-    }
-
     impl Baseboard {
         pub fn builder() -> builder::Baseboard {
             Default::default()
@@ -3580,12 +3284,6 @@ pub mod types {
         SingleHop,
         #[serde(rename = "multi_hop")]
         MultiHop,
-    }
-
-    impl ::std::convert::From<&Self> for BfdMode {
-        fn from(value: &BfdMode) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for BfdMode {
@@ -3674,12 +3372,6 @@ pub mod types {
         /// The switch to enable this session on. Must be `switch0` or
         /// `switch1`.
         pub switch: Name,
-    }
-
-    impl ::std::convert::From<&BfdSessionDisable> for BfdSessionDisable {
-        fn from(value: &BfdSessionDisable) -> Self {
-            value.clone()
-        }
     }
 
     impl BfdSessionDisable {
@@ -3782,12 +3474,6 @@ pub mod types {
         pub switch: Name,
     }
 
-    impl ::std::convert::From<&BfdSessionEnable> for BfdSessionEnable {
-        fn from(value: &BfdSessionEnable) -> Self {
-            value.clone()
-        }
-    }
-
     impl BfdSessionEnable {
         pub fn builder() -> builder::BfdSessionEnable {
             Default::default()
@@ -3863,12 +3549,6 @@ pub mod types {
         /// the init state.
         #[serde(rename = "up")]
         Up,
-    }
-
-    impl ::std::convert::From<&Self> for BfdState {
-        fn from(value: &BfdState) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for BfdState {
@@ -3984,12 +3664,6 @@ pub mod types {
         pub switch: Name,
     }
 
-    impl ::std::convert::From<&BfdStatus> for BfdStatus {
-        fn from(value: &BfdStatus) -> Self {
-            value.clone()
-        }
-    }
-
     impl BfdStatus {
         pub fn builder() -> builder::BfdStatus {
             Default::default()
@@ -4063,12 +3737,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&BgpAnnounceSet> for BgpAnnounceSet {
-        fn from(value: &BgpAnnounceSet) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpAnnounceSet {
         pub fn builder() -> builder::BgpAnnounceSet {
             Default::default()
@@ -4115,12 +3783,6 @@ pub mod types {
         pub announcement: ::std::vec::Vec<BgpAnnouncementCreate>,
         pub description: ::std::string::String,
         pub name: Name,
-    }
-
-    impl ::std::convert::From<&BgpAnnounceSetCreate> for BgpAnnounceSetCreate {
-        fn from(value: &BgpAnnounceSetCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl BgpAnnounceSetCreate {
@@ -4178,12 +3840,6 @@ pub mod types {
         pub network: IpNet,
     }
 
-    impl ::std::convert::From<&BgpAnnouncement> for BgpAnnouncement {
-        fn from(value: &BgpAnnouncement) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpAnnouncement {
         pub fn builder() -> builder::BgpAnnouncement {
             Default::default()
@@ -4232,12 +3888,6 @@ pub mod types {
         pub address_lot_block: NameOrId,
         /// The network being announced.
         pub network: IpNet,
-    }
-
-    impl ::std::convert::From<&BgpAnnouncementCreate> for BgpAnnouncementCreate {
-        fn from(value: &BgpAnnouncementCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl BgpAnnouncementCreate {
@@ -4333,12 +3983,6 @@ pub mod types {
         pub vrf: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&BgpConfig> for BgpConfig {
-        fn from(value: &BgpConfig) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpConfig {
         pub fn builder() -> builder::BgpConfig {
             Default::default()
@@ -4415,12 +4059,6 @@ pub mod types {
         pub vrf: ::std::option::Option<Name>,
     }
 
-    impl ::std::convert::From<&BgpConfigCreate> for BgpConfigCreate {
-        fn from(value: &BgpConfigCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpConfigCreate {
         pub fn builder() -> builder::BgpConfigCreate {
             Default::default()
@@ -4469,12 +4107,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&BgpConfigResultsPage> for BgpConfigResultsPage {
-        fn from(value: &BgpConfigResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpConfigResultsPage {
         pub fn builder() -> builder::BgpConfigResultsPage {
             Default::default()
@@ -4513,12 +4145,6 @@ pub mod types {
     pub struct BgpExported {
         /// Exported routes indexed by peer address.
         pub exports: ::std::collections::HashMap<::std::string::String, ::std::vec::Vec<Ipv4Net>>,
-    }
-
-    impl ::std::convert::From<&BgpExported> for BgpExported {
-        fn from(value: &BgpExported) -> Self {
-            value.clone()
-        }
     }
 
     impl BgpExported {
@@ -4587,12 +4213,6 @@ pub mod types {
         pub switch: SwitchLocation,
     }
 
-    impl ::std::convert::From<&BgpImportedRouteIpv4> for BgpImportedRouteIpv4 {
-        fn from(value: &BgpImportedRouteIpv4) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpImportedRouteIpv4 {
         pub fn builder() -> builder::BgpImportedRouteIpv4 {
             Default::default()
@@ -4622,12 +4242,6 @@ pub mod types {
     impl ::std::convert::From<BgpMessageHistory> for ::serde_json::Value {
         fn from(value: BgpMessageHistory) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&BgpMessageHistory> for BgpMessageHistory {
-        fn from(value: &BgpMessageHistory) -> Self {
-            value.clone()
         }
     }
 
@@ -4874,12 +4488,6 @@ pub mod types {
         pub vlan_id: ::std::option::Option<u16>,
     }
 
-    impl ::std::convert::From<&BgpPeer> for BgpPeer {
-        fn from(value: &BgpPeer) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpPeer {
         pub fn builder() -> builder::BgpPeer {
             Default::default()
@@ -4927,12 +4535,6 @@ pub mod types {
         /// phy1, on 4x phy0-phy3, etc.
         pub link_name: Name,
         pub peers: ::std::vec::Vec<BgpPeer>,
-    }
-
-    impl ::std::convert::From<&BgpPeerConfig> for BgpPeerConfig {
-        fn from(value: &BgpPeerConfig) -> Self {
-            value.clone()
-        }
     }
 
     impl BgpPeerConfig {
@@ -5055,12 +4657,6 @@ pub mod types {
         /// keepalive messages with peers.
         #[serde(rename = "established")]
         Established,
-    }
-
-    impl ::std::convert::From<&Self> for BgpPeerState {
-        fn from(value: &BgpPeerState) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for BgpPeerState {
@@ -5198,12 +4794,6 @@ pub mod types {
         pub switch: SwitchLocation,
     }
 
-    impl ::std::convert::From<&BgpPeerStatus> for BgpPeerStatus {
-        fn from(value: &BgpPeerStatus) -> Self {
-            value.clone()
-        }
-    }
-
     impl BgpPeerStatus {
         pub fn builder() -> builder::BgpPeerStatus {
             Default::default()
@@ -5314,12 +4904,6 @@ pub mod types {
         RangeFrom { start: f64 },
     }
 
-    impl ::std::convert::From<&Self> for BinRangedouble {
-        fn from(value: &BinRangedouble) -> Self {
-            value.clone()
-        }
-    }
-
     /// A type storing a range over `T`.
     ///
     /// This type supports ranges similar to the `RangeTo`, `Range` and
@@ -5422,12 +5006,6 @@ pub mod types {
         /// A range bounded inclusively below and unbounded above, `start..`.
         #[serde(rename = "range_from")]
         RangeFrom { start: f32 },
-    }
-
-    impl ::std::convert::From<&Self> for BinRangefloat {
-        fn from(value: &BinRangefloat) -> Self {
-            value.clone()
-        }
     }
 
     /// A type storing a range over `T`.
@@ -5534,12 +5112,6 @@ pub mod types {
         RangeFrom { start: i16 },
     }
 
-    impl ::std::convert::From<&Self> for BinRangeint16 {
-        fn from(value: &BinRangeint16) -> Self {
-            value.clone()
-        }
-    }
-
     /// A type storing a range over `T`.
     ///
     /// This type supports ranges similar to the `RangeTo`, `Range` and
@@ -5642,12 +5214,6 @@ pub mod types {
         /// A range bounded inclusively below and unbounded above, `start..`.
         #[serde(rename = "range_from")]
         RangeFrom { start: i32 },
-    }
-
-    impl ::std::convert::From<&Self> for BinRangeint32 {
-        fn from(value: &BinRangeint32) -> Self {
-            value.clone()
-        }
     }
 
     /// A type storing a range over `T`.
@@ -5754,12 +5320,6 @@ pub mod types {
         RangeFrom { start: i64 },
     }
 
-    impl ::std::convert::From<&Self> for BinRangeint64 {
-        fn from(value: &BinRangeint64) -> Self {
-            value.clone()
-        }
-    }
-
     /// A type storing a range over `T`.
     ///
     /// This type supports ranges similar to the `RangeTo`, `Range` and
@@ -5862,12 +5422,6 @@ pub mod types {
         /// A range bounded inclusively below and unbounded above, `start..`.
         #[serde(rename = "range_from")]
         RangeFrom { start: i8 },
-    }
-
-    impl ::std::convert::From<&Self> for BinRangeint8 {
-        fn from(value: &BinRangeint8) -> Self {
-            value.clone()
-        }
     }
 
     /// A type storing a range over `T`.
@@ -5978,12 +5532,6 @@ pub mod types {
         RangeFrom { start: u16 },
     }
 
-    impl ::std::convert::From<&Self> for BinRangeuint16 {
-        fn from(value: &BinRangeuint16) -> Self {
-            value.clone()
-        }
-    }
-
     /// A type storing a range over `T`.
     ///
     /// This type supports ranges similar to the `RangeTo`, `Range` and
@@ -6090,12 +5638,6 @@ pub mod types {
         /// A range bounded inclusively below and unbounded above, `start..`.
         #[serde(rename = "range_from")]
         RangeFrom { start: u32 },
-    }
-
-    impl ::std::convert::From<&Self> for BinRangeuint32 {
-        fn from(value: &BinRangeuint32) -> Self {
-            value.clone()
-        }
     }
 
     /// A type storing a range over `T`.
@@ -6206,12 +5748,6 @@ pub mod types {
         RangeFrom { start: u64 },
     }
 
-    impl ::std::convert::From<&Self> for BinRangeuint64 {
-        fn from(value: &BinRangeuint64) -> Self {
-            value.clone()
-        }
-    }
-
     /// A type storing a range over `T`.
     ///
     /// This type supports ranges similar to the `RangeTo`, `Range` and
@@ -6320,12 +5856,6 @@ pub mod types {
         RangeFrom { start: u8 },
     }
 
-    impl ::std::convert::From<&Self> for BinRangeuint8 {
-        fn from(value: &BinRangeuint8) -> Self {
-            value.clone()
-        }
-    }
-
     /// Type storing bin edges and a count of samples within it.
     ///
     /// <details><summary>JSON schema</summary>
@@ -6366,12 +5896,6 @@ pub mod types {
         pub count: u64,
         /// The range of the support covered by this bin.
         pub range: BinRangedouble,
-    }
-
-    impl ::std::convert::From<&Bindouble> for Bindouble {
-        fn from(value: &Bindouble) -> Self {
-            value.clone()
-        }
     }
 
     impl Bindouble {
@@ -6422,12 +5946,6 @@ pub mod types {
         pub range: BinRangefloat,
     }
 
-    impl ::std::convert::From<&Binfloat> for Binfloat {
-        fn from(value: &Binfloat) -> Self {
-            value.clone()
-        }
-    }
-
     impl Binfloat {
         pub fn builder() -> builder::Binfloat {
             Default::default()
@@ -6474,12 +5992,6 @@ pub mod types {
         pub count: u64,
         /// The range of the support covered by this bin.
         pub range: BinRangeint16,
-    }
-
-    impl ::std::convert::From<&Binint16> for Binint16 {
-        fn from(value: &Binint16) -> Self {
-            value.clone()
-        }
     }
 
     impl Binint16 {
@@ -6530,12 +6042,6 @@ pub mod types {
         pub range: BinRangeint32,
     }
 
-    impl ::std::convert::From<&Binint32> for Binint32 {
-        fn from(value: &Binint32) -> Self {
-            value.clone()
-        }
-    }
-
     impl Binint32 {
         pub fn builder() -> builder::Binint32 {
             Default::default()
@@ -6582,12 +6088,6 @@ pub mod types {
         pub count: u64,
         /// The range of the support covered by this bin.
         pub range: BinRangeint64,
-    }
-
-    impl ::std::convert::From<&Binint64> for Binint64 {
-        fn from(value: &Binint64) -> Self {
-            value.clone()
-        }
     }
 
     impl Binint64 {
@@ -6638,12 +6138,6 @@ pub mod types {
         pub range: BinRangeint8,
     }
 
-    impl ::std::convert::From<&Binint8> for Binint8 {
-        fn from(value: &Binint8) -> Self {
-            value.clone()
-        }
-    }
-
     impl Binint8 {
         pub fn builder() -> builder::Binint8 {
             Default::default()
@@ -6690,12 +6184,6 @@ pub mod types {
         pub count: u64,
         /// The range of the support covered by this bin.
         pub range: BinRangeuint16,
-    }
-
-    impl ::std::convert::From<&Binuint16> for Binuint16 {
-        fn from(value: &Binuint16) -> Self {
-            value.clone()
-        }
     }
 
     impl Binuint16 {
@@ -6746,12 +6234,6 @@ pub mod types {
         pub range: BinRangeuint32,
     }
 
-    impl ::std::convert::From<&Binuint32> for Binuint32 {
-        fn from(value: &Binuint32) -> Self {
-            value.clone()
-        }
-    }
-
     impl Binuint32 {
         pub fn builder() -> builder::Binuint32 {
             Default::default()
@@ -6798,12 +6280,6 @@ pub mod types {
         pub count: u64,
         /// The range of the support covered by this bin.
         pub range: BinRangeuint64,
-    }
-
-    impl ::std::convert::From<&Binuint64> for Binuint64 {
-        fn from(value: &Binuint64) -> Self {
-            value.clone()
-        }
     }
 
     impl Binuint64 {
@@ -6854,12 +6330,6 @@ pub mod types {
         pub range: BinRangeuint8,
     }
 
-    impl ::std::convert::From<&Binuint8> for Binuint8 {
-        fn from(value: &Binuint8) -> Self {
-            value.clone()
-        }
-    }
-
     impl Binuint8 {
         pub fn builder() -> builder::Binuint8 {
             Default::default()
@@ -6895,12 +6365,6 @@ pub mod types {
     impl ::std::convert::From<BlockSize> for i64 {
         fn from(value: BlockSize) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&BlockSize> for BlockSize {
-        fn from(value: &BlockSize) -> Self {
-            value.clone()
         }
     }
 
@@ -6953,12 +6417,6 @@ pub mod types {
     impl ::std::convert::From<ByteCount> for u64 {
         fn from(value: ByteCount) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&ByteCount> for ByteCount {
-        fn from(value: &ByteCount) -> Self {
-            value.clone()
         }
     }
 
@@ -7086,12 +6544,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Certificate> for Certificate {
-        fn from(value: &Certificate) -> Self {
-            value.clone()
-        }
-    }
-
     impl Certificate {
         pub fn builder() -> builder::Certificate {
             Default::default()
@@ -7155,12 +6607,6 @@ pub mod types {
         pub service: ServiceUsingCertificate,
     }
 
-    impl ::std::convert::From<&CertificateCreate> for CertificateCreate {
-        fn from(value: &CertificateCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl CertificateCreate {
         pub fn builder() -> builder::CertificateCreate {
             Default::default()
@@ -7207,12 +6653,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&CertificateResultsPage> for CertificateResultsPage {
-        fn from(value: &CertificateResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl CertificateResultsPage {
@@ -7263,12 +6703,6 @@ pub mod types {
         pub time_last_used: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&ConsoleSession> for ConsoleSession {
-        fn from(value: &ConsoleSession) -> Self {
-            value.clone()
-        }
-    }
-
     impl ConsoleSession {
         pub fn builder() -> builder::ConsoleSession {
             Default::default()
@@ -7317,12 +6751,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&ConsoleSessionResultsPage> for ConsoleSessionResultsPage {
-        fn from(value: &ConsoleSessionResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl ConsoleSessionResultsPage {
         pub fn builder() -> builder::ConsoleSessionResultsPage {
             Default::default()
@@ -7360,12 +6788,6 @@ pub mod types {
     pub struct Cumulativedouble {
         pub start_time: ::chrono::DateTime<::chrono::offset::Utc>,
         pub value: f64,
-    }
-
-    impl ::std::convert::From<&Cumulativedouble> for Cumulativedouble {
-        fn from(value: &Cumulativedouble) -> Self {
-            value.clone()
-        }
     }
 
     impl Cumulativedouble {
@@ -7407,12 +6829,6 @@ pub mod types {
         pub value: f32,
     }
 
-    impl ::std::convert::From<&Cumulativefloat> for Cumulativefloat {
-        fn from(value: &Cumulativefloat) -> Self {
-            value.clone()
-        }
-    }
-
     impl Cumulativefloat {
         pub fn builder() -> builder::Cumulativefloat {
             Default::default()
@@ -7450,12 +6866,6 @@ pub mod types {
     pub struct Cumulativeint64 {
         pub start_time: ::chrono::DateTime<::chrono::offset::Utc>,
         pub value: i64,
-    }
-
-    impl ::std::convert::From<&Cumulativeint64> for Cumulativeint64 {
-        fn from(value: &Cumulativeint64) -> Self {
-            value.clone()
-        }
     }
 
     impl Cumulativeint64 {
@@ -7496,12 +6906,6 @@ pub mod types {
     pub struct Cumulativeuint64 {
         pub start_time: ::chrono::DateTime<::chrono::offset::Utc>,
         pub value: u64,
-    }
-
-    impl ::std::convert::From<&Cumulativeuint64> for Cumulativeuint64 {
-        fn from(value: &Cumulativeuint64) -> Self {
-            value.clone()
-        }
     }
 
     impl Cumulativeuint64 {
@@ -7579,12 +6983,6 @@ pub mod types {
         pub silo_id: ::uuid::Uuid,
         /// Name of the silo to which this user belongs.
         pub silo_name: Name,
-    }
-
-    impl ::std::convert::From<&CurrentUser> for CurrentUser {
-        fn from(value: &CurrentUser) -> Self {
-            value.clone()
-        }
     }
 
     impl CurrentUser {
@@ -8192,12 +7590,6 @@ pub mod types {
         Missing(MissingDatum),
     }
 
-    impl ::std::convert::From<&Self> for Datum {
-        fn from(value: &Datum) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<bool> for Datum {
         fn from(value: bool) -> Self {
             Self::Bool(value)
@@ -8470,12 +7862,6 @@ pub mod types {
         HistogramF64,
     }
 
-    impl ::std::convert::From<&Self> for DatumType {
-        fn from(value: &DatumType) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for DatumType {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -8608,12 +7994,6 @@ pub mod types {
         pub public_cert: ::std::string::String,
     }
 
-    impl ::std::convert::From<&DerEncodedKeyPair> for DerEncodedKeyPair {
-        fn from(value: &DerEncodedKeyPair) -> Self {
-            value.clone()
-        }
-    }
-
     impl DerEncodedKeyPair {
         pub fn builder() -> builder::DerEncodedKeyPair {
             Default::default()
@@ -8672,12 +8052,6 @@ pub mod types {
         pub time_expires: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     }
 
-    impl ::std::convert::From<&DeviceAccessToken> for DeviceAccessToken {
-        fn from(value: &DeviceAccessToken) -> Self {
-            value.clone()
-        }
-    }
-
     impl DeviceAccessToken {
         pub fn builder() -> builder::DeviceAccessToken {
             Default::default()
@@ -8718,12 +8092,6 @@ pub mod types {
         pub client_id: ::uuid::Uuid,
         pub device_code: ::std::string::String,
         pub grant_type: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&DeviceAccessTokenRequest> for DeviceAccessTokenRequest {
-        fn from(value: &DeviceAccessTokenRequest) -> Self {
-            value.clone()
-        }
     }
 
     impl DeviceAccessTokenRequest {
@@ -8772,12 +8140,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&DeviceAccessTokenResultsPage> for DeviceAccessTokenResultsPage {
-        fn from(value: &DeviceAccessTokenResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl DeviceAccessTokenResultsPage {
@@ -8847,12 +8209,6 @@ pub mod types {
         pub ttl_seconds: ::std::option::Option<::std::num::NonZeroU32>,
     }
 
-    impl ::std::convert::From<&DeviceAuthRequest> for DeviceAuthRequest {
-        fn from(value: &DeviceAuthRequest) -> Self {
-            value.clone()
-        }
-    }
-
     impl DeviceAuthRequest {
         pub fn builder() -> builder::DeviceAuthRequest {
             Default::default()
@@ -8882,12 +8238,6 @@ pub mod types {
     )]
     pub struct DeviceAuthVerify {
         pub user_code: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&DeviceAuthVerify> for DeviceAuthVerify {
-        fn from(value: &DeviceAuthVerify) -> Self {
-            value.clone()
-        }
     }
 
     impl DeviceAuthVerify {
@@ -8932,12 +8282,6 @@ pub mod types {
     pub enum Digest {
         #[serde(rename = "sha256")]
         Sha256(::std::string::String),
-    }
-
-    impl ::std::convert::From<&Self> for Digest {
-        fn from(value: &Digest) -> Self {
-            value.clone()
-        }
     }
 
     /// View of a Disk
@@ -9059,12 +8403,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Disk> for Disk {
-        fn from(value: &Disk) -> Self {
-            value.clone()
-        }
-    }
-
     impl Disk {
         pub fn builder() -> builder::Disk {
             Default::default()
@@ -9131,12 +8469,6 @@ pub mod types {
         Distributed(DiskSource),
     }
 
-    impl ::std::convert::From<&Self> for DiskBackend {
-        fn from(value: &DiskBackend) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<DiskSource> for DiskBackend {
         fn from(value: DiskSource) -> Self {
             Self::Distributed(value)
@@ -9196,12 +8528,6 @@ pub mod types {
         pub size: ByteCount,
     }
 
-    impl ::std::convert::From<&DiskCreate> for DiskCreate {
-        fn from(value: &DiskCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl DiskCreate {
         pub fn builder() -> builder::DiskCreate {
             Default::default()
@@ -9237,12 +8563,6 @@ pub mod types {
     pub struct DiskPath {
         /// Name or ID of the disk
         pub disk: NameOrId,
-    }
-
-    impl ::std::convert::From<&DiskPath> for DiskPath {
-        fn from(value: &DiskPath) -> Self {
-            value.clone()
-        }
     }
 
     impl DiskPath {
@@ -9291,12 +8611,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&DiskResultsPage> for DiskResultsPage {
-        fn from(value: &DiskResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl DiskResultsPage {
@@ -9424,12 +8738,6 @@ pub mod types {
         /// an external source.
         #[serde(rename = "importing_blocks")]
         ImportingBlocks { block_size: BlockSize },
-    }
-
-    impl ::std::convert::From<&Self> for DiskSource {
-        fn from(value: &DiskSource) -> Self {
-            value.clone()
-        }
     }
 
     /// State of a Disk
@@ -9674,12 +8982,6 @@ pub mod types {
         Faulted,
     }
 
-    impl ::std::convert::From<&Self> for DiskState {
-        fn from(value: &DiskState) -> Self {
-            value.clone()
-        }
-    }
-
     /// `DiskType`
     ///
     /// <details><summary>JSON schema</summary>
@@ -9712,12 +9014,6 @@ pub mod types {
         Distributed,
         #[serde(rename = "local")]
         Local,
-    }
-
-    impl ::std::convert::From<&Self> for DiskType {
-        fn from(value: &DiskType) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for DiskType {
@@ -9871,12 +9167,6 @@ pub mod types {
         pub sum_of_samples: f64,
     }
 
-    impl ::std::convert::From<&Distributiondouble> for Distributiondouble {
-        fn from(value: &Distributiondouble) -> Self {
-            value.clone()
-        }
-    }
-
     impl Distributiondouble {
         pub fn builder() -> builder::Distributiondouble {
             Default::default()
@@ -9989,12 +9279,6 @@ pub mod types {
         pub sum_of_samples: i64,
     }
 
-    impl ::std::convert::From<&Distributionint64> for Distributionint64 {
-        fn from(value: &Distributionint64) -> Self {
-            value.clone()
-        }
-    }
-
     impl Distributionint64 {
         pub fn builder() -> builder::Distributionint64 {
             Default::default()
@@ -10065,12 +9349,6 @@ pub mod types {
         pub pool: ::std::option::Option<NameOrId>,
     }
 
-    impl ::std::convert::From<&EphemeralIpCreate> for EphemeralIpCreate {
-        fn from(value: &EphemeralIpCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for EphemeralIpCreate {
         fn default() -> Self {
             Self {
@@ -10120,12 +9398,6 @@ pub mod types {
         pub error_code: ::std::option::Option<::std::string::String>,
         pub message: ::std::string::String,
         pub request_id: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&Error> for Error {
-        fn from(value: &Error) -> Self {
-            value.clone()
-        }
     }
 
     impl Error {
@@ -10345,12 +9617,6 @@ pub mod types {
         },
     }
 
-    impl ::std::convert::From<&Self> for ExternalIp {
-        fn from(value: &ExternalIp) -> Self {
-            value.clone()
-        }
-    }
-
     /// Parameters for creating an external IP address for instances.
     ///
     /// <details><summary>JSON schema</summary>
@@ -10463,12 +9729,6 @@ pub mod types {
         Floating { floating_ip: NameOrId },
     }
 
-    impl ::std::convert::From<&Self> for ExternalIpCreate {
-        fn from(value: &ExternalIpCreate) -> Self {
-            value.clone()
-        }
-    }
-
     /// A single page of results
     ///
     /// <details><summary>JSON schema</summary>
@@ -10509,12 +9769,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&ExternalIpResultsPage> for ExternalIpResultsPage {
-        fn from(value: &ExternalIpResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl ExternalIpResultsPage {
@@ -10561,12 +9815,6 @@ pub mod types {
         /// Instances are considered co-located if they are on the same sled
         #[serde(rename = "sled")]
         Sled,
-    }
-
-    impl ::std::convert::From<&Self> for FailureDomain {
-        fn from(value: &FailureDomain) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for FailureDomain {
@@ -10654,12 +9902,6 @@ pub mod types {
         pub source: FieldSource,
     }
 
-    impl ::std::convert::From<&FieldSchema> for FieldSchema {
-        fn from(value: &FieldSchema) -> Self {
-            value.clone()
-        }
-    }
-
     impl FieldSchema {
         pub fn builder() -> builder::FieldSchema {
             Default::default()
@@ -10700,12 +9942,6 @@ pub mod types {
         Target,
         #[serde(rename = "metric")]
         Metric,
-    }
-
-    impl ::std::convert::From<&Self> for FieldSource {
-        fn from(value: &FieldSource) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for FieldSource {
@@ -10817,12 +10053,6 @@ pub mod types {
         Uuid,
         #[serde(rename = "bool")]
         Bool,
-    }
-
-    impl ::std::convert::From<&Self> for FieldType {
-        fn from(value: &FieldType) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for FieldType {
@@ -11164,12 +10394,6 @@ pub mod types {
         Bool(bool),
     }
 
-    impl ::std::convert::From<&Self> for FieldValue {
-        fn from(value: &FieldValue) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<i8> for FieldValue {
         fn from(value: i8) -> Self {
             Self::I8(value)
@@ -11279,12 +10503,6 @@ pub mod types {
         pub snapshot_name: ::std::option::Option<Name>,
     }
 
-    impl ::std::convert::From<&FinalizeDisk> for FinalizeDisk {
-        fn from(value: &FinalizeDisk) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for FinalizeDisk {
         fn default() -> Self {
             Self {
@@ -11334,12 +10552,6 @@ pub mod types {
         Collaborator,
         #[serde(rename = "viewer")]
         Viewer,
-    }
-
-    impl ::std::convert::From<&Self> for FleetRole {
-        fn from(value: &FleetRole) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for FleetRole {
@@ -11427,12 +10639,6 @@ pub mod types {
         pub role_assignments: ::std::vec::Vec<FleetRoleRoleAssignment>,
     }
 
-    impl ::std::convert::From<&FleetRolePolicy> for FleetRolePolicy {
-        fn from(value: &FleetRolePolicy) -> Self {
-            value.clone()
-        }
-    }
-
     impl FleetRolePolicy {
         pub fn builder() -> builder::FleetRolePolicy {
             Default::default()
@@ -11483,12 +10689,6 @@ pub mod types {
         pub identity_id: ::uuid::Uuid,
         pub identity_type: IdentityType,
         pub role_name: FleetRole,
-    }
-
-    impl ::std::convert::From<&FleetRoleRoleAssignment> for FleetRoleRoleAssignment {
-        fn from(value: &FleetRoleRoleAssignment) -> Self {
-            value.clone()
-        }
     }
 
     impl FleetRoleRoleAssignment {
@@ -11601,12 +10801,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&FloatingIp> for FloatingIp {
-        fn from(value: &FloatingIp) -> Self {
-            value.clone()
-        }
-    }
-
     impl FloatingIp {
         pub fn builder() -> builder::FloatingIp {
             Default::default()
@@ -11657,12 +10851,6 @@ pub mod types {
         /// Name or ID of the resource that this IP address should be attached
         /// to
         pub parent: NameOrId,
-    }
-
-    impl ::std::convert::From<&FloatingIpAttach> for FloatingIpAttach {
-        fn from(value: &FloatingIpAttach) -> Self {
-            value.clone()
-        }
     }
 
     impl FloatingIpAttach {
@@ -11764,12 +10952,6 @@ pub mod types {
         pub pool: ::std::option::Option<NameOrId>,
     }
 
-    impl ::std::convert::From<&FloatingIpCreate> for FloatingIpCreate {
-        fn from(value: &FloatingIpCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl FloatingIpCreate {
         pub fn builder() -> builder::FloatingIpCreate {
             Default::default()
@@ -11807,12 +10989,6 @@ pub mod types {
     pub enum FloatingIpParentKind {
         #[serde(rename = "instance")]
         Instance,
-    }
-
-    impl ::std::convert::From<&Self> for FloatingIpParentKind {
-        fn from(value: &FloatingIpParentKind) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for FloatingIpParentKind {
@@ -11900,12 +11076,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&FloatingIpResultsPage> for FloatingIpResultsPage {
-        fn from(value: &FloatingIpResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl FloatingIpResultsPage {
         pub fn builder() -> builder::FloatingIpResultsPage {
             Default::default()
@@ -11953,12 +11123,6 @@ pub mod types {
         pub description: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&FloatingIpUpdate> for FloatingIpUpdate {
-        fn from(value: &FloatingIpUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for FloatingIpUpdate {
@@ -12018,12 +11182,6 @@ pub mod types {
         pub silo_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&Group> for Group {
-        fn from(value: &Group) -> Self {
-            value.clone()
-        }
-    }
-
     impl Group {
         pub fn builder() -> builder::Group {
             Default::default()
@@ -12070,12 +11228,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&GroupResultsPage> for GroupResultsPage {
-        fn from(value: &GroupResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl GroupResultsPage {
@@ -12210,12 +11362,6 @@ pub mod types {
         pub sum_of_samples: f64,
     }
 
-    impl ::std::convert::From<&Histogramdouble> for Histogramdouble {
-        fn from(value: &Histogramdouble) -> Self {
-            value.clone()
-        }
-    }
-
     impl Histogramdouble {
         pub fn builder() -> builder::Histogramdouble {
             Default::default()
@@ -12346,12 +11492,6 @@ pub mod types {
         /// The start time of the histogram.
         pub start_time: ::chrono::DateTime<::chrono::offset::Utc>,
         pub sum_of_samples: f64,
-    }
-
-    impl ::std::convert::From<&Histogramfloat> for Histogramfloat {
-        fn from(value: &Histogramfloat) -> Self {
-            value.clone()
-        }
     }
 
     impl Histogramfloat {
@@ -12489,12 +11629,6 @@ pub mod types {
         pub sum_of_samples: i64,
     }
 
-    impl ::std::convert::From<&Histogramint16> for Histogramint16 {
-        fn from(value: &Histogramint16) -> Self {
-            value.clone()
-        }
-    }
-
     impl Histogramint16 {
         pub fn builder() -> builder::Histogramint16 {
             Default::default()
@@ -12628,12 +11762,6 @@ pub mod types {
         pub start_time: ::chrono::DateTime<::chrono::offset::Utc>,
         /// The sum of all samples in the histogram.
         pub sum_of_samples: i64,
-    }
-
-    impl ::std::convert::From<&Histogramint32> for Histogramint32 {
-        fn from(value: &Histogramint32) -> Self {
-            value.clone()
-        }
     }
 
     impl Histogramint32 {
@@ -12771,12 +11899,6 @@ pub mod types {
         pub sum_of_samples: i64,
     }
 
-    impl ::std::convert::From<&Histogramint64> for Histogramint64 {
-        fn from(value: &Histogramint64) -> Self {
-            value.clone()
-        }
-    }
-
     impl Histogramint64 {
         pub fn builder() -> builder::Histogramint64 {
             Default::default()
@@ -12910,12 +12032,6 @@ pub mod types {
         pub start_time: ::chrono::DateTime<::chrono::offset::Utc>,
         /// The sum of all samples in the histogram.
         pub sum_of_samples: i64,
-    }
-
-    impl ::std::convert::From<&Histogramint8> for Histogramint8 {
-        fn from(value: &Histogramint8) -> Self {
-            value.clone()
-        }
     }
 
     impl Histogramint8 {
@@ -13055,12 +12171,6 @@ pub mod types {
         pub sum_of_samples: i64,
     }
 
-    impl ::std::convert::From<&Histogramuint16> for Histogramuint16 {
-        fn from(value: &Histogramuint16) -> Self {
-            value.clone()
-        }
-    }
-
     impl Histogramuint16 {
         pub fn builder() -> builder::Histogramuint16 {
             Default::default()
@@ -13196,12 +12306,6 @@ pub mod types {
         pub start_time: ::chrono::DateTime<::chrono::offset::Utc>,
         /// The sum of all samples in the histogram.
         pub sum_of_samples: i64,
-    }
-
-    impl ::std::convert::From<&Histogramuint32> for Histogramuint32 {
-        fn from(value: &Histogramuint32) -> Self {
-            value.clone()
-        }
     }
 
     impl Histogramuint32 {
@@ -13341,12 +12445,6 @@ pub mod types {
         pub sum_of_samples: i64,
     }
 
-    impl ::std::convert::From<&Histogramuint64> for Histogramuint64 {
-        fn from(value: &Histogramuint64) -> Self {
-            value.clone()
-        }
-    }
-
     impl Histogramuint64 {
         pub fn builder() -> builder::Histogramuint64 {
             Default::default()
@@ -13484,12 +12582,6 @@ pub mod types {
         pub sum_of_samples: i64,
     }
 
-    impl ::std::convert::From<&Histogramuint8> for Histogramuint8 {
-        fn from(value: &Histogramuint8) -> Self {
-            value.clone()
-        }
-    }
-
     impl Histogramuint8 {
         pub fn builder() -> builder::Histogramuint8 {
             Default::default()
@@ -13541,12 +12633,6 @@ pub mod types {
     impl ::std::convert::From<Hostname> for ::std::string::String {
         fn from(value: Hostname) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&Hostname> for Hostname {
-        fn from(value: &Hostname) -> Self {
-            value.clone()
         }
     }
 
@@ -13662,12 +12748,6 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::From<&IcmpParamRange> for IcmpParamRange {
-        fn from(value: &IcmpParamRange) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::str::FromStr for IcmpParamRange {
         type Err = self::error::ConversionError;
         fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -13765,12 +12845,6 @@ pub mod types {
         /// sort in increasing order of "id"
         #[serde(rename = "id_ascending")]
         IdAscending,
-    }
-
-    impl ::std::convert::From<&Self> for IdSortMode {
-        fn from(value: &IdSortMode) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for IdSortMode {
@@ -13892,12 +12966,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&IdentityProvider> for IdentityProvider {
-        fn from(value: &IdentityProvider) -> Self {
-            value.clone()
-        }
-    }
-
     impl IdentityProvider {
         pub fn builder() -> builder::IdentityProvider {
             Default::default()
@@ -13946,12 +13014,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&IdentityProviderResultsPage> for IdentityProviderResultsPage {
-        fn from(value: &IdentityProviderResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl IdentityProviderResultsPage {
         pub fn builder() -> builder::IdentityProviderResultsPage {
             Default::default()
@@ -13993,12 +13055,6 @@ pub mod types {
         /// SAML identity provider
         #[serde(rename = "saml")]
         Saml,
-    }
-
-    impl ::std::convert::From<&Self> for IdentityProviderType {
-        fn from(value: &IdentityProviderType) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for IdentityProviderType {
@@ -14077,12 +13133,6 @@ pub mod types {
         SiloUser,
         #[serde(rename = "silo_group")]
         SiloGroup,
-    }
-
-    impl ::std::convert::From<&Self> for IdentityType {
-        fn from(value: &IdentityType) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for IdentityType {
@@ -14186,12 +13236,6 @@ pub mod types {
         Url { url: ::std::string::String },
         #[serde(rename = "base64_encoded_xml")]
         Base64EncodedXml { data: ::std::string::String },
-    }
-
-    impl ::std::convert::From<&Self> for IdpMetadataSource {
-        fn from(value: &IdpMetadataSource) -> Self {
-            value.clone()
-        }
     }
 
     /// View of an image
@@ -14332,12 +13376,6 @@ pub mod types {
         pub version: ::std::string::String,
     }
 
-    impl ::std::convert::From<&Image> for Image {
-        fn from(value: &Image) -> Self {
-            value.clone()
-        }
-    }
-
     impl Image {
         pub fn builder() -> builder::Image {
             Default::default()
@@ -14402,12 +13440,6 @@ pub mod types {
         pub version: ::std::string::String,
     }
 
-    impl ::std::convert::From<&ImageCreate> for ImageCreate {
-        fn from(value: &ImageCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ImageCreate {
         pub fn builder() -> builder::ImageCreate {
             Default::default()
@@ -14456,12 +13488,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&ImageResultsPage> for ImageResultsPage {
-        fn from(value: &ImageResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl ImageResultsPage {
         pub fn builder() -> builder::ImageResultsPage {
             Default::default()
@@ -14508,12 +13534,6 @@ pub mod types {
         Snapshot(::uuid::Uuid),
     }
 
-    impl ::std::convert::From<&Self> for ImageSource {
-        fn from(value: &ImageSource) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::uuid::Uuid> for ImageSource {
         fn from(value: ::uuid::Uuid) -> Self {
             Self::Snapshot(value)
@@ -14551,12 +13571,6 @@ pub mod types {
     pub struct ImportBlocksBulkWrite {
         pub base64_encoded_data: ::std::string::String,
         pub offset: u64,
-    }
-
-    impl ::std::convert::From<&ImportBlocksBulkWrite> for ImportBlocksBulkWrite {
-        fn from(value: &ImportBlocksBulkWrite) -> Self {
-            value.clone()
-        }
     }
 
     impl ImportBlocksBulkWrite {
@@ -14624,12 +13638,6 @@ pub mod types {
         NoFiltering,
         #[serde(rename = "allow")]
         Allow(::std::vec::Vec<IpNet>),
-    }
-
-    impl ::std::convert::From<&Self> for ImportExportPolicy {
-        fn from(value: &ImportExportPolicy) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::convert::From<::std::vec::Vec<IpNet>> for ImportExportPolicy {
@@ -14873,12 +13881,6 @@ pub mod types {
         pub time_run_state_updated: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Instance> for Instance {
-        fn from(value: &Instance) -> Self {
-            value.clone()
-        }
-    }
-
     impl Instance {
         pub fn builder() -> builder::Instance {
             Default::default()
@@ -14943,12 +13945,6 @@ pub mod types {
         /// availability of the system.
         #[serde(rename = "best_effort")]
         BestEffort,
-    }
-
-    impl ::std::convert::From<&Self> for InstanceAutoRestartPolicy {
-        fn from(value: &InstanceAutoRestartPolicy) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for InstanceAutoRestartPolicy {
@@ -15024,12 +14020,6 @@ pub mod types {
     impl ::std::convert::From<InstanceCpuCount> for u16 {
         fn from(value: InstanceCpuCount) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&InstanceCpuCount> for InstanceCpuCount {
-        fn from(value: &InstanceCpuCount) -> Self {
-            value.clone()
         }
     }
 
@@ -15164,12 +14154,6 @@ pub mod types {
         /// An AMD Turin-like CPU platform.
         #[serde(rename = "amd_turin")]
         AmdTurin,
-    }
-
-    impl ::std::convert::From<&Self> for InstanceCpuPlatform {
-        fn from(value: &InstanceCpuPlatform) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for InstanceCpuPlatform {
@@ -15526,12 +14510,6 @@ pub mod types {
         pub user_data: ::std::string::String,
     }
 
-    impl ::std::convert::From<&InstanceCreate> for InstanceCreate {
-        fn from(value: &InstanceCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl InstanceCreate {
         pub fn builder() -> builder::InstanceCreate {
             Default::default()
@@ -15636,12 +14614,6 @@ pub mod types {
             /// A disk name to attach
             name: Name,
         },
-    }
-
-    impl ::std::convert::From<&Self> for InstanceDiskAttachment {
-        fn from(value: &InstanceDiskAttachment) -> Self {
-            value.clone()
-        }
     }
 
     /// An `InstanceNetworkInterface` represents a virtual network interface
@@ -15776,12 +14748,6 @@ pub mod types {
         pub vpc_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&InstanceNetworkInterface> for InstanceNetworkInterface {
-        fn from(value: &InstanceNetworkInterface) -> Self {
-            value.clone()
-        }
-    }
-
     impl InstanceNetworkInterface {
         pub fn builder() -> builder::InstanceNetworkInterface {
             Default::default()
@@ -15878,12 +14844,6 @@ pub mod types {
         None,
     }
 
-    impl ::std::convert::From<&Self> for InstanceNetworkInterfaceAttachment {
-        fn from(value: &InstanceNetworkInterfaceAttachment) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::vec::Vec<InstanceNetworkInterfaceCreate>>
         for InstanceNetworkInterfaceAttachment
     {
@@ -15972,12 +14932,6 @@ pub mod types {
         pub vpc_name: Name,
     }
 
-    impl ::std::convert::From<&InstanceNetworkInterfaceCreate> for InstanceNetworkInterfaceCreate {
-        fn from(value: &InstanceNetworkInterfaceCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl InstanceNetworkInterfaceCreate {
         pub fn builder() -> builder::InstanceNetworkInterfaceCreate {
             Default::default()
@@ -16024,14 +14978,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&InstanceNetworkInterfaceResultsPage>
-        for InstanceNetworkInterfaceResultsPage
-    {
-        fn from(value: &InstanceNetworkInterfaceResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl InstanceNetworkInterfaceResultsPage {
@@ -16127,12 +15073,6 @@ pub mod types {
         pub transit_ips: ::std::vec::Vec<IpNet>,
     }
 
-    impl ::std::convert::From<&InstanceNetworkInterfaceUpdate> for InstanceNetworkInterfaceUpdate {
-        fn from(value: &InstanceNetworkInterfaceUpdate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for InstanceNetworkInterfaceUpdate {
         fn default() -> Self {
             Self {
@@ -16192,12 +15132,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&InstanceResultsPage> for InstanceResultsPage {
-        fn from(value: &InstanceResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl InstanceResultsPage {
         pub fn builder() -> builder::InstanceResultsPage {
             Default::default()
@@ -16251,12 +15185,6 @@ pub mod types {
         /// The absolute offset since boot (suitable for use as `byte_offset` in
         /// a subsequent request) of the last byte returned in `data`.
         pub last_byte_offset: u64,
-    }
-
-    impl ::std::convert::From<&InstanceSerialConsoleData> for InstanceSerialConsoleData {
-        fn from(value: &InstanceSerialConsoleData) -> Self {
-            value.clone()
-        }
     }
 
     impl InstanceSerialConsoleData {
@@ -16405,12 +15333,6 @@ pub mod types {
         /// The instance has been deleted.
         #[serde(rename = "destroyed")]
         Destroyed,
-    }
-
-    impl ::std::convert::From<&Self> for InstanceState {
-        fn from(value: &InstanceState) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for InstanceState {
@@ -16649,12 +15571,6 @@ pub mod types {
         pub ncpus: InstanceCpuCount,
     }
 
-    impl ::std::convert::From<&InstanceUpdate> for InstanceUpdate {
-        fn from(value: &InstanceUpdate) -> Self {
-            value.clone()
-        }
-    }
-
     impl InstanceUpdate {
         pub fn builder() -> builder::InstanceUpdate {
             Default::default()
@@ -16724,12 +15640,6 @@ pub mod types {
         IfIndex(u32),
         #[serde(rename = "port_number")]
         PortNumber(u32),
-    }
-
-    impl ::std::convert::From<&Self> for InterfaceNum {
-        fn from(value: &InterfaceNum) -> Self {
-            value.clone()
-        }
     }
 
     /// An internet gateway provides a path between VPC networks and external
@@ -16807,12 +15717,6 @@ pub mod types {
         pub vpc_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&InternetGateway> for InternetGateway {
-        fn from(value: &InternetGateway) -> Self {
-            value.clone()
-        }
-    }
-
     impl InternetGateway {
         pub fn builder() -> builder::InternetGateway {
             Default::default()
@@ -16848,12 +15752,6 @@ pub mod types {
     pub struct InternetGatewayCreate {
         pub description: ::std::string::String,
         pub name: Name,
-    }
-
-    impl ::std::convert::From<&InternetGatewayCreate> for InternetGatewayCreate {
-        fn from(value: &InternetGatewayCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl InternetGatewayCreate {
@@ -16943,12 +15841,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&InternetGatewayIpAddress> for InternetGatewayIpAddress {
-        fn from(value: &InternetGatewayIpAddress) -> Self {
-            value.clone()
-        }
-    }
-
     impl InternetGatewayIpAddress {
         pub fn builder() -> builder::InternetGatewayIpAddress {
             Default::default()
@@ -16990,12 +15882,6 @@ pub mod types {
         pub address: ::std::net::IpAddr,
         pub description: ::std::string::String,
         pub name: Name,
-    }
-
-    impl ::std::convert::From<&InternetGatewayIpAddressCreate> for InternetGatewayIpAddressCreate {
-        fn from(value: &InternetGatewayIpAddressCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl InternetGatewayIpAddressCreate {
@@ -17044,14 +15930,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&InternetGatewayIpAddressResultsPage>
-        for InternetGatewayIpAddressResultsPage
-    {
-        fn from(value: &InternetGatewayIpAddressResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl InternetGatewayIpAddressResultsPage {
@@ -17141,12 +16019,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&InternetGatewayIpPool> for InternetGatewayIpPool {
-        fn from(value: &InternetGatewayIpPool) -> Self {
-            value.clone()
-        }
-    }
-
     impl InternetGatewayIpPool {
         pub fn builder() -> builder::InternetGatewayIpPool {
             Default::default()
@@ -17187,12 +16059,6 @@ pub mod types {
         pub description: ::std::string::String,
         pub ip_pool: NameOrId,
         pub name: Name,
-    }
-
-    impl ::std::convert::From<&InternetGatewayIpPoolCreate> for InternetGatewayIpPoolCreate {
-        fn from(value: &InternetGatewayIpPoolCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl InternetGatewayIpPoolCreate {
@@ -17243,12 +16109,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&InternetGatewayIpPoolResultsPage> for InternetGatewayIpPoolResultsPage {
-        fn from(value: &InternetGatewayIpPoolResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl InternetGatewayIpPoolResultsPage {
         pub fn builder() -> builder::InternetGatewayIpPoolResultsPage {
             Default::default()
@@ -17297,12 +16157,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&InternetGatewayResultsPage> for InternetGatewayResultsPage {
-        fn from(value: &InternetGatewayResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl InternetGatewayResultsPage {
         pub fn builder() -> builder::InternetGatewayResultsPage {
             Default::default()
@@ -17348,12 +16202,6 @@ pub mod types {
     pub enum IpNet {
         V4(Ipv4Net),
         V6(Ipv6Net),
-    }
-
-    impl ::std::convert::From<&Self> for IpNet {
-        fn from(value: &IpNet) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::str::FromStr for IpNet {
@@ -17504,12 +16352,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&IpPool> for IpPool {
-        fn from(value: &IpPool) -> Self {
-            value.clone()
-        }
-    }
-
     impl IpPool {
         pub fn builder() -> builder::IpPool {
             Default::default()
@@ -17587,12 +16429,6 @@ pub mod types {
         pub pool_type: IpPoolType,
     }
 
-    impl ::std::convert::From<&IpPoolCreate> for IpPoolCreate {
-        fn from(value: &IpPoolCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl IpPoolCreate {
         pub fn builder() -> builder::IpPoolCreate {
             Default::default()
@@ -17639,12 +16475,6 @@ pub mod types {
         /// up to 4 default pools total.
         pub is_default: bool,
         pub silo: NameOrId,
-    }
-
-    impl ::std::convert::From<&IpPoolLinkSilo> for IpPoolLinkSilo {
-        fn from(value: &IpPoolLinkSilo) -> Self {
-            value.clone()
-        }
     }
 
     impl IpPoolLinkSilo {
@@ -17696,12 +16526,6 @@ pub mod types {
         pub time_created: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&IpPoolRange> for IpPoolRange {
-        fn from(value: &IpPoolRange) -> Self {
-            value.clone()
-        }
-    }
-
     impl IpPoolRange {
         pub fn builder() -> builder::IpPoolRange {
             Default::default()
@@ -17750,12 +16574,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&IpPoolRangeResultsPage> for IpPoolRangeResultsPage {
-        fn from(value: &IpPoolRangeResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl IpPoolRangeResultsPage {
         pub fn builder() -> builder::IpPoolRangeResultsPage {
             Default::default()
@@ -17802,12 +16620,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&IpPoolResultsPage> for IpPoolResultsPage {
-        fn from(value: &IpPoolResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl IpPoolResultsPage {
@@ -17868,12 +16680,6 @@ pub mod types {
         pub silo_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&IpPoolSiloLink> for IpPoolSiloLink {
-        fn from(value: &IpPoolSiloLink) -> Self {
-            value.clone()
-        }
-    }
-
     impl IpPoolSiloLink {
         pub fn builder() -> builder::IpPoolSiloLink {
             Default::default()
@@ -17922,12 +16728,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&IpPoolSiloLinkResultsPage> for IpPoolSiloLinkResultsPage {
-        fn from(value: &IpPoolSiloLinkResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl IpPoolSiloLinkResultsPage {
         pub fn builder() -> builder::IpPoolSiloLinkResultsPage {
             Default::default()
@@ -17973,12 +16773,6 @@ pub mod types {
         /// existing default of the same type and version will remain linked but
         /// will no longer be the default.
         pub is_default: bool,
-    }
-
-    impl ::std::convert::From<&IpPoolSiloUpdate> for IpPoolSiloUpdate {
-        fn from(value: &IpPoolSiloUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl IpPoolSiloUpdate {
@@ -18038,12 +16832,6 @@ pub mod types {
         /// mixed).
         #[serde(rename = "multicast")]
         Multicast,
-    }
-
-    impl ::std::convert::From<&Self> for IpPoolType {
-        fn from(value: &IpPoolType) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for IpPoolType {
@@ -18134,12 +16922,6 @@ pub mod types {
         pub name: ::std::option::Option<Name>,
     }
 
-    impl ::std::convert::From<&IpPoolUpdate> for IpPoolUpdate {
-        fn from(value: &IpPoolUpdate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for IpPoolUpdate {
         fn default() -> Self {
             Self {
@@ -18203,12 +16985,6 @@ pub mod types {
         pub remaining: f64,
     }
 
-    impl ::std::convert::From<&IpPoolUtilization> for IpPoolUtilization {
-        fn from(value: &IpPoolUtilization) -> Self {
-            value.clone()
-        }
-    }
-
     impl IpPoolUtilization {
         pub fn builder() -> builder::IpPoolUtilization {
             Default::default()
@@ -18249,12 +17025,6 @@ pub mod types {
     pub enum IpRange {
         V4(Ipv4Range),
         V6(Ipv6Range),
-    }
-
-    impl ::std::convert::From<&Self> for IpRange {
-        fn from(value: &IpRange) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::convert::From<Ipv4Range> for IpRange {
@@ -18302,12 +17072,6 @@ pub mod types {
         V4,
         #[serde(rename = "v6")]
         V6,
-    }
-
-    impl ::std::convert::From<&Self> for IpVersion {
-        fn from(value: &IpVersion) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for IpVersion {
@@ -18402,12 +17166,6 @@ pub mod types {
     impl ::std::convert::From<Ipv4Net> for ::std::string::String {
         fn from(value: Ipv4Net) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&Ipv4Net> for Ipv4Net {
-        fn from(value: &Ipv4Net) -> Self {
-            value.clone()
         }
     }
 
@@ -18509,12 +17267,6 @@ pub mod types {
         pub last: ::std::net::Ipv4Addr,
     }
 
-    impl ::std::convert::From<&Ipv4Range> for Ipv4Range {
-        fn from(value: &Ipv4Range) -> Self {
-            value.clone()
-        }
-    }
-
     impl Ipv4Range {
         pub fn builder() -> builder::Ipv4Range {
             Default::default()
@@ -18576,12 +17328,6 @@ pub mod types {
     impl ::std::convert::From<Ipv6Net> for ::std::string::String {
         fn from(value: Ipv6Net) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&Ipv6Net> for Ipv6Net {
-        fn from(value: &Ipv6Net) -> Self {
-            value.clone()
         }
     }
 
@@ -18700,12 +17446,6 @@ pub mod types {
         pub last: ::std::net::Ipv6Addr,
     }
 
-    impl ::std::convert::From<&Ipv6Range> for Ipv6Range {
-        fn from(value: &Ipv6Range) -> Self {
-            value.clone()
-        }
-    }
-
     impl Ipv6Range {
         pub fn builder() -> builder::Ipv6Range {
             Default::default()
@@ -18755,12 +17495,6 @@ pub mod types {
     impl ::std::convert::From<L4PortRange> for ::std::string::String {
         fn from(value: L4PortRange) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&L4PortRange> for L4PortRange {
-        fn from(value: &L4PortRange) -> Self {
-            value.clone()
         }
     }
 
@@ -18936,12 +17670,6 @@ pub mod types {
         pub tx_eq: ::std::option::Option<TxEqConfig>,
     }
 
-    impl ::std::convert::From<&LinkConfigCreate> for LinkConfigCreate {
-        fn from(value: &LinkConfigCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl LinkConfigCreate {
         pub fn builder() -> builder::LinkConfigCreate {
             Default::default()
@@ -19004,12 +17732,6 @@ pub mod types {
         /// Reed-Solomon forward error correction.
         #[serde(rename = "rs")]
         Rs,
-    }
-
-    impl ::std::convert::From<&Self> for LinkFec {
-        fn from(value: &LinkFec) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for LinkFec {
@@ -19177,12 +17899,6 @@ pub mod types {
         Speed400G,
     }
 
-    impl ::std::convert::From<&Self> for LinkSpeed {
-        fn from(value: &LinkSpeed) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for LinkSpeed {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -19340,12 +18056,6 @@ pub mod types {
         pub system_name: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&LldpLinkConfig> for LldpLinkConfig {
-        fn from(value: &LldpLinkConfig) -> Self {
-            value.clone()
-        }
-    }
-
     impl LldpLinkConfig {
         pub fn builder() -> builder::LldpLinkConfig {
             Default::default()
@@ -19439,12 +18149,6 @@ pub mod types {
         /// The LLDP system name TLV.
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub system_name: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&LldpLinkConfigCreate> for LldpLinkConfigCreate {
-        fn from(value: &LldpLinkConfigCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl LldpLinkConfigCreate {
@@ -19561,12 +18265,6 @@ pub mod types {
         pub system_name: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&LldpNeighbor> for LldpNeighbor {
-        fn from(value: &LldpNeighbor) -> Self {
-            value.clone()
-        }
-    }
-
     impl LldpNeighbor {
         pub fn builder() -> builder::LldpNeighbor {
             Default::default()
@@ -19613,12 +18311,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&LldpNeighborResultsPage> for LldpNeighborResultsPage {
-        fn from(value: &LldpNeighborResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl LldpNeighborResultsPage {
@@ -19692,12 +18384,6 @@ pub mod types {
         pub rack_id: ::uuid::Uuid,
         /// Switch location where this loopback address is assigned.
         pub switch_location: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&LoopbackAddress> for LoopbackAddress {
-        fn from(value: &LoopbackAddress) -> Self {
-            value.clone()
-        }
     }
 
     impl LoopbackAddress {
@@ -19790,12 +18476,6 @@ pub mod types {
         pub switch_location: Name,
     }
 
-    impl ::std::convert::From<&LoopbackAddressCreate> for LoopbackAddressCreate {
-        fn from(value: &LoopbackAddressCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl LoopbackAddressCreate {
         pub fn builder() -> builder::LoopbackAddressCreate {
             Default::default()
@@ -19842,12 +18522,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&LoopbackAddressResultsPage> for LoopbackAddressResultsPage {
-        fn from(value: &LoopbackAddressResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl LoopbackAddressResultsPage {
@@ -19897,12 +18571,6 @@ pub mod types {
     impl ::std::convert::From<MacAddr> for ::std::string::String {
         fn from(value: MacAddr) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&MacAddr> for MacAddr {
-        fn from(value: &MacAddr) -> Self {
-            value.clone()
         }
     }
 
@@ -20009,12 +18677,6 @@ pub mod types {
         pub oid: ::std::option::Option<::std::vec::Vec<u8>>,
     }
 
-    impl ::std::convert::From<&ManagementAddress> for ManagementAddress {
-        fn from(value: &ManagementAddress) -> Self {
-            value.clone()
-        }
-    }
-
     impl ManagementAddress {
         pub fn builder() -> builder::ManagementAddress {
             Default::default()
@@ -20052,12 +18714,6 @@ pub mod types {
     pub struct Measurement {
         pub datum: Datum,
         pub timestamp: ::chrono::DateTime<::chrono::offset::Utc>,
-    }
-
-    impl ::std::convert::From<&Measurement> for Measurement {
-        fn from(value: &Measurement) -> Self {
-            value.clone()
-        }
     }
 
     impl Measurement {
@@ -20106,12 +18762,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&MeasurementResultsPage> for MeasurementResultsPage {
-        fn from(value: &MeasurementResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl MeasurementResultsPage {
@@ -20180,12 +18830,6 @@ pub mod types {
         /// The value represents an accumulation between two points in time.
         #[serde(rename = "cumulative")]
         Cumulative,
-    }
-
-    impl ::std::convert::From<&Self> for MetricType {
-        fn from(value: &MetricType) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for MetricType {
@@ -20267,12 +18911,6 @@ pub mod types {
         pub datum_type: DatumType,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub start_time: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
-    }
-
-    impl ::std::convert::From<&MissingDatum> for MissingDatum {
-        fn from(value: &MissingDatum) -> Self {
-            value.clone()
-        }
     }
 
     impl MissingDatum {
@@ -20396,12 +19034,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&MulticastGroup> for MulticastGroup {
-        fn from(value: &MulticastGroup) -> Self {
-            value.clone()
-        }
-    }
-
     impl MulticastGroup {
         pub fn builder() -> builder::MulticastGroup {
             Default::default()
@@ -20513,12 +19145,6 @@ pub mod types {
         pub source_ips: ::std::option::Option<::std::vec::Vec<::std::net::IpAddr>>,
     }
 
-    impl ::std::convert::From<&MulticastGroupCreate> for MulticastGroupCreate {
-        fn from(value: &MulticastGroupCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl MulticastGroupCreate {
         pub fn builder() -> builder::MulticastGroupCreate {
             Default::default()
@@ -20617,12 +19243,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&MulticastGroupMember> for MulticastGroupMember {
-        fn from(value: &MulticastGroupMember) -> Self {
-            value.clone()
-        }
-    }
-
     impl MulticastGroupMember {
         pub fn builder() -> builder::MulticastGroupMember {
             Default::default()
@@ -20661,12 +19281,6 @@ pub mod types {
     pub struct MulticastGroupMemberAdd {
         /// Name or ID of the instance to add to the multicast group
         pub instance: NameOrId,
-    }
-
-    impl ::std::convert::From<&MulticastGroupMemberAdd> for MulticastGroupMemberAdd {
-        fn from(value: &MulticastGroupMemberAdd) -> Self {
-            value.clone()
-        }
     }
 
     impl MulticastGroupMemberAdd {
@@ -20717,12 +19331,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&MulticastGroupMemberResultsPage> for MulticastGroupMemberResultsPage {
-        fn from(value: &MulticastGroupMemberResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl MulticastGroupMemberResultsPage {
         pub fn builder() -> builder::MulticastGroupMemberResultsPage {
             Default::default()
@@ -20769,12 +19377,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&MulticastGroupResultsPage> for MulticastGroupResultsPage {
-        fn from(value: &MulticastGroupResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl MulticastGroupResultsPage {
@@ -20854,12 +19456,6 @@ pub mod types {
         pub source_ips: ::std::option::Option<::std::vec::Vec<::std::net::IpAddr>>,
     }
 
-    impl ::std::convert::From<&MulticastGroupUpdate> for MulticastGroupUpdate {
-        fn from(value: &MulticastGroupUpdate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for MulticastGroupUpdate {
         fn default() -> Self {
             Self {
@@ -20923,12 +19519,6 @@ pub mod types {
     impl ::std::convert::From<Name> for ::std::string::String {
         fn from(value: Name) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&Name> for Name {
-        fn from(value: &Name) -> Self {
-            value.clone()
         }
     }
 
@@ -21026,12 +19616,6 @@ pub mod types {
     pub enum NameOrId {
         Id(::uuid::Uuid),
         Name(Name),
-    }
-
-    impl ::std::convert::From<&Self> for NameOrId {
-        fn from(value: &NameOrId) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::str::FromStr for NameOrId {
@@ -21152,12 +19736,6 @@ pub mod types {
         IdAscending,
     }
 
-    impl ::std::convert::From<&Self> for NameOrIdSortMode {
-        fn from(value: &NameOrIdSortMode) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for NameOrIdSortMode {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -21244,12 +19822,6 @@ pub mod types {
         /// sort in increasing order of "name"
         #[serde(rename = "name_ascending")]
         NameAscending,
-    }
-
-    impl ::std::convert::From<&Self> for NameSortMode {
-        fn from(value: &NameSortMode) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for NameSortMode {
@@ -21346,12 +19918,6 @@ pub mod types {
         IEEE802(::std::vec::Vec<u8>),
     }
 
-    impl ::std::convert::From<&Self> for NetworkAddress {
-        fn from(value: &NetworkAddress) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::net::IpAddr> for NetworkAddress {
         fn from(value: ::std::net::IpAddr) -> Self {
             Self::IpAddr(value)
@@ -21442,12 +20008,6 @@ pub mod types {
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub transit_ips: ::std::vec::Vec<IpNet>,
         pub vni: Vni,
-    }
-
-    impl ::std::convert::From<&NetworkInterface> for NetworkInterface {
-        fn from(value: &NetworkInterface) -> Self {
-            value.clone()
-        }
     }
 
     impl NetworkInterface {
@@ -21544,12 +20104,6 @@ pub mod types {
         Probe(::uuid::Uuid),
     }
 
-    impl ::std::convert::From<&Self> for NetworkInterfaceKind {
-        fn from(value: &NetworkInterfaceKind) -> Self {
-            value.clone()
-        }
-    }
-
     /// The result of a successful OxQL query.
     ///
     /// <details><summary>JSON schema</summary>
@@ -21580,12 +20134,6 @@ pub mod types {
     pub struct OxqlQueryResult {
         /// Tables resulting from the query, each containing timeseries.
         pub tables: ::std::vec::Vec<OxqlTable>,
-    }
-
-    impl ::std::convert::From<&OxqlQueryResult> for OxqlQueryResult {
-        fn from(value: &OxqlQueryResult) -> Self {
-            value.clone()
-        }
     }
 
     impl OxqlQueryResult {
@@ -21637,12 +20185,6 @@ pub mod types {
         pub timeseries: ::std::vec::Vec<Timeseries>,
     }
 
-    impl ::std::convert::From<&OxqlTable> for OxqlTable {
-        fn from(value: &OxqlTable) -> Self {
-            value.clone()
-        }
-    }
-
     impl OxqlTable {
         pub fn builder() -> builder::OxqlTable {
             Default::default()
@@ -21684,12 +20226,6 @@ pub mod types {
         Ascending,
         #[serde(rename = "descending")]
         Descending,
-    }
-
-    impl ::std::convert::From<&Self> for PaginationOrder {
-        fn from(value: &PaginationOrder) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for PaginationOrder {
@@ -21773,12 +20309,6 @@ pub mod types {
     impl ::std::convert::From<Password> for ::std::string::String {
         fn from(value: Password) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&Password> for Password {
-        fn from(value: &Password) -> Self {
-            value.clone()
         }
     }
 
@@ -21935,12 +20465,6 @@ pub mod types {
         pub vendor: ::std::string::String,
     }
 
-    impl ::std::convert::From<&PhysicalDisk> for PhysicalDisk {
-        fn from(value: &PhysicalDisk) -> Self {
-            value.clone()
-        }
-    }
-
     impl PhysicalDisk {
         pub fn builder() -> builder::PhysicalDisk {
             Default::default()
@@ -21980,12 +20504,6 @@ pub mod types {
         M2,
         #[serde(rename = "u2")]
         U2,
-    }
-
-    impl ::std::convert::From<&Self> for PhysicalDiskKind {
-        fn from(value: &PhysicalDiskKind) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for PhysicalDiskKind {
@@ -22101,12 +20619,6 @@ pub mod types {
         Expunged,
     }
 
-    impl ::std::convert::From<&Self> for PhysicalDiskPolicy {
-        fn from(value: &PhysicalDiskPolicy) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for PhysicalDiskPolicy {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -22194,12 +20706,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&PhysicalDiskResultsPage> for PhysicalDiskResultsPage {
-        fn from(value: &PhysicalDiskResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl PhysicalDiskResultsPage {
         pub fn builder() -> builder::PhysicalDiskResultsPage {
             Default::default()
@@ -22261,12 +20767,6 @@ pub mod types {
         /// hardware may be reused, but it will be treated as a brand-new disk.)
         #[serde(rename = "decommissioned")]
         Decommissioned,
-    }
-
-    impl ::std::convert::From<&Self> for PhysicalDiskState {
-        fn from(value: &PhysicalDiskState) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for PhysicalDiskState {
@@ -22347,12 +20847,6 @@ pub mod types {
         pub status: PingStatus,
     }
 
-    impl ::std::convert::From<&Ping> for Ping {
-        fn from(value: &Ping) -> Self {
-            value.clone()
-        }
-    }
-
     impl Ping {
         pub fn builder() -> builder::Ping {
             Default::default()
@@ -22388,12 +20882,6 @@ pub mod types {
     pub enum PingStatus {
         #[serde(rename = "ok")]
         Ok,
-    }
-
-    impl ::std::convert::From<&Self> for PingStatus {
-        fn from(value: &PingStatus) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for PingStatus {
@@ -22490,12 +20978,6 @@ pub mod types {
         pub values: ::std::vec::Vec<Values>,
     }
 
-    impl ::std::convert::From<&Points> for Points {
-        fn from(value: &Points) -> Self {
-            value.clone()
-        }
-    }
-
     impl Points {
         pub fn builder() -> builder::Points {
             Default::default()
@@ -22575,12 +21057,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Probe> for Probe {
-        fn from(value: &Probe) -> Self {
-            value.clone()
-        }
-    }
-
     impl Probe {
         pub fn builder() -> builder::Probe {
             Default::default()
@@ -22640,12 +21116,6 @@ pub mod types {
         pub sled: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&ProbeCreate> for ProbeCreate {
-        fn from(value: &ProbeCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ProbeCreate {
         pub fn builder() -> builder::ProbeCreate {
             Default::default()
@@ -22697,12 +21167,6 @@ pub mod types {
         pub last_port: u16,
     }
 
-    impl ::std::convert::From<&ProbeExternalIp> for ProbeExternalIp {
-        fn from(value: &ProbeExternalIp) -> Self {
-            value.clone()
-        }
-    }
-
     impl ProbeExternalIp {
         pub fn builder() -> builder::ProbeExternalIp {
             Default::default()
@@ -22744,12 +21208,6 @@ pub mod types {
         Floating,
         #[serde(rename = "ephemeral")]
         Ephemeral,
-    }
-
-    impl ::std::convert::From<&Self> for ProbeExternalIpKind {
-        fn from(value: &ProbeExternalIpKind) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for ProbeExternalIpKind {
@@ -22849,12 +21307,6 @@ pub mod types {
         pub sled: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&ProbeInfo> for ProbeInfo {
-        fn from(value: &ProbeInfo) -> Self {
-            value.clone()
-        }
-    }
-
     impl ProbeInfo {
         pub fn builder() -> builder::ProbeInfo {
             Default::default()
@@ -22901,12 +21353,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&ProbeInfoResultsPage> for ProbeInfoResultsPage {
-        fn from(value: &ProbeInfoResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl ProbeInfoResultsPage {
@@ -22980,12 +21426,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Project> for Project {
-        fn from(value: &Project) -> Self {
-            value.clone()
-        }
-    }
-
     impl Project {
         pub fn builder() -> builder::Project {
             Default::default()
@@ -23021,12 +21461,6 @@ pub mod types {
     pub struct ProjectCreate {
         pub description: ::std::string::String,
         pub name: Name,
-    }
-
-    impl ::std::convert::From<&ProjectCreate> for ProjectCreate {
-        fn from(value: &ProjectCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl ProjectCreate {
@@ -23077,12 +21511,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&ProjectResultsPage> for ProjectResultsPage {
-        fn from(value: &ProjectResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl ProjectResultsPage {
         pub fn builder() -> builder::ProjectResultsPage {
             Default::default()
@@ -23127,12 +21555,6 @@ pub mod types {
         LimitedCollaborator,
         #[serde(rename = "viewer")]
         Viewer,
-    }
-
-    impl ::std::convert::From<&Self> for ProjectRole {
-        fn from(value: &ProjectRole) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for ProjectRole {
@@ -23222,12 +21644,6 @@ pub mod types {
         pub role_assignments: ::std::vec::Vec<ProjectRoleRoleAssignment>,
     }
 
-    impl ::std::convert::From<&ProjectRolePolicy> for ProjectRolePolicy {
-        fn from(value: &ProjectRolePolicy) -> Self {
-            value.clone()
-        }
-    }
-
     impl ProjectRolePolicy {
         pub fn builder() -> builder::ProjectRolePolicy {
             Default::default()
@@ -23280,12 +21696,6 @@ pub mod types {
         pub role_name: ProjectRole,
     }
 
-    impl ::std::convert::From<&ProjectRoleRoleAssignment> for ProjectRoleRoleAssignment {
-        fn from(value: &ProjectRoleRoleAssignment) -> Self {
-            value.clone()
-        }
-    }
-
     impl ProjectRoleRoleAssignment {
         pub fn builder() -> builder::ProjectRoleRoleAssignment {
             Default::default()
@@ -23333,12 +21743,6 @@ pub mod types {
         pub description: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&ProjectUpdate> for ProjectUpdate {
-        fn from(value: &ProjectUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for ProjectUpdate {
@@ -23443,12 +21847,6 @@ pub mod types {
         pub p: f64,
     }
 
-    impl ::std::convert::From<&Quantile> for Quantile {
-        fn from(value: &Quantile) -> Self {
-            value.clone()
-        }
-    }
-
     impl Quantile {
         pub fn builder() -> builder::Quantile {
             Default::default()
@@ -23501,12 +21899,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Rack> for Rack {
-        fn from(value: &Rack) -> Self {
-            value.clone()
-        }
-    }
-
     impl Rack {
         pub fn builder() -> builder::Rack {
             Default::default()
@@ -23553,12 +21945,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&RackResultsPage> for RackResultsPage {
-        fn from(value: &RackResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl RackResultsPage {
@@ -23634,12 +22020,6 @@ pub mod types {
         pub vid: ::std::option::Option<u16>,
     }
 
-    impl ::std::convert::From<&Route> for Route {
-        fn from(value: &Route) -> Self {
-            value.clone()
-        }
-    }
-
     impl Route {
         pub fn builder() -> builder::Route {
             Default::default()
@@ -23690,12 +22070,6 @@ pub mod types {
         pub link_name: Name,
         /// The set of routes assigned to a switch port.
         pub routes: ::std::vec::Vec<Route>,
-    }
-
-    impl ::std::convert::From<&RouteConfig> for RouteConfig {
-        fn from(value: &RouteConfig) -> Self {
-            value.clone()
-        }
     }
 
     impl RouteConfig {
@@ -23823,12 +22197,6 @@ pub mod types {
         /// Route applies to traffic destined for the specified VPC subnet
         #[serde(rename = "subnet")]
         Subnet(Name),
-    }
-
-    impl ::std::convert::From<&Self> for RouteDestination {
-        fn from(value: &RouteDestination) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::convert::From<::std::net::IpAddr> for RouteDestination {
@@ -23992,12 +22360,6 @@ pub mod types {
         Drop,
     }
 
-    impl ::std::convert::From<&Self> for RouteTarget {
-        fn from(value: &RouteTarget) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::net::IpAddr> for RouteTarget {
         fn from(value: ::std::net::IpAddr) -> Self {
             Self::Ip(value)
@@ -24116,12 +22478,6 @@ pub mod types {
         pub vpc_router_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&RouterRoute> for RouterRoute {
-        fn from(value: &RouterRoute) -> Self {
-            value.clone()
-        }
-    }
-
     impl RouterRoute {
         pub fn builder() -> builder::RouterRoute {
             Default::default()
@@ -24181,12 +22537,6 @@ pub mod types {
         pub name: Name,
         /// The location that matched packets should be forwarded to.
         pub target: RouteTarget,
-    }
-
-    impl ::std::convert::From<&RouterRouteCreate> for RouterRouteCreate {
-        fn from(value: &RouterRouteCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl RouterRouteCreate {
@@ -24282,12 +22632,6 @@ pub mod types {
         Custom,
     }
 
-    impl ::std::convert::From<&Self> for RouterRouteKind {
-        fn from(value: &RouterRouteKind) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for RouterRouteKind {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -24379,12 +22723,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&RouterRouteResultsPage> for RouterRouteResultsPage {
-        fn from(value: &RouterRouteResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl RouterRouteResultsPage {
         pub fn builder() -> builder::RouterRouteResultsPage {
             Default::default()
@@ -24458,12 +22796,6 @@ pub mod types {
         pub name: ::std::option::Option<Name>,
         /// The location that matched packets should be forwarded to.
         pub target: RouteTarget,
-    }
-
-    impl ::std::convert::From<&RouterRouteUpdate> for RouterRouteUpdate {
-        fn from(value: &RouterRouteUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl RouterRouteUpdate {
@@ -24602,12 +22934,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&SamlIdentityProvider> for SamlIdentityProvider {
-        fn from(value: &SamlIdentityProvider) -> Self {
-            value.clone()
-        }
-    }
-
     impl SamlIdentityProvider {
         pub fn builder() -> builder::SamlIdentityProvider {
             Default::default()
@@ -24727,12 +23053,6 @@ pub mod types {
         pub technical_contact_email: ::std::string::String,
     }
 
-    impl ::std::convert::From<&SamlIdentityProviderCreate> for SamlIdentityProviderCreate {
-        fn from(value: &SamlIdentityProviderCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl SamlIdentityProviderCreate {
         pub fn builder() -> builder::SamlIdentityProviderCreate {
             Default::default()
@@ -24778,12 +23098,6 @@ pub mod types {
         pub time_created: ::chrono::DateTime<::chrono::offset::Utc>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub time_expires: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
-    }
-
-    impl ::std::convert::From<&ScimClientBearerToken> for ScimClientBearerToken {
-        fn from(value: &ScimClientBearerToken) -> Self {
-            value.clone()
-        }
     }
 
     impl ScimClientBearerToken {
@@ -24841,12 +23155,6 @@ pub mod types {
         pub time_expires: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     }
 
-    impl ::std::convert::From<&ScimClientBearerTokenValue> for ScimClientBearerTokenValue {
-        fn from(value: &ScimClientBearerTokenValue) -> Self {
-            value.clone()
-        }
-    }
-
     impl ScimClientBearerTokenValue {
         pub fn builder() -> builder::ScimClientBearerTokenValue {
             Default::default()
@@ -24889,12 +23197,6 @@ pub mod types {
         /// Path MTU discovery and better cope with fragmentation issues.
         /// Otherwise all inbound ICMP traffic will be dropped.
         pub enabled: bool,
-    }
-
-    impl ::std::convert::From<&ServiceIcmpConfig> for ServiceIcmpConfig {
-        fn from(value: &ServiceIcmpConfig) -> Self {
-            value.clone()
-        }
     }
 
     impl ServiceIcmpConfig {
@@ -24940,12 +23242,6 @@ pub mod types {
         /// This certificate is intended for access to the external API.
         #[serde(rename = "external_api")]
         ExternalApi,
-    }
-
-    impl ::std::convert::From<&Self> for ServiceUsingCertificate {
-        fn from(value: &ServiceUsingCertificate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for ServiceUsingCertificate {
@@ -25025,12 +23321,6 @@ pub mod types {
         pub system_version: SetTargetReleaseParamsSystemVersion,
     }
 
-    impl ::std::convert::From<&SetTargetReleaseParams> for SetTargetReleaseParams {
-        fn from(value: &SetTargetReleaseParams) -> Self {
-            value.clone()
-        }
-    }
-
     impl SetTargetReleaseParams {
         pub fn builder() -> builder::SetTargetReleaseParams {
             Default::default()
@@ -25076,14 +23366,6 @@ pub mod types {
     impl ::std::convert::From<SetTargetReleaseParamsSystemVersion> for ::std::string::String {
         fn from(value: SetTargetReleaseParamsSystemVersion) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&SetTargetReleaseParamsSystemVersion>
-        for SetTargetReleaseParamsSystemVersion
-    {
-        fn from(value: &SetTargetReleaseParamsSystemVersion) -> Self {
-            value.clone()
         }
     }
 
@@ -25267,12 +23549,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Silo> for Silo {
-        fn from(value: &Silo) -> Self {
-            value.clone()
-        }
-    }
-
     impl Silo {
         pub fn builder() -> builder::Silo {
             Default::default()
@@ -25319,12 +23595,6 @@ pub mod types {
         pub silo_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&SiloAuthSettings> for SiloAuthSettings {
-        fn from(value: &SiloAuthSettings) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloAuthSettings {
         pub fn builder() -> builder::SiloAuthSettings {
             Default::default()
@@ -25363,12 +23633,6 @@ pub mod types {
         /// Maximum lifetime of a device token in seconds. If set to null, users
         /// will be able to create tokens that do not expire.
         pub device_token_max_ttl_seconds: ::std::option::Option<::std::num::NonZeroU32>,
-    }
-
-    impl ::std::convert::From<&SiloAuthSettingsUpdate> for SiloAuthSettingsUpdate {
-        fn from(value: &SiloAuthSettingsUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl SiloAuthSettingsUpdate {
@@ -25494,12 +23758,6 @@ pub mod types {
         pub tls_certificates: ::std::vec::Vec<CertificateCreate>,
     }
 
-    impl ::std::convert::From<&SiloCreate> for SiloCreate {
-        fn from(value: &SiloCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloCreate {
         pub fn builder() -> builder::SiloCreate {
             Default::default()
@@ -25577,12 +23835,6 @@ pub mod types {
         /// from the same authentication provider.
         #[serde(rename = "saml_scim")]
         SamlScim,
-    }
-
-    impl ::std::convert::From<&Self> for SiloIdentityMode {
-        fn from(value: &SiloIdentityMode) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SiloIdentityMode {
@@ -25736,12 +23988,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&SiloIpPool> for SiloIpPool {
-        fn from(value: &SiloIpPool) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloIpPool {
         pub fn builder() -> builder::SiloIpPool {
             Default::default()
@@ -25788,12 +24034,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SiloIpPoolResultsPage> for SiloIpPoolResultsPage {
-        fn from(value: &SiloIpPoolResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SiloIpPoolResultsPage {
@@ -25861,12 +24101,6 @@ pub mod types {
         pub storage: ByteCount,
     }
 
-    impl ::std::convert::From<&SiloQuotas> for SiloQuotas {
-        fn from(value: &SiloQuotas) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloQuotas {
         pub fn builder() -> builder::SiloQuotas {
             Default::default()
@@ -25929,12 +24163,6 @@ pub mod types {
         pub storage: ByteCount,
     }
 
-    impl ::std::convert::From<&SiloQuotasCreate> for SiloQuotasCreate {
-        fn from(value: &SiloQuotasCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloQuotasCreate {
         pub fn builder() -> builder::SiloQuotasCreate {
             Default::default()
@@ -25981,12 +24209,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SiloQuotasResultsPage> for SiloQuotasResultsPage {
-        fn from(value: &SiloQuotasResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SiloQuotasResultsPage {
@@ -26068,12 +24290,6 @@ pub mod types {
         pub storage: ::std::option::Option<ByteCount>,
     }
 
-    impl ::std::convert::From<&SiloQuotasUpdate> for SiloQuotasUpdate {
-        fn from(value: &SiloQuotasUpdate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for SiloQuotasUpdate {
         fn default() -> Self {
             Self {
@@ -26132,12 +24348,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&SiloResultsPage> for SiloResultsPage {
-        fn from(value: &SiloResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloResultsPage {
         pub fn builder() -> builder::SiloResultsPage {
             Default::default()
@@ -26182,12 +24392,6 @@ pub mod types {
         LimitedCollaborator,
         #[serde(rename = "viewer")]
         Viewer,
-    }
-
-    impl ::std::convert::From<&Self> for SiloRole {
-        fn from(value: &SiloRole) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SiloRole {
@@ -26277,12 +24481,6 @@ pub mod types {
         pub role_assignments: ::std::vec::Vec<SiloRoleRoleAssignment>,
     }
 
-    impl ::std::convert::From<&SiloRolePolicy> for SiloRolePolicy {
-        fn from(value: &SiloRolePolicy) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloRolePolicy {
         pub fn builder() -> builder::SiloRolePolicy {
             Default::default()
@@ -26333,12 +24531,6 @@ pub mod types {
         pub identity_id: ::uuid::Uuid,
         pub identity_type: IdentityType,
         pub role_name: SiloRole,
-    }
-
-    impl ::std::convert::From<&SiloRoleRoleAssignment> for SiloRoleRoleAssignment {
-        fn from(value: &SiloRoleRoleAssignment) -> Self {
-            value.clone()
-        }
     }
 
     impl SiloRoleRoleAssignment {
@@ -26409,12 +24601,6 @@ pub mod types {
         pub silo_name: Name,
     }
 
-    impl ::std::convert::From<&SiloUtilization> for SiloUtilization {
-        fn from(value: &SiloUtilization) -> Self {
-            value.clone()
-        }
-    }
-
     impl SiloUtilization {
         pub fn builder() -> builder::SiloUtilization {
             Default::default()
@@ -26461,12 +24647,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SiloUtilizationResultsPage> for SiloUtilizationResultsPage {
-        fn from(value: &SiloUtilizationResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SiloUtilizationResultsPage {
@@ -26577,12 +24757,6 @@ pub mod types {
         pub usable_physical_ram: ByteCount,
     }
 
-    impl ::std::convert::From<&Sled> for Sled {
-        fn from(value: &Sled) -> Self {
-            value.clone()
-        }
-    }
-
     impl Sled {
         pub fn builder() -> builder::Sled {
             Default::default()
@@ -26614,12 +24788,6 @@ pub mod types {
     )]
     pub struct SledId {
         pub id: ::uuid::Uuid,
-    }
-
-    impl ::std::convert::From<&SledId> for SledId {
-        fn from(value: &SledId) -> Self {
-            value.clone()
-        }
     }
 
     impl SledId {
@@ -26722,12 +24890,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&SledInstance> for SledInstance {
-        fn from(value: &SledInstance) -> Self {
-            value.clone()
-        }
-    }
-
     impl SledInstance {
         pub fn builder() -> builder::SledInstance {
             Default::default()
@@ -26774,12 +24936,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SledInstanceResultsPage> for SledInstanceResultsPage {
-        fn from(value: &SledInstanceResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SledInstanceResultsPage {
@@ -26857,12 +25013,6 @@ pub mod types {
         Expunged,
     }
 
-    impl ::std::convert::From<&Self> for SledPolicy {
-        fn from(value: &SledPolicy) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<SledProvisionPolicy> for SledPolicy {
         fn from(value: SledProvisionPolicy) -> Self {
             Self::InService(value)
@@ -26924,12 +25074,6 @@ pub mod types {
         /// on this sled unless manually migrated off.
         #[serde(rename = "non_provisionable")]
         NonProvisionable,
-    }
-
-    impl ::std::convert::From<&Self> for SledProvisionPolicy {
-        fn from(value: &SledProvisionPolicy) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SledProvisionPolicy {
@@ -27009,12 +25153,6 @@ pub mod types {
         pub state: SledProvisionPolicy,
     }
 
-    impl ::std::convert::From<&SledProvisionPolicyParams> for SledProvisionPolicyParams {
-        fn from(value: &SledProvisionPolicyParams) -> Self {
-            value.clone()
-        }
-    }
-
     impl SledProvisionPolicyParams {
         pub fn builder() -> builder::SledProvisionPolicyParams {
             Default::default()
@@ -27064,12 +25202,6 @@ pub mod types {
         pub old_state: SledProvisionPolicy,
     }
 
-    impl ::std::convert::From<&SledProvisionPolicyResponse> for SledProvisionPolicyResponse {
-        fn from(value: &SledProvisionPolicyResponse) -> Self {
-            value.clone()
-        }
-    }
-
     impl SledProvisionPolicyResponse {
         pub fn builder() -> builder::SledProvisionPolicyResponse {
             Default::default()
@@ -27116,12 +25248,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SledResultsPage> for SledResultsPage {
-        fn from(value: &SledResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SledResultsPage {
@@ -27184,12 +25310,6 @@ pub mod types {
         /// hardware may be reused, but it will be treated as a brand-new sled.)
         #[serde(rename = "decommissioned")]
         Decommissioned,
-    }
-
-    impl ::std::convert::From<&Self> for SledState {
-        fn from(value: &SledState) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SledState {
@@ -27324,12 +25444,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Snapshot> for Snapshot {
-        fn from(value: &Snapshot) -> Self {
-            value.clone()
-        }
-    }
-
     impl Snapshot {
         pub fn builder() -> builder::Snapshot {
             Default::default()
@@ -27376,12 +25490,6 @@ pub mod types {
         /// The disk to be snapshotted
         pub disk: NameOrId,
         pub name: Name,
-    }
-
-    impl ::std::convert::From<&SnapshotCreate> for SnapshotCreate {
-        fn from(value: &SnapshotCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl SnapshotCreate {
@@ -27432,12 +25540,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&SnapshotResultsPage> for SnapshotResultsPage {
-        fn from(value: &SnapshotResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl SnapshotResultsPage {
         pub fn builder() -> builder::SnapshotResultsPage {
             Default::default()
@@ -27482,12 +25584,6 @@ pub mod types {
         Faulted,
         #[serde(rename = "destroyed")]
         Destroyed,
-    }
-
-    impl ::std::convert::From<&Self> for SnapshotState {
-        fn from(value: &SnapshotState) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SnapshotState {
@@ -27620,12 +25716,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&SshKey> for SshKey {
-        fn from(value: &SshKey) -> Self {
-            value.clone()
-        }
-    }
-
     impl SshKey {
         pub fn builder() -> builder::SshKey {
             Default::default()
@@ -27669,12 +25759,6 @@ pub mod types {
         pub name: Name,
         /// SSH public key, e.g., `"ssh-ed25519 AAAAC3NzaC..."`
         pub public_key: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&SshKeyCreate> for SshKeyCreate {
-        fn from(value: &SshKeyCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl SshKeyCreate {
@@ -27725,12 +25809,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&SshKeyResultsPage> for SshKeyResultsPage {
-        fn from(value: &SshKeyResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl SshKeyResultsPage {
         pub fn builder() -> builder::SshKeyResultsPage {
             Default::default()
@@ -27763,12 +25841,6 @@ pub mod types {
         /// User comment for the support bundle
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub user_comment: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SupportBundleCreate> for SupportBundleCreate {
-        fn from(value: &SupportBundleCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for SupportBundleCreate {
@@ -27843,12 +25915,6 @@ pub mod types {
         pub user_comment: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&SupportBundleInfo> for SupportBundleInfo {
-        fn from(value: &SupportBundleInfo) -> Self {
-            value.clone()
-        }
-    }
-
     impl SupportBundleInfo {
         pub fn builder() -> builder::SupportBundleInfo {
             Default::default()
@@ -27895,12 +25961,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SupportBundleInfoResultsPage> for SupportBundleInfoResultsPage {
-        fn from(value: &SupportBundleInfoResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SupportBundleInfoResultsPage {
@@ -27998,12 +26058,6 @@ pub mod types {
         Active,
     }
 
-    impl ::std::convert::From<&Self> for SupportBundleState {
-        fn from(value: &SupportBundleState) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for SupportBundleState {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -28081,12 +26135,6 @@ pub mod types {
         pub user_comment: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&SupportBundleUpdate> for SupportBundleUpdate {
-        fn from(value: &SupportBundleUpdate) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for SupportBundleUpdate {
         fn default() -> Self {
             Self {
@@ -28161,12 +26209,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Switch> for Switch {
-        fn from(value: &Switch) -> Self {
-            value.clone()
-        }
-    }
-
     impl Switch {
         pub fn builder() -> builder::Switch {
             Default::default()
@@ -28213,12 +26255,6 @@ pub mod types {
         pub history: ::std::collections::HashMap<::std::string::String, BgpMessageHistory>,
         /// Switch this message history is associated with.
         pub switch: SwitchLocation,
-    }
-
-    impl ::std::convert::From<&SwitchBgpHistory> for SwitchBgpHistory {
-        fn from(value: &SwitchBgpHistory) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchBgpHistory {
@@ -28296,12 +26332,6 @@ pub mod types {
         pub v6_enabled: bool,
     }
 
-    impl ::std::convert::From<&SwitchInterfaceConfig> for SwitchInterfaceConfig {
-        fn from(value: &SwitchInterfaceConfig) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchInterfaceConfig {
         pub fn builder() -> builder::SwitchInterfaceConfig {
             Default::default()
@@ -28362,12 +26392,6 @@ pub mod types {
         pub link_name: Name,
         /// Whether or not IPv6 is enabled.
         pub v6_enabled: bool,
-    }
-
-    impl ::std::convert::From<&SwitchInterfaceConfigCreate> for SwitchInterfaceConfigCreate {
-        fn from(value: &SwitchInterfaceConfigCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchInterfaceConfigCreate {
@@ -28463,12 +26487,6 @@ pub mod types {
         Loopback,
     }
 
-    impl ::std::convert::From<&Self> for SwitchInterfaceKind {
-        fn from(value: &SwitchInterfaceKind) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<u16> for SwitchInterfaceKind {
         fn from(value: u16) -> Self {
             Self::Vlan(value)
@@ -28539,12 +26557,6 @@ pub mod types {
         /// specific to any particular port.
         #[serde(rename = "loopback")]
         Loopback,
-    }
-
-    impl ::std::convert::From<&Self> for SwitchInterfaceKind2 {
-        fn from(value: &SwitchInterfaceKind2) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SwitchInterfaceKind2 {
@@ -28620,12 +26632,6 @@ pub mod types {
         }
     }
 
-    impl ::std::convert::From<&SwitchLinkState> for SwitchLinkState {
-        fn from(value: &SwitchLinkState) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::serde_json::Value> for SwitchLinkState {
         fn from(value: ::serde_json::Value) -> Self {
             Self(value)
@@ -28678,12 +26684,6 @@ pub mod types {
         /// Switch in lower slot
         #[serde(rename = "switch1")]
         Switch1,
-    }
-
-    impl ::std::convert::From<&Self> for SwitchLocation {
-        fn from(value: &SwitchLocation) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SwitchLocation {
@@ -28800,12 +26800,6 @@ pub mod types {
         pub switch_location: ::std::string::String,
     }
 
-    impl ::std::convert::From<&SwitchPort> for SwitchPort {
-        fn from(value: &SwitchPort) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPort {
         pub fn builder() -> builder::SwitchPort {
             Default::default()
@@ -28907,12 +26901,6 @@ pub mod types {
         pub vlan_id: ::std::option::Option<u16>,
     }
 
-    impl ::std::convert::From<&SwitchPortAddressView> for SwitchPortAddressView {
-        fn from(value: &SwitchPortAddressView) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPortAddressView {
         pub fn builder() -> builder::SwitchPortAddressView {
             Default::default()
@@ -28950,12 +26938,6 @@ pub mod types {
     pub struct SwitchPortApplySettings {
         /// A name or id to use when applying switch port settings.
         pub port_settings: NameOrId,
-    }
-
-    impl ::std::convert::From<&SwitchPortApplySettings> for SwitchPortApplySettings {
-        fn from(value: &SwitchPortApplySettings) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchPortApplySettings {
@@ -29006,12 +26988,6 @@ pub mod types {
         pub port_settings_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&SwitchPortConfig> for SwitchPortConfig {
-        fn from(value: &SwitchPortConfig) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPortConfig {
         pub fn builder() -> builder::SwitchPortConfig {
             Default::default()
@@ -29048,12 +27024,6 @@ pub mod types {
     pub struct SwitchPortConfigCreate {
         /// Link geometry for the switch port.
         pub geometry: SwitchPortGeometry,
-    }
-
-    impl ::std::convert::From<&SwitchPortConfigCreate> for SwitchPortConfigCreate {
-        fn from(value: &SwitchPortConfigCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchPortConfigCreate {
@@ -29121,12 +27091,6 @@ pub mod types {
         /// The port contains four SFP28 links each with one lane.
         #[serde(rename = "sfp28x4")]
         Sfp28x4,
-    }
-
-    impl ::std::convert::From<&Self> for SwitchPortGeometry {
-        fn from(value: &SwitchPortGeometry) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SwitchPortGeometry {
@@ -29235,12 +27199,6 @@ pub mod types {
         /// The port contains four SFP28 links each with one lane.
         #[serde(rename = "sfp28x4")]
         Sfp28x4,
-    }
-
-    impl ::std::convert::From<&Self> for SwitchPortGeometry2 {
-        fn from(value: &SwitchPortGeometry2) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SwitchPortGeometry2 {
@@ -29419,12 +27377,6 @@ pub mod types {
         pub tx_eq_config: ::std::option::Option<TxEqConfig2>,
     }
 
-    impl ::std::convert::From<&SwitchPortLinkConfig> for SwitchPortLinkConfig {
-        fn from(value: &SwitchPortLinkConfig) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPortLinkConfig {
         pub fn builder() -> builder::SwitchPortLinkConfig {
             Default::default()
@@ -29471,12 +27423,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SwitchPortResultsPage> for SwitchPortResultsPage {
-        fn from(value: &SwitchPortResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchPortResultsPage {
@@ -29572,12 +27518,6 @@ pub mod types {
         /// reachable over an 802.1Q tagged L2 segment.
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub vlan_id: ::std::option::Option<u16>,
-    }
-
-    impl ::std::convert::From<&SwitchPortRouteConfig> for SwitchPortRouteConfig {
-        fn from(value: &SwitchPortRouteConfig) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchPortRouteConfig {
@@ -29738,12 +27678,6 @@ pub mod types {
         pub vlan_interfaces: ::std::vec::Vec<SwitchVlanInterfaceConfig>,
     }
 
-    impl ::std::convert::From<&SwitchPortSettings> for SwitchPortSettings {
-        fn from(value: &SwitchPortSettings) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPortSettings {
         pub fn builder() -> builder::SwitchPortSettings {
             Default::default()
@@ -29854,12 +27788,6 @@ pub mod types {
         pub routes: ::std::vec::Vec<RouteConfig>,
     }
 
-    impl ::std::convert::From<&SwitchPortSettingsCreate> for SwitchPortSettingsCreate {
-        fn from(value: &SwitchPortSettingsCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPortSettingsCreate {
         pub fn builder() -> builder::SwitchPortSettingsCreate {
             Default::default()
@@ -29910,12 +27838,6 @@ pub mod types {
         pub port_settings_group_id: ::uuid::Uuid,
         /// The id of a port settings object referencing a port settings group.
         pub port_settings_id: ::uuid::Uuid,
-    }
-
-    impl ::std::convert::From<&SwitchPortSettingsGroups> for SwitchPortSettingsGroups {
-        fn from(value: &SwitchPortSettingsGroups) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchPortSettingsGroups {
@@ -29991,12 +27913,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&SwitchPortSettingsIdentity> for SwitchPortSettingsIdentity {
-        fn from(value: &SwitchPortSettingsIdentity) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPortSettingsIdentity {
         pub fn builder() -> builder::SwitchPortSettingsIdentity {
             Default::default()
@@ -30045,14 +27961,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&SwitchPortSettingsIdentityResultsPage>
-        for SwitchPortSettingsIdentityResultsPage
-    {
-        fn from(value: &SwitchPortSettingsIdentityResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchPortSettingsIdentityResultsPage {
         pub fn builder() -> builder::SwitchPortSettingsIdentityResultsPage {
             Default::default()
@@ -30099,12 +28007,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&SwitchResultsPage> for SwitchResultsPage {
-        fn from(value: &SwitchResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl SwitchResultsPage {
@@ -30158,12 +28060,6 @@ pub mod types {
         pub vlan_id: u16,
     }
 
-    impl ::std::convert::From<&SwitchVlanInterfaceConfig> for SwitchVlanInterfaceConfig {
-        fn from(value: &SwitchVlanInterfaceConfig) -> Self {
-            value.clone()
-        }
-    }
-
     impl SwitchVlanInterfaceConfig {
         pub fn builder() -> builder::SwitchVlanInterfaceConfig {
             Default::default()
@@ -30205,12 +28101,6 @@ pub mod types {
         CpusProvisioned,
         #[serde(rename = "ram_provisioned")]
         RamProvisioned,
-    }
-
-    impl ::std::convert::From<&Self> for SystemMetricName {
-        fn from(value: &SystemMetricName) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for SystemMetricName {
@@ -30297,14 +28187,6 @@ pub mod types {
     impl ::std::convert::From<SystemUpdateRepositoryViewSystemVersion> for ::std::string::String {
         fn from(value: SystemUpdateRepositoryViewSystemVersion) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&SystemUpdateRepositoryViewSystemVersion>
-        for SystemUpdateRepositoryViewSystemVersion
-    {
-        fn from(value: &SystemUpdateRepositoryViewSystemVersion) -> Self {
-            value.clone()
         }
     }
 
@@ -30411,12 +28293,6 @@ pub mod types {
         pub version: TargetReleaseVersion,
     }
 
-    impl ::std::convert::From<&TargetRelease> for TargetRelease {
-        fn from(value: &TargetRelease) -> Self {
-            value.clone()
-        }
-    }
-
     impl TargetRelease {
         pub fn builder() -> builder::TargetRelease {
             Default::default()
@@ -30461,12 +28337,6 @@ pub mod types {
     impl ::std::convert::From<TargetReleaseVersion> for ::std::string::String {
         fn from(value: TargetReleaseVersion) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&TargetReleaseVersion> for TargetReleaseVersion {
-        fn from(value: &TargetReleaseVersion) -> Self {
-            value.clone()
         }
     }
 
@@ -30584,12 +28454,6 @@ pub mod types {
         TimeAndIdDescending,
     }
 
-    impl ::std::convert::From<&Self> for TimeAndIdSortMode {
-        fn from(value: &TimeAndIdSortMode) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::fmt::Display for TimeAndIdSortMode {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
@@ -30674,12 +28538,6 @@ pub mod types {
         pub points: Points,
     }
 
-    impl ::std::convert::From<&Timeseries> for Timeseries {
-        fn from(value: &Timeseries) -> Self {
-            value.clone()
-        }
-    }
-
     impl Timeseries {
         pub fn builder() -> builder::Timeseries {
             Default::default()
@@ -30716,12 +28574,6 @@ pub mod types {
     pub struct TimeseriesDescription {
         pub metric: ::std::string::String,
         pub target: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&TimeseriesDescription> for TimeseriesDescription {
-        fn from(value: &TimeseriesDescription) -> Self {
-            value.clone()
-        }
     }
 
     impl TimeseriesDescription {
@@ -30772,12 +28624,6 @@ pub mod types {
     impl ::std::convert::From<TimeseriesName> for ::std::string::String {
         fn from(value: TimeseriesName) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&TimeseriesName> for TimeseriesName {
-        fn from(value: &TimeseriesName) -> Self {
-            value.clone()
         }
     }
 
@@ -30869,12 +28715,6 @@ pub mod types {
         pub query: ::std::string::String,
     }
 
-    impl ::std::convert::From<&TimeseriesQuery> for TimeseriesQuery {
-        fn from(value: &TimeseriesQuery) -> Self {
-            value.clone()
-        }
-    }
-
     impl TimeseriesQuery {
         pub fn builder() -> builder::TimeseriesQuery {
             Default::default()
@@ -30954,12 +28794,6 @@ pub mod types {
         pub version: ::std::num::NonZeroU8,
     }
 
-    impl ::std::convert::From<&TimeseriesSchema> for TimeseriesSchema {
-        fn from(value: &TimeseriesSchema) -> Self {
-            value.clone()
-        }
-    }
-
     impl TimeseriesSchema {
         pub fn builder() -> builder::TimeseriesSchema {
             Default::default()
@@ -31006,12 +28840,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&TimeseriesSchemaResultsPage> for TimeseriesSchemaResultsPage {
-        fn from(value: &TimeseriesSchemaResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl TimeseriesSchemaResultsPage {
@@ -31088,12 +28916,6 @@ pub mod types {
         pub time_created: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&TufRepo> for TufRepo {
-        fn from(value: &TufRepo) -> Self {
-            value.clone()
-        }
-    }
-
     impl TufRepo {
         pub fn builder() -> builder::TufRepo {
             Default::default()
@@ -31140,12 +28962,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&TufRepoResultsPage> for TufRepoResultsPage {
-        fn from(value: &TufRepoResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl TufRepoResultsPage {
@@ -31197,12 +29013,6 @@ pub mod types {
     impl ::std::convert::From<TufRepoSystemVersion> for ::std::string::String {
         fn from(value: TufRepoSystemVersion) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&TufRepoSystemVersion> for TufRepoSystemVersion {
-        fn from(value: &TufRepoSystemVersion) -> Self {
-            value.clone()
         }
     }
 
@@ -31298,12 +29108,6 @@ pub mod types {
         pub status: TufRepoUploadStatus,
     }
 
-    impl ::std::convert::From<&TufRepoUpload> for TufRepoUpload {
-        fn from(value: &TufRepoUpload) -> Self {
-            value.clone()
-        }
-    }
-
     impl TufRepoUpload {
         pub fn builder() -> builder::TufRepoUpload {
             Default::default()
@@ -31359,12 +29163,6 @@ pub mod types {
         /// The repository did not exist, and was inserted into the database
         #[serde(rename = "inserted")]
         Inserted,
-    }
-
-    impl ::std::convert::From<&Self> for TufRepoUploadStatus {
-        fn from(value: &TufRepoUploadStatus) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for TufRepoUploadStatus {
@@ -31489,12 +29287,6 @@ pub mod types {
         pub pre2: ::std::option::Option<i32>,
     }
 
-    impl ::std::convert::From<&TxEqConfig> for TxEqConfig {
-        fn from(value: &TxEqConfig) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for TxEqConfig {
         fn default() -> Self {
             Self {
@@ -31590,12 +29382,6 @@ pub mod types {
         pub pre2: ::std::option::Option<i32>,
     }
 
-    impl ::std::convert::From<&TxEqConfig2> for TxEqConfig2 {
-        fn from(value: &TxEqConfig2) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::default::Default for TxEqConfig2 {
         fn default() -> Self {
             Self {
@@ -31654,12 +29440,6 @@ pub mod types {
         pub rack_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&UninitializedSled> for UninitializedSled {
-        fn from(value: &UninitializedSled) -> Self {
-            value.clone()
-        }
-    }
-
     impl UninitializedSled {
         pub fn builder() -> builder::UninitializedSled {
             Default::default()
@@ -31695,12 +29475,6 @@ pub mod types {
     pub struct UninitializedSledId {
         pub part: ::std::string::String,
         pub serial: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&UninitializedSledId> for UninitializedSledId {
-        fn from(value: &UninitializedSledId) -> Self {
-            value.clone()
-        }
     }
 
     impl UninitializedSledId {
@@ -31749,12 +29523,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&UninitializedSledResultsPage> for UninitializedSledResultsPage {
-        fn from(value: &UninitializedSledResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl UninitializedSledResultsPage {
@@ -31839,12 +29607,6 @@ pub mod types {
         /// Rotations per minute.
         #[serde(rename = "rpm")]
         Rpm,
-    }
-
-    impl ::std::convert::From<&Self> for Units {
-        fn from(value: &Units) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for Units {
@@ -32008,12 +29770,6 @@ pub mod types {
         pub time_last_step_planned: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&UpdateStatus> for UpdateStatus {
-        fn from(value: &UpdateStatus) -> Self {
-            value.clone()
-        }
-    }
-
     impl UpdateStatus {
         pub fn builder() -> builder::UpdateStatus {
             Default::default()
@@ -32067,12 +29823,6 @@ pub mod types {
         pub time_created: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&UpdatesTrustRoot> for UpdatesTrustRoot {
-        fn from(value: &UpdatesTrustRoot) -> Self {
-            value.clone()
-        }
-    }
-
     impl UpdatesTrustRoot {
         pub fn builder() -> builder::UpdatesTrustRoot {
             Default::default()
@@ -32121,12 +29871,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&UpdatesTrustRootResultsPage> for UpdatesTrustRootResultsPage {
-        fn from(value: &UpdatesTrustRootResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl UpdatesTrustRootResultsPage {
         pub fn builder() -> builder::UpdatesTrustRootResultsPage {
             Default::default()
@@ -32173,12 +29917,6 @@ pub mod types {
         pub id: ::uuid::Uuid,
         /// Uuid of the silo to which this user belongs
         pub silo_id: ::uuid::Uuid,
-    }
-
-    impl ::std::convert::From<&User> for User {
-        fn from(value: &User) -> Self {
-            value.clone()
-        }
     }
 
     impl User {
@@ -32257,12 +29995,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&UserBuiltin> for UserBuiltin {
-        fn from(value: &UserBuiltin) -> Self {
-            value.clone()
-        }
-    }
-
     impl UserBuiltin {
         pub fn builder() -> builder::UserBuiltin {
             Default::default()
@@ -32309,12 +30041,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&UserBuiltinResultsPage> for UserBuiltinResultsPage {
-        fn from(value: &UserBuiltinResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl UserBuiltinResultsPage {
@@ -32364,12 +30090,6 @@ pub mod types {
         pub external_id: UserId,
         /// how to set the user's login password
         pub password: UserPassword,
-    }
-
-    impl ::std::convert::From<&UserCreate> for UserCreate {
-        fn from(value: &UserCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl UserCreate {
@@ -32424,12 +30144,6 @@ pub mod types {
     impl ::std::convert::From<UserId> for ::std::string::String {
         fn from(value: UserId) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&UserId> for UserId {
-        fn from(value: &UserId) -> Self {
-            value.clone()
         }
     }
 
@@ -32551,12 +30265,6 @@ pub mod types {
         LoginDisallowed,
     }
 
-    impl ::std::convert::From<&Self> for UserPassword {
-        fn from(value: &UserPassword) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<Password> for UserPassword {
         fn from(value: Password) -> Self {
             Self::Password(value)
@@ -32605,12 +30313,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&UserResultsPage> for UserResultsPage {
-        fn from(value: &UserResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl UserResultsPage {
         pub fn builder() -> builder::UserResultsPage {
             Default::default()
@@ -32646,12 +30348,6 @@ pub mod types {
     pub struct UsernamePasswordCredentials {
         pub password: Password,
         pub username: UserId,
-    }
-
-    impl ::std::convert::From<&UsernamePasswordCredentials> for UsernamePasswordCredentials {
-        fn from(value: &UsernamePasswordCredentials) -> Self {
-            value.clone()
-        }
     }
 
     impl UsernamePasswordCredentials {
@@ -32711,12 +30407,6 @@ pub mod types {
         /// associated with a stopped instances are not counted here whereas
         /// associated disks will still be counted
         pub provisioned: VirtualResourceCounts,
-    }
-
-    impl ::std::convert::From<&Utilization> for Utilization {
-        fn from(value: &Utilization) -> Self {
-            value.clone()
-        }
     }
 
     impl Utilization {
@@ -32921,12 +30611,6 @@ pub mod types {
         DoubleDistribution(::std::vec::Vec<::std::option::Option<Distributiondouble>>),
     }
 
-    impl ::std::convert::From<&Self> for ValueArray {
-        fn from(value: &ValueArray) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::vec::Vec<::std::option::Option<i64>>> for ValueArray {
         fn from(value: ::std::vec::Vec<::std::option::Option<i64>>) -> Self {
             Self::Integer(value)
@@ -33013,12 +30697,6 @@ pub mod types {
         pub values: ValueArray,
     }
 
-    impl ::std::convert::From<&Values> for Values {
-        fn from(value: &Values) -> Self {
-            value.clone()
-        }
-    }
-
     impl Values {
         pub fn builder() -> builder::Values {
             Default::default()
@@ -33074,12 +30752,6 @@ pub mod types {
         /// Sort in decreasing semantic version order (newest first)
         #[serde(rename = "version_descending")]
         VersionDescending,
-    }
-
-    impl ::std::convert::From<&Self> for VersionSortMode {
-        fn from(value: &VersionSortMode) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for VersionSortMode {
@@ -33180,12 +30852,6 @@ pub mod types {
         pub storage: ByteCount,
     }
 
-    impl ::std::convert::From<&VirtualResourceCounts> for VirtualResourceCounts {
-        fn from(value: &VirtualResourceCounts) -> Self {
-            value.clone()
-        }
-    }
-
     impl VirtualResourceCounts {
         pub fn builder() -> builder::VirtualResourceCounts {
             Default::default()
@@ -33220,12 +30886,6 @@ pub mod types {
     impl ::std::convert::From<Vni> for u32 {
         fn from(value: Vni) -> Self {
             value.0
-        }
-    }
-
-    impl ::std::convert::From<&Vni> for Vni {
-        fn from(value: &Vni) -> Self {
-            value.clone()
         }
     }
 
@@ -33374,12 +31034,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&Vpc> for Vpc {
-        fn from(value: &Vpc) -> Self {
-            value.clone()
-        }
-    }
-
     impl Vpc {
         pub fn builder() -> builder::Vpc {
             Default::default()
@@ -33448,12 +31102,6 @@ pub mod types {
         pub name: Name,
     }
 
-    impl ::std::convert::From<&VpcCreate> for VpcCreate {
-        fn from(value: &VpcCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl VpcCreate {
         pub fn builder() -> builder::VpcCreate {
             Default::default()
@@ -33501,12 +31149,6 @@ pub mod types {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub code: ::std::option::Option<IcmpParamRange>,
         pub icmp_type: u8,
-    }
-
-    impl ::std::convert::From<&VpcFirewallIcmpFilter> for VpcFirewallIcmpFilter {
-        fn from(value: &VpcFirewallIcmpFilter) -> Self {
-            value.clone()
-        }
     }
 
     impl VpcFirewallIcmpFilter {
@@ -33654,12 +31296,6 @@ pub mod types {
         pub vpc_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&VpcFirewallRule> for VpcFirewallRule {
-        fn from(value: &VpcFirewallRule) -> Self {
-            value.clone()
-        }
-    }
-
     impl VpcFirewallRule {
         pub fn builder() -> builder::VpcFirewallRule {
             Default::default()
@@ -33698,12 +31334,6 @@ pub mod types {
         Allow,
         #[serde(rename = "deny")]
         Deny,
-    }
-
-    impl ::std::convert::From<&Self> for VpcFirewallRuleAction {
-        fn from(value: &VpcFirewallRuleAction) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for VpcFirewallRuleAction {
@@ -33783,12 +31413,6 @@ pub mod types {
         Inbound,
         #[serde(rename = "outbound")]
         Outbound,
-    }
-
-    impl ::std::convert::From<&Self> for VpcFirewallRuleDirection {
-        fn from(value: &VpcFirewallRuleDirection) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for VpcFirewallRuleDirection {
@@ -33910,12 +31534,6 @@ pub mod types {
         /// If present, the networking protocols this rule applies to.
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub protocols: ::std::option::Option<::std::vec::Vec<VpcFirewallRuleProtocol>>,
-    }
-
-    impl ::std::convert::From<&VpcFirewallRuleFilter> for VpcFirewallRuleFilter {
-        fn from(value: &VpcFirewallRuleFilter) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for VpcFirewallRuleFilter {
@@ -34071,12 +31689,6 @@ pub mod types {
         IpNet(IpNet),
     }
 
-    impl ::std::convert::From<&Self> for VpcFirewallRuleHostFilter {
-        fn from(value: &VpcFirewallRuleHostFilter) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::net::IpAddr> for VpcFirewallRuleHostFilter {
         fn from(value: ::std::net::IpAddr) -> Self {
             Self::Ip(value)
@@ -34172,12 +31784,6 @@ pub mod types {
         Icmp(::std::option::Option<VpcFirewallIcmpFilter>),
     }
 
-    impl ::std::convert::From<&Self> for VpcFirewallRuleProtocol {
-        fn from(value: &VpcFirewallRuleProtocol) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::option::Option<VpcFirewallIcmpFilter>>
         for VpcFirewallRuleProtocol
     {
@@ -34218,12 +31824,6 @@ pub mod types {
         Disabled,
         #[serde(rename = "enabled")]
         Enabled,
-    }
-
-    impl ::std::convert::From<&Self> for VpcFirewallRuleStatus {
-        fn from(value: &VpcFirewallRuleStatus) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for VpcFirewallRuleStatus {
@@ -34410,12 +32010,6 @@ pub mod types {
         IpNet(IpNet),
     }
 
-    impl ::std::convert::From<&Self> for VpcFirewallRuleTarget {
-        fn from(value: &VpcFirewallRuleTarget) -> Self {
-            value.clone()
-        }
-    }
-
     impl ::std::convert::From<::std::net::IpAddr> for VpcFirewallRuleTarget {
         fn from(value: ::std::net::IpAddr) -> Self {
             Self::Ip(value)
@@ -34534,12 +32128,6 @@ pub mod types {
         pub targets: ::std::vec::Vec<VpcFirewallRuleTarget>,
     }
 
-    impl ::std::convert::From<&VpcFirewallRuleUpdate> for VpcFirewallRuleUpdate {
-        fn from(value: &VpcFirewallRuleUpdate) -> Self {
-            value.clone()
-        }
-    }
-
     impl VpcFirewallRuleUpdate {
         pub fn builder() -> builder::VpcFirewallRuleUpdate {
             Default::default()
@@ -34574,12 +32162,6 @@ pub mod types {
     pub struct VpcFirewallRuleUpdateParams {
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub rules: ::std::vec::Vec<VpcFirewallRuleUpdate>,
-    }
-
-    impl ::std::convert::From<&VpcFirewallRuleUpdateParams> for VpcFirewallRuleUpdateParams {
-        fn from(value: &VpcFirewallRuleUpdateParams) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for VpcFirewallRuleUpdateParams {
@@ -34623,12 +32205,6 @@ pub mod types {
     )]
     pub struct VpcFirewallRules {
         pub rules: ::std::vec::Vec<VpcFirewallRule>,
-    }
-
-    impl ::std::convert::From<&VpcFirewallRules> for VpcFirewallRules {
-        fn from(value: &VpcFirewallRules) -> Self {
-            value.clone()
-        }
     }
 
     impl VpcFirewallRules {
@@ -34677,12 +32253,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&VpcResultsPage> for VpcResultsPage {
-        fn from(value: &VpcResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl VpcResultsPage {
@@ -34771,12 +32341,6 @@ pub mod types {
         pub vpc_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&VpcRouter> for VpcRouter {
-        fn from(value: &VpcRouter) -> Self {
-            value.clone()
-        }
-    }
-
     impl VpcRouter {
         pub fn builder() -> builder::VpcRouter {
             Default::default()
@@ -34812,12 +32376,6 @@ pub mod types {
     pub struct VpcRouterCreate {
         pub description: ::std::string::String,
         pub name: Name,
-    }
-
-    impl ::std::convert::From<&VpcRouterCreate> for VpcRouterCreate {
-        fn from(value: &VpcRouterCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl VpcRouterCreate {
@@ -34858,12 +32416,6 @@ pub mod types {
         System,
         #[serde(rename = "custom")]
         Custom,
-    }
-
-    impl ::std::convert::From<&Self> for VpcRouterKind {
-        fn from(value: &VpcRouterKind) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for VpcRouterKind {
@@ -34953,12 +32505,6 @@ pub mod types {
         pub next_page: ::std::option::Option<::std::string::String>,
     }
 
-    impl ::std::convert::From<&VpcRouterResultsPage> for VpcRouterResultsPage {
-        fn from(value: &VpcRouterResultsPage) -> Self {
-            value.clone()
-        }
-    }
-
     impl VpcRouterResultsPage {
         pub fn builder() -> builder::VpcRouterResultsPage {
             Default::default()
@@ -35006,12 +32552,6 @@ pub mod types {
         pub description: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&VpcRouterUpdate> for VpcRouterUpdate {
-        fn from(value: &VpcRouterUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for VpcRouterUpdate {
@@ -35139,12 +32679,6 @@ pub mod types {
         pub vpc_id: ::uuid::Uuid,
     }
 
-    impl ::std::convert::From<&VpcSubnet> for VpcSubnet {
-        fn from(value: &VpcSubnet) -> Self {
-            value.clone()
-        }
-    }
-
     impl VpcSubnet {
         pub fn builder() -> builder::VpcSubnet {
             Default::default()
@@ -35252,12 +32786,6 @@ pub mod types {
         pub name: Name,
     }
 
-    impl ::std::convert::From<&VpcSubnetCreate> for VpcSubnetCreate {
-        fn from(value: &VpcSubnetCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl VpcSubnetCreate {
         pub fn builder() -> builder::VpcSubnetCreate {
             Default::default()
@@ -35304,12 +32832,6 @@ pub mod types {
         /// token used to fetch the next page of results (if any)
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub next_page: ::std::option::Option<::std::string::String>,
-    }
-
-    impl ::std::convert::From<&VpcSubnetResultsPage> for VpcSubnetResultsPage {
-        fn from(value: &VpcSubnetResultsPage) -> Self {
-            value.clone()
-        }
     }
 
     impl VpcSubnetResultsPage {
@@ -35379,12 +32901,6 @@ pub mod types {
         pub description: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&VpcSubnetUpdate> for VpcSubnetUpdate {
-        fn from(value: &VpcSubnetUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for VpcSubnetUpdate {
@@ -35460,12 +32976,6 @@ pub mod types {
         pub dns_name: ::std::option::Option<Name>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&VpcUpdate> for VpcUpdate {
-        fn from(value: &VpcUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for VpcUpdate {
@@ -35551,12 +33061,6 @@ pub mod types {
         pub subscriptions: ::std::vec::Vec<AlertSubscription>,
     }
 
-    impl ::std::convert::From<&WebhookCreate> for WebhookCreate {
-        fn from(value: &WebhookCreate) -> Self {
-            value.clone()
-        }
-    }
-
     impl WebhookCreate {
         pub fn builder() -> builder::WebhookCreate {
             Default::default()
@@ -35637,12 +33141,6 @@ pub mod types {
         pub time_sent: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&WebhookDeliveryAttempt> for WebhookDeliveryAttempt {
-        fn from(value: &WebhookDeliveryAttempt) -> Self {
-            value.clone()
-        }
-    }
-
     impl WebhookDeliveryAttempt {
         pub fn builder() -> builder::WebhookDeliveryAttempt {
             Default::default()
@@ -35721,12 +33219,6 @@ pub mod types {
         /// but no response was received within the delivery timeout.
         #[serde(rename = "failed_timeout")]
         FailedTimeout,
-    }
-
-    impl ::std::convert::From<&Self> for WebhookDeliveryAttemptResult {
-        fn from(value: &WebhookDeliveryAttemptResult) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::fmt::Display for WebhookDeliveryAttemptResult {
@@ -35818,12 +33310,6 @@ pub mod types {
         pub duration_ms: u32,
         /// The HTTP status code returned from the webhook endpoint.
         pub status: u16,
-    }
-
-    impl ::std::convert::From<&WebhookDeliveryResponse> for WebhookDeliveryResponse {
-        fn from(value: &WebhookDeliveryResponse) -> Self {
-            value.clone()
-        }
     }
 
     impl WebhookDeliveryResponse {
@@ -35925,12 +33411,6 @@ pub mod types {
         pub time_modified: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&WebhookReceiver> for WebhookReceiver {
-        fn from(value: &WebhookReceiver) -> Self {
-            value.clone()
-        }
-    }
-
     impl WebhookReceiver {
         pub fn builder() -> builder::WebhookReceiver {
             Default::default()
@@ -35990,12 +33470,6 @@ pub mod types {
         pub endpoint: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub name: ::std::option::Option<Name>,
-    }
-
-    impl ::std::convert::From<&WebhookReceiverUpdate> for WebhookReceiverUpdate {
-        fn from(value: &WebhookReceiverUpdate) -> Self {
-            value.clone()
-        }
     }
 
     impl ::std::default::Default for WebhookReceiverUpdate {
@@ -36059,12 +33533,6 @@ pub mod types {
         pub time_created: ::chrono::DateTime<::chrono::offset::Utc>,
     }
 
-    impl ::std::convert::From<&WebhookSecret> for WebhookSecret {
-        fn from(value: &WebhookSecret) -> Self {
-            value.clone()
-        }
-    }
-
     impl WebhookSecret {
         pub fn builder() -> builder::WebhookSecret {
             Default::default()
@@ -36096,12 +33564,6 @@ pub mod types {
     pub struct WebhookSecretCreate {
         /// The value of the shared secret key.
         pub secret: ::std::string::String,
-    }
-
-    impl ::std::convert::From<&WebhookSecretCreate> for WebhookSecretCreate {
-        fn from(value: &WebhookSecretCreate) -> Self {
-            value.clone()
-        }
     }
 
     impl WebhookSecretCreate {
@@ -36140,12 +33602,6 @@ pub mod types {
         pub secrets: ::std::vec::Vec<WebhookSecret>,
     }
 
-    impl ::std::convert::From<&WebhookSecrets> for WebhookSecrets {
-        fn from(value: &WebhookSecrets) -> Self {
-            value.clone()
-        }
-    }
-
     impl WebhookSecrets {
         pub fn builder() -> builder::WebhookSecrets {
             Default::default()
@@ -36179,7 +33635,7 @@ pub mod types {
             {
                 self.address = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address: {e}"));
                 self
             }
             pub fn address_lot<T>(mut self, value: T) -> Self
@@ -36189,7 +33645,7 @@ pub mod types {
             {
                 self.address_lot = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address_lot: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address_lot: {e}"));
                 self
             }
             pub fn vlan_id<T>(mut self, value: T) -> Self
@@ -36199,7 +33655,7 @@ pub mod types {
             {
                 self.vlan_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vlan_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vlan_id: {e}"));
                 self
             }
         }
@@ -36251,7 +33707,7 @@ pub mod types {
             {
                 self.addresses = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for addresses: {}", e));
+                    .map_err(|e| format!("error converting supplied value for addresses: {e}"));
                 self
             }
             pub fn link_name<T>(mut self, value: T) -> Self
@@ -36261,7 +33717,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
         }
@@ -36324,7 +33780,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -36334,7 +33790,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn kind<T>(mut self, value: T) -> Self
@@ -36344,7 +33800,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -36354,7 +33810,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -36362,9 +33818,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -36372,9 +33828,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -36431,9 +33887,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::net::IpAddr>,
                 T::Error: ::std::fmt::Display,
             {
-                self.first_address = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for first_address: {}", e)
-                });
+                self.first_address = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for first_address: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -36443,7 +33899,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn last_address<T>(mut self, value: T) -> Self
@@ -36451,9 +33907,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::net::IpAddr>,
                 T::Error: ::std::fmt::Display,
             {
-                self.last_address = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for last_address: {}", e)
-                });
+                self.last_address = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for last_address: {e}"));
                 self
             }
         }
@@ -36502,9 +33958,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::net::IpAddr>,
                 T::Error: ::std::fmt::Display,
             {
-                self.first_address = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for first_address: {}", e)
-                });
+                self.first_address = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for first_address: {e}"));
                 self
             }
             pub fn last_address<T>(mut self, value: T) -> Self
@@ -36512,9 +33968,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::net::IpAddr>,
                 T::Error: ::std::fmt::Display,
             {
-                self.last_address = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for last_address: {}", e)
-                });
+                self.last_address = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for last_address: {e}"));
                 self
             }
         }
@@ -36569,7 +34025,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -36579,7 +34035,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -36635,7 +34091,7 @@ pub mod types {
             {
                 self.blocks = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for blocks: {}", e));
+                    .map_err(|e| format!("error converting supplied value for blocks: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -36645,7 +34101,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn kind<T>(mut self, value: T) -> Self
@@ -36655,7 +34111,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -36665,7 +34121,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -36721,7 +34177,7 @@ pub mod types {
             {
                 self.blocks = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for blocks: {}", e));
+                    .map_err(|e| format!("error converting supplied value for blocks: {e}"));
                 self
             }
             pub fn lot<T>(mut self, value: T) -> Self
@@ -36731,7 +34187,7 @@ pub mod types {
             {
                 self.lot = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for lot: {}", e));
+                    .map_err(|e| format!("error converting supplied value for lot: {e}"));
                 self
             }
         }
@@ -36783,7 +34239,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -36793,7 +34249,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -36845,7 +34301,7 @@ pub mod types {
             {
                 self.blocks = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for blocks: {}", e));
+                    .map_err(|e| format!("error converting supplied value for blocks: {e}"));
                 self
             }
             pub fn lot<T>(mut self, value: T) -> Self
@@ -36855,7 +34311,7 @@ pub mod types {
             {
                 self.lot = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for lot: {}", e));
+                    .map_err(|e| format!("error converting supplied value for lot: {e}"));
                 self
             }
         }
@@ -36922,7 +34378,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn failure_domain<T>(mut self, value: T) -> Self
@@ -36931,7 +34387,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.failure_domain = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for failure_domain: {}", e)
+                    format!("error converting supplied value for failure_domain: {e}")
                 });
                 self
             }
@@ -36942,7 +34398,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -36952,7 +34408,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn policy<T>(mut self, value: T) -> Self
@@ -36962,7 +34418,7 @@ pub mod types {
             {
                 self.policy = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for policy: {}", e));
+                    .map_err(|e| format!("error converting supplied value for policy: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -36972,7 +34428,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -36980,9 +34436,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -36990,9 +34446,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -37057,7 +34513,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn failure_domain<T>(mut self, value: T) -> Self
@@ -37066,7 +34522,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.failure_domain = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for failure_domain: {}", e)
+                    format!("error converting supplied value for failure_domain: {e}")
                 });
                 self
             }
@@ -37077,7 +34533,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn policy<T>(mut self, value: T) -> Self
@@ -37087,7 +34543,7 @@ pub mod types {
             {
                 self.policy = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for policy: {}", e));
+                    .map_err(|e| format!("error converting supplied value for policy: {e}"));
                 self
             }
         }
@@ -37146,7 +34602,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -37156,7 +34612,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -37213,7 +34669,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -37223,7 +34679,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -37275,7 +34731,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -37285,7 +34741,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -37334,10 +34790,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.switch_histories = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for switch_histories: {}",
-                        e
-                    )
+                    format!("error converting supplied value for switch_histories: {e}")
                 });
                 self
             }
@@ -37385,7 +34838,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -37395,7 +34848,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -37447,7 +34900,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -37457,7 +34910,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -37521,7 +34974,7 @@ pub mod types {
             {
                 self.alert_class = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for alert_class: {}", e));
+                    .map_err(|e| format!("error converting supplied value for alert_class: {e}"));
                 self
             }
             pub fn alert_id<T>(mut self, value: T) -> Self
@@ -37531,7 +34984,7 @@ pub mod types {
             {
                 self.alert_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for alert_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for alert_id: {e}"));
                 self
             }
             pub fn attempts<T>(mut self, value: T) -> Self
@@ -37541,7 +34994,7 @@ pub mod types {
             {
                 self.attempts = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for attempts: {}", e));
+                    .map_err(|e| format!("error converting supplied value for attempts: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -37551,7 +35004,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn receiver_id<T>(mut self, value: T) -> Self
@@ -37561,7 +35014,7 @@ pub mod types {
             {
                 self.receiver_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for receiver_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for receiver_id: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -37571,7 +35024,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_started<T>(mut self, value: T) -> Self
@@ -37579,9 +35032,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_started = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_started: {}", e)
-                });
+                self.time_started = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_started: {e}"));
                 self
             }
             pub fn trigger<T>(mut self, value: T) -> Self
@@ -37591,7 +35044,7 @@ pub mod types {
             {
                 self.trigger = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for trigger: {}", e));
+                    .map_err(|e| format!("error converting supplied value for trigger: {e}"));
                 self
             }
         }
@@ -37650,7 +35103,7 @@ pub mod types {
             {
                 self.delivery_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for delivery_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for delivery_id: {e}"));
                 self
             }
         }
@@ -37701,7 +35154,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -37711,7 +35164,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -37761,7 +35214,7 @@ pub mod types {
             {
                 self.probe = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for probe: {}", e));
+                    .map_err(|e| format!("error converting supplied value for probe: {e}"));
                 self
             }
             pub fn resends_started<T>(mut self, value: T) -> Self
@@ -37770,7 +35223,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.resends_started = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for resends_started: {}", e)
+                    format!("error converting supplied value for resends_started: {e}")
                 });
                 self
             }
@@ -37839,7 +35292,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -37849,7 +35302,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn kind<T>(mut self, value: T) -> Self
@@ -37859,7 +35312,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -37869,7 +35322,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn subscriptions<T>(mut self, value: T) -> Self
@@ -37877,9 +35330,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::vec::Vec<super::AlertSubscription>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.subscriptions = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for subscriptions: {}", e)
-                });
+                self.subscriptions = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for subscriptions: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -37887,9 +35340,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -37897,9 +35350,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -37962,7 +35415,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -37972,7 +35425,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -38017,9 +35470,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::AlertSubscription>,
                 T::Error: ::std::fmt::Display,
             {
-                self.subscription = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for subscription: {}", e)
-                });
+                self.subscription = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for subscription: {e}"));
                 self
             }
         }
@@ -38062,9 +35515,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::AlertSubscription>,
                 T::Error: ::std::fmt::Display,
             {
-                self.subscription = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for subscription: {}", e)
-                });
+                self.subscription = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for subscription: {e}"));
                 self
             }
         }
@@ -38119,7 +35572,7 @@ pub mod types {
             {
                 self.allowed_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for allowed_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for allowed_ips: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -38127,9 +35580,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -38137,9 +35590,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -38188,7 +35641,7 @@ pub mod types {
             {
                 self.allowed_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for allowed_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for allowed_ips: {e}"));
                 self
             }
         }
@@ -38253,7 +35706,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn failure_domain<T>(mut self, value: T) -> Self
@@ -38262,7 +35715,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.failure_domain = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for failure_domain: {}", e)
+                    format!("error converting supplied value for failure_domain: {e}")
                 });
                 self
             }
@@ -38273,7 +35726,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -38283,7 +35736,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn policy<T>(mut self, value: T) -> Self
@@ -38293,7 +35746,7 @@ pub mod types {
             {
                 self.policy = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for policy: {}", e));
+                    .map_err(|e| format!("error converting supplied value for policy: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -38303,7 +35756,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -38311,9 +35764,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -38321,9 +35774,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -38388,7 +35841,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn failure_domain<T>(mut self, value: T) -> Self
@@ -38397,7 +35850,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.failure_domain = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for failure_domain: {}", e)
+                    format!("error converting supplied value for failure_domain: {e}")
                 });
                 self
             }
@@ -38408,7 +35861,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn policy<T>(mut self, value: T) -> Self
@@ -38418,7 +35871,7 @@ pub mod types {
             {
                 self.policy = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for policy: {}", e));
+                    .map_err(|e| format!("error converting supplied value for policy: {e}"));
                 self
             }
         }
@@ -38477,7 +35930,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -38487,7 +35940,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -38546,7 +35999,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -38556,7 +36009,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -38608,7 +36061,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -38618,7 +36071,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -38697,7 +36150,7 @@ pub mod types {
             {
                 self.actor = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for actor: {}", e));
+                    .map_err(|e| format!("error converting supplied value for actor: {e}"));
                 self
             }
             pub fn auth_method<T>(mut self, value: T) -> Self
@@ -38707,7 +36160,7 @@ pub mod types {
             {
                 self.auth_method = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for auth_method: {}", e));
+                    .map_err(|e| format!("error converting supplied value for auth_method: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -38717,7 +36170,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn operation_id<T>(mut self, value: T) -> Self
@@ -38725,9 +36178,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.operation_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for operation_id: {}", e)
-                });
+                self.operation_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for operation_id: {e}"));
                 self
             }
             pub fn request_id<T>(mut self, value: T) -> Self
@@ -38737,7 +36190,7 @@ pub mod types {
             {
                 self.request_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for request_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for request_id: {e}"));
                 self
             }
             pub fn request_uri<T>(mut self, value: T) -> Self
@@ -38747,7 +36200,7 @@ pub mod types {
             {
                 self.request_uri = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for request_uri: {}", e));
+                    .map_err(|e| format!("error converting supplied value for request_uri: {e}"));
                 self
             }
             pub fn result<T>(mut self, value: T) -> Self
@@ -38757,7 +36210,7 @@ pub mod types {
             {
                 self.result = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for result: {}", e));
+                    .map_err(|e| format!("error converting supplied value for result: {e}"));
                 self
             }
             pub fn source_ip<T>(mut self, value: T) -> Self
@@ -38767,7 +36220,7 @@ pub mod types {
             {
                 self.source_ip = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for source_ip: {}", e));
+                    .map_err(|e| format!("error converting supplied value for source_ip: {e}"));
                 self
             }
             pub fn time_completed<T>(mut self, value: T) -> Self
@@ -38776,7 +36229,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.time_completed = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_completed: {}", e)
+                    format!("error converting supplied value for time_completed: {e}")
                 });
                 self
             }
@@ -38785,9 +36238,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_started = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_started: {}", e)
-                });
+                self.time_started = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_started: {e}"));
                 self
             }
             pub fn user_agent<T>(mut self, value: T) -> Self
@@ -38797,7 +36250,7 @@ pub mod types {
             {
                 self.user_agent = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for user_agent: {}", e));
+                    .map_err(|e| format!("error converting supplied value for user_agent: {e}"));
                 self
             }
         }
@@ -38868,7 +36321,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -38878,7 +36331,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -38929,7 +36382,7 @@ pub mod types {
             {
                 self.part = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for part: {}", e));
+                    .map_err(|e| format!("error converting supplied value for part: {e}"));
                 self
             }
             pub fn revision<T>(mut self, value: T) -> Self
@@ -38939,7 +36392,7 @@ pub mod types {
             {
                 self.revision = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for revision: {}", e));
+                    .map_err(|e| format!("error converting supplied value for revision: {e}"));
                 self
             }
             pub fn serial<T>(mut self, value: T) -> Self
@@ -38949,7 +36402,7 @@ pub mod types {
             {
                 self.serial = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for serial: {}", e));
+                    .map_err(|e| format!("error converting supplied value for serial: {e}"));
                 self
             }
         }
@@ -39000,7 +36453,7 @@ pub mod types {
             {
                 self.remote = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for remote: {}", e));
+                    .map_err(|e| format!("error converting supplied value for remote: {e}"));
                 self
             }
             pub fn switch<T>(mut self, value: T) -> Self
@@ -39010,7 +36463,7 @@ pub mod types {
             {
                 self.switch = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                    .map_err(|e| format!("error converting supplied value for switch: {e}"));
                 self
             }
         }
@@ -39071,10 +36524,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.detection_threshold = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for detection_threshold: {}",
-                        e
-                    )
+                    format!("error converting supplied value for detection_threshold: {e}")
                 });
                 self
             }
@@ -39085,7 +36535,7 @@ pub mod types {
             {
                 self.local = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for local: {}", e));
+                    .map_err(|e| format!("error converting supplied value for local: {e}"));
                 self
             }
             pub fn mode<T>(mut self, value: T) -> Self
@@ -39095,7 +36545,7 @@ pub mod types {
             {
                 self.mode = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mode: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mode: {e}"));
                 self
             }
             pub fn remote<T>(mut self, value: T) -> Self
@@ -39105,7 +36555,7 @@ pub mod types {
             {
                 self.remote = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for remote: {}", e));
+                    .map_err(|e| format!("error converting supplied value for remote: {e}"));
                 self
             }
             pub fn required_rx<T>(mut self, value: T) -> Self
@@ -39115,7 +36565,7 @@ pub mod types {
             {
                 self.required_rx = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for required_rx: {}", e));
+                    .map_err(|e| format!("error converting supplied value for required_rx: {e}"));
                 self
             }
             pub fn switch<T>(mut self, value: T) -> Self
@@ -39125,7 +36575,7 @@ pub mod types {
             {
                 self.switch = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                    .map_err(|e| format!("error converting supplied value for switch: {e}"));
                 self
             }
         }
@@ -39196,10 +36646,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.detection_threshold = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for detection_threshold: {}",
-                        e
-                    )
+                    format!("error converting supplied value for detection_threshold: {e}")
                 });
                 self
             }
@@ -39210,7 +36657,7 @@ pub mod types {
             {
                 self.local = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for local: {}", e));
+                    .map_err(|e| format!("error converting supplied value for local: {e}"));
                 self
             }
             pub fn mode<T>(mut self, value: T) -> Self
@@ -39220,7 +36667,7 @@ pub mod types {
             {
                 self.mode = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mode: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mode: {e}"));
                 self
             }
             pub fn peer<T>(mut self, value: T) -> Self
@@ -39230,7 +36677,7 @@ pub mod types {
             {
                 self.peer = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for peer: {}", e));
+                    .map_err(|e| format!("error converting supplied value for peer: {e}"));
                 self
             }
             pub fn required_rx<T>(mut self, value: T) -> Self
@@ -39240,7 +36687,7 @@ pub mod types {
             {
                 self.required_rx = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for required_rx: {}", e));
+                    .map_err(|e| format!("error converting supplied value for required_rx: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -39250,7 +36697,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn switch<T>(mut self, value: T) -> Self
@@ -39260,7 +36707,7 @@ pub mod types {
             {
                 self.switch = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                    .map_err(|e| format!("error converting supplied value for switch: {e}"));
                 self
             }
         }
@@ -39331,7 +36778,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -39341,7 +36788,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -39351,7 +36798,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -39359,9 +36806,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -39369,9 +36816,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -39429,9 +36876,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::vec::Vec<super::BgpAnnouncementCreate>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.announcement = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for announcement: {}", e)
-                });
+                self.announcement = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for announcement: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -39441,7 +36888,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -39451,7 +36898,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -39505,10 +36952,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.address_lot_block_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for address_lot_block_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for address_lot_block_id: {e}")
                 });
                 self
             }
@@ -39518,7 +36962,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.announce_set_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for announce_set_id: {}", e)
+                    format!("error converting supplied value for announce_set_id: {e}")
                 });
                 self
             }
@@ -39529,7 +36973,7 @@ pub mod types {
             {
                 self.network = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for network: {}", e));
+                    .map_err(|e| format!("error converting supplied value for network: {e}"));
                 self
             }
         }
@@ -39579,10 +37023,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.address_lot_block = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for address_lot_block: {}",
-                        e
-                    )
+                    format!("error converting supplied value for address_lot_block: {e}")
                 });
                 self
             }
@@ -39593,7 +37034,7 @@ pub mod types {
             {
                 self.network = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for network: {}", e));
+                    .map_err(|e| format!("error converting supplied value for network: {e}"));
                 self
             }
         }
@@ -39661,7 +37102,7 @@ pub mod types {
             {
                 self.asn = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for asn: {}", e));
+                    .map_err(|e| format!("error converting supplied value for asn: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -39671,7 +37112,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -39681,7 +37122,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -39691,7 +37132,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -39699,9 +37140,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -39709,9 +37150,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vrf<T>(mut self, value: T) -> Self
@@ -39721,7 +37162,7 @@ pub mod types {
             {
                 self.vrf = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vrf: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vrf: {e}"));
                 self
             }
         }
@@ -39788,7 +37229,7 @@ pub mod types {
             {
                 self.asn = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for asn: {}", e));
+                    .map_err(|e| format!("error converting supplied value for asn: {e}"));
                 self
             }
             pub fn bgp_announce_set_id<T>(mut self, value: T) -> Self
@@ -39797,10 +37238,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.bgp_announce_set_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for bgp_announce_set_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for bgp_announce_set_id: {e}")
                 });
                 self
             }
@@ -39811,7 +37249,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -39821,7 +37259,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn vrf<T>(mut self, value: T) -> Self
@@ -39831,7 +37269,7 @@ pub mod types {
             {
                 self.vrf = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vrf: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vrf: {e}"));
                 self
             }
         }
@@ -39889,7 +37327,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -39899,7 +37337,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -39954,7 +37392,7 @@ pub mod types {
             {
                 self.exports = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for exports: {}", e));
+                    .map_err(|e| format!("error converting supplied value for exports: {e}"));
                 self
             }
         }
@@ -40005,7 +37443,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn nexthop<T>(mut self, value: T) -> Self
@@ -40015,7 +37453,7 @@ pub mod types {
             {
                 self.nexthop = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for nexthop: {}", e));
+                    .map_err(|e| format!("error converting supplied value for nexthop: {e}"));
                 self
             }
             pub fn prefix<T>(mut self, value: T) -> Self
@@ -40025,7 +37463,7 @@ pub mod types {
             {
                 self.prefix = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for prefix: {}", e));
+                    .map_err(|e| format!("error converting supplied value for prefix: {e}"));
                 self
             }
             pub fn switch<T>(mut self, value: T) -> Self
@@ -40035,7 +37473,7 @@ pub mod types {
             {
                 self.switch = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                    .map_err(|e| format!("error converting supplied value for switch: {e}"));
                 self
             }
         }
@@ -40124,7 +37562,7 @@ pub mod types {
             {
                 self.addr = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for addr: {}", e));
+                    .map_err(|e| format!("error converting supplied value for addr: {e}"));
                 self
             }
             pub fn allowed_export<T>(mut self, value: T) -> Self
@@ -40133,7 +37571,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.allowed_export = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for allowed_export: {}", e)
+                    format!("error converting supplied value for allowed_export: {e}")
                 });
                 self
             }
@@ -40143,7 +37581,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.allowed_import = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for allowed_import: {}", e)
+                    format!("error converting supplied value for allowed_import: {e}")
                 });
                 self
             }
@@ -40154,7 +37592,7 @@ pub mod types {
             {
                 self.bgp_config = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bgp_config: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bgp_config: {e}"));
                 self
             }
             pub fn communities<T>(mut self, value: T) -> Self
@@ -40164,7 +37602,7 @@ pub mod types {
             {
                 self.communities = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for communities: {}", e));
+                    .map_err(|e| format!("error converting supplied value for communities: {e}"));
                 self
             }
             pub fn connect_retry<T>(mut self, value: T) -> Self
@@ -40172,9 +37610,9 @@ pub mod types {
                 T: ::std::convert::TryInto<u32>,
                 T::Error: ::std::fmt::Display,
             {
-                self.connect_retry = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for connect_retry: {}", e)
-                });
+                self.connect_retry = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for connect_retry: {e}"));
                 self
             }
             pub fn delay_open<T>(mut self, value: T) -> Self
@@ -40184,7 +37622,7 @@ pub mod types {
             {
                 self.delay_open = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for delay_open: {}", e));
+                    .map_err(|e| format!("error converting supplied value for delay_open: {e}"));
                 self
             }
             pub fn enforce_first_as<T>(mut self, value: T) -> Self
@@ -40193,10 +37631,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.enforce_first_as = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for enforce_first_as: {}",
-                        e
-                    )
+                    format!("error converting supplied value for enforce_first_as: {e}")
                 });
                 self
             }
@@ -40207,7 +37642,7 @@ pub mod types {
             {
                 self.hold_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for hold_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for hold_time: {e}"));
                 self
             }
             pub fn idle_hold_time<T>(mut self, value: T) -> Self
@@ -40216,7 +37651,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.idle_hold_time = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for idle_hold_time: {}", e)
+                    format!("error converting supplied value for idle_hold_time: {e}")
                 });
                 self
             }
@@ -40226,7 +37661,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.interface_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for interface_name: {}", e)
+                    format!("error converting supplied value for interface_name: {e}")
                 });
                 self
             }
@@ -40237,7 +37672,7 @@ pub mod types {
             {
                 self.keepalive = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for keepalive: {}", e));
+                    .map_err(|e| format!("error converting supplied value for keepalive: {e}"));
                 self
             }
             pub fn local_pref<T>(mut self, value: T) -> Self
@@ -40247,7 +37682,7 @@ pub mod types {
             {
                 self.local_pref = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for local_pref: {}", e));
+                    .map_err(|e| format!("error converting supplied value for local_pref: {e}"));
                 self
             }
             pub fn md5_auth_key<T>(mut self, value: T) -> Self
@@ -40255,9 +37690,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.md5_auth_key = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for md5_auth_key: {}", e)
-                });
+                self.md5_auth_key = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for md5_auth_key: {e}"));
                 self
             }
             pub fn min_ttl<T>(mut self, value: T) -> Self
@@ -40267,7 +37702,7 @@ pub mod types {
             {
                 self.min_ttl = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min_ttl: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min_ttl: {e}"));
                 self
             }
             pub fn multi_exit_discriminator<T>(mut self, value: T) -> Self
@@ -40276,10 +37711,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.multi_exit_discriminator = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for multi_exit_discriminator: {}",
-                        e
-                    )
+                    format!("error converting supplied value for multi_exit_discriminator: {e}")
                 });
                 self
             }
@@ -40290,7 +37722,7 @@ pub mod types {
             {
                 self.remote_asn = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for remote_asn: {}", e));
+                    .map_err(|e| format!("error converting supplied value for remote_asn: {e}"));
                 self
             }
             pub fn vlan_id<T>(mut self, value: T) -> Self
@@ -40300,7 +37732,7 @@ pub mod types {
             {
                 self.vlan_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vlan_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vlan_id: {e}"));
                 self
             }
         }
@@ -40381,7 +37813,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn peers<T>(mut self, value: T) -> Self
@@ -40391,7 +37823,7 @@ pub mod types {
             {
                 self.peers = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for peers: {}", e));
+                    .map_err(|e| format!("error converting supplied value for peers: {e}"));
                 self
             }
         }
@@ -40450,7 +37882,7 @@ pub mod types {
             {
                 self.addr = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for addr: {}", e));
+                    .map_err(|e| format!("error converting supplied value for addr: {e}"));
                 self
             }
             pub fn local_asn<T>(mut self, value: T) -> Self
@@ -40460,7 +37892,7 @@ pub mod types {
             {
                 self.local_asn = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for local_asn: {}", e));
+                    .map_err(|e| format!("error converting supplied value for local_asn: {e}"));
                 self
             }
             pub fn remote_asn<T>(mut self, value: T) -> Self
@@ -40470,7 +37902,7 @@ pub mod types {
             {
                 self.remote_asn = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for remote_asn: {}", e));
+                    .map_err(|e| format!("error converting supplied value for remote_asn: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -40480,7 +37912,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn state_duration_millis<T>(mut self, value: T) -> Self
@@ -40489,10 +37921,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.state_duration_millis = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for state_duration_millis: {}",
-                        e
-                    )
+                    format!("error converting supplied value for state_duration_millis: {e}")
                 });
                 self
             }
@@ -40503,7 +37932,7 @@ pub mod types {
             {
                 self.switch = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                    .map_err(|e| format!("error converting supplied value for switch: {e}"));
                 self
             }
         }
@@ -40560,7 +37989,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40570,7 +37999,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -40619,7 +38048,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40629,7 +38058,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -40678,7 +38107,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40688,7 +38117,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -40737,7 +38166,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40747,7 +38176,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -40796,7 +38225,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40806,7 +38235,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -40855,7 +38284,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40865,7 +38294,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -40914,7 +38343,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40924,7 +38353,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -40973,7 +38402,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -40983,7 +38412,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -41032,7 +38461,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -41042,7 +38471,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -41091,7 +38520,7 @@ pub mod types {
             {
                 self.count = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for count: {}", e));
+                    .map_err(|e| format!("error converting supplied value for count: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -41101,7 +38530,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
         }
@@ -41166,7 +38595,7 @@ pub mod types {
             {
                 self.cert = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for cert: {}", e));
+                    .map_err(|e| format!("error converting supplied value for cert: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -41176,7 +38605,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -41186,7 +38615,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -41196,7 +38625,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn service<T>(mut self, value: T) -> Self
@@ -41206,7 +38635,7 @@ pub mod types {
             {
                 self.service = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for service: {}", e));
+                    .map_err(|e| format!("error converting supplied value for service: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -41214,9 +38643,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -41224,9 +38653,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -41291,7 +38720,7 @@ pub mod types {
             {
                 self.cert = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for cert: {}", e));
+                    .map_err(|e| format!("error converting supplied value for cert: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -41301,7 +38730,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn key<T>(mut self, value: T) -> Self
@@ -41311,7 +38740,7 @@ pub mod types {
             {
                 self.key = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for key: {}", e));
+                    .map_err(|e| format!("error converting supplied value for key: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -41321,7 +38750,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn service<T>(mut self, value: T) -> Self
@@ -41331,7 +38760,7 @@ pub mod types {
             {
                 self.service = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for service: {}", e));
+                    .map_err(|e| format!("error converting supplied value for service: {e}"));
                 self
             }
         }
@@ -41390,7 +38819,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -41400,7 +38829,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -41457,7 +38886,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -41465,9 +38894,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_last_used<T>(mut self, value: T) -> Self
@@ -41476,7 +38905,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.time_last_used = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_last_used: {}", e)
+                    format!("error converting supplied value for time_last_used: {e}")
                 });
                 self
             }
@@ -41534,7 +38963,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -41544,7 +38973,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -41596,7 +39025,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn value<T>(mut self, value: T) -> Self
@@ -41606,7 +39035,7 @@ pub mod types {
             {
                 self.value = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for value: {}", e));
+                    .map_err(|e| format!("error converting supplied value for value: {e}"));
                 self
             }
         }
@@ -41658,7 +39087,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn value<T>(mut self, value: T) -> Self
@@ -41668,7 +39097,7 @@ pub mod types {
             {
                 self.value = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for value: {}", e));
+                    .map_err(|e| format!("error converting supplied value for value: {e}"));
                 self
             }
         }
@@ -41720,7 +39149,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn value<T>(mut self, value: T) -> Self
@@ -41730,7 +39159,7 @@ pub mod types {
             {
                 self.value = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for value: {}", e));
+                    .map_err(|e| format!("error converting supplied value for value: {e}"));
                 self
             }
         }
@@ -41782,7 +39211,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn value<T>(mut self, value: T) -> Self
@@ -41792,7 +39221,7 @@ pub mod types {
             {
                 self.value = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for value: {}", e));
+                    .map_err(|e| format!("error converting supplied value for value: {e}"));
                 self
             }
         }
@@ -41847,9 +39276,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.display_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for display_name: {}", e)
-                });
+                self.display_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for display_name: {e}"));
                 self
             }
             pub fn fleet_viewer<T>(mut self, value: T) -> Self
@@ -41857,9 +39286,9 @@ pub mod types {
                 T: ::std::convert::TryInto<bool>,
                 T::Error: ::std::fmt::Display,
             {
-                self.fleet_viewer = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for fleet_viewer: {}", e)
-                });
+                self.fleet_viewer = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for fleet_viewer: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -41869,7 +39298,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn silo_admin<T>(mut self, value: T) -> Self
@@ -41879,7 +39308,7 @@ pub mod types {
             {
                 self.silo_admin = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_admin: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_admin: {e}"));
                 self
             }
             pub fn silo_id<T>(mut self, value: T) -> Self
@@ -41889,7 +39318,7 @@ pub mod types {
             {
                 self.silo_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_id: {e}"));
                 self
             }
             pub fn silo_name<T>(mut self, value: T) -> Self
@@ -41899,7 +39328,7 @@ pub mod types {
             {
                 self.silo_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_name: {e}"));
                 self
             }
         }
@@ -41956,7 +39385,7 @@ pub mod types {
             {
                 self.private_key = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for private_key: {}", e));
+                    .map_err(|e| format!("error converting supplied value for private_key: {e}"));
                 self
             }
             pub fn public_cert<T>(mut self, value: T) -> Self
@@ -41966,7 +39395,7 @@ pub mod types {
             {
                 self.public_cert = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for public_cert: {}", e));
+                    .map_err(|e| format!("error converting supplied value for public_cert: {e}"));
                 self
             }
         }
@@ -42023,7 +39452,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -42031,9 +39460,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_expires<T>(mut self, value: T) -> Self
@@ -42043,9 +39472,9 @@ pub mod types {
                 >,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_expires = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_expires: {}", e)
-                });
+                self.time_expires = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_expires: {e}"));
                 self
             }
         }
@@ -42098,7 +39527,7 @@ pub mod types {
             {
                 self.client_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for client_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for client_id: {e}"));
                 self
             }
             pub fn device_code<T>(mut self, value: T) -> Self
@@ -42108,7 +39537,7 @@ pub mod types {
             {
                 self.device_code = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for device_code: {}", e));
+                    .map_err(|e| format!("error converting supplied value for device_code: {e}"));
                 self
             }
             pub fn grant_type<T>(mut self, value: T) -> Self
@@ -42118,7 +39547,7 @@ pub mod types {
             {
                 self.grant_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for grant_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for grant_type: {e}"));
                 self
             }
         }
@@ -42175,7 +39604,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -42185,7 +39614,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -42237,7 +39666,7 @@ pub mod types {
             {
                 self.client_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for client_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for client_id: {e}"));
                 self
             }
             pub fn ttl_seconds<T>(mut self, value: T) -> Self
@@ -42247,7 +39676,7 @@ pub mod types {
             {
                 self.ttl_seconds = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ttl_seconds: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ttl_seconds: {e}"));
                 self
             }
         }
@@ -42294,7 +39723,7 @@ pub mod types {
             {
                 self.user_code = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for user_code: {}", e));
+                    .map_err(|e| format!("error converting supplied value for user_code: {e}"));
                 self
             }
         }
@@ -42371,7 +39800,7 @@ pub mod types {
             {
                 self.block_size = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for block_size: {}", e));
+                    .map_err(|e| format!("error converting supplied value for block_size: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -42381,7 +39810,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn device_path<T>(mut self, value: T) -> Self
@@ -42391,7 +39820,7 @@ pub mod types {
             {
                 self.device_path = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for device_path: {}", e));
+                    .map_err(|e| format!("error converting supplied value for device_path: {e}"));
                 self
             }
             pub fn disk_type<T>(mut self, value: T) -> Self
@@ -42401,7 +39830,7 @@ pub mod types {
             {
                 self.disk_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for disk_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for disk_type: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -42411,7 +39840,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn image_id<T>(mut self, value: T) -> Self
@@ -42421,7 +39850,7 @@ pub mod types {
             {
                 self.image_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for image_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for image_id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -42431,7 +39860,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -42441,7 +39870,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn size<T>(mut self, value: T) -> Self
@@ -42451,7 +39880,7 @@ pub mod types {
             {
                 self.size = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for size: {}", e));
+                    .map_err(|e| format!("error converting supplied value for size: {e}"));
                 self
             }
             pub fn snapshot_id<T>(mut self, value: T) -> Self
@@ -42461,7 +39890,7 @@ pub mod types {
             {
                 self.snapshot_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for snapshot_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for snapshot_id: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -42471,7 +39900,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -42479,9 +39908,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -42489,9 +39918,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -42564,7 +39993,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn disk_backend<T>(mut self, value: T) -> Self
@@ -42572,9 +40001,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::DiskBackend>,
                 T::Error: ::std::fmt::Display,
             {
-                self.disk_backend = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for disk_backend: {}", e)
-                });
+                self.disk_backend = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for disk_backend: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -42584,7 +40013,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn size<T>(mut self, value: T) -> Self
@@ -42594,7 +40023,7 @@ pub mod types {
             {
                 self.size = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for size: {}", e));
+                    .map_err(|e| format!("error converting supplied value for size: {e}"));
                 self
             }
         }
@@ -42645,7 +40074,7 @@ pub mod types {
             {
                 self.disk = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for disk: {}", e));
+                    .map_err(|e| format!("error converting supplied value for disk: {e}"));
                 self
             }
         }
@@ -42693,7 +40122,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -42703,7 +40132,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -42766,7 +40195,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn counts<T>(mut self, value: T) -> Self
@@ -42776,7 +40205,7 @@ pub mod types {
             {
                 self.counts = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for counts: {}", e));
+                    .map_err(|e| format!("error converting supplied value for counts: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -42786,7 +40215,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -42796,7 +40225,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -42806,7 +40235,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -42816,7 +40245,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -42826,7 +40255,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -42834,9 +40263,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -42845,7 +40274,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -42923,7 +40352,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn counts<T>(mut self, value: T) -> Self
@@ -42933,7 +40362,7 @@ pub mod types {
             {
                 self.counts = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for counts: {}", e));
+                    .map_err(|e| format!("error converting supplied value for counts: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -42943,7 +40372,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -42953,7 +40382,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -42963,7 +40392,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -42973,7 +40402,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -42983,7 +40412,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -42991,9 +40420,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -43002,7 +40431,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -43072,7 +40501,7 @@ pub mod types {
             {
                 self.ip_version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_version: {e}"));
                 self
             }
             pub fn pool<T>(mut self, value: T) -> Self
@@ -43082,7 +40511,7 @@ pub mod types {
             {
                 self.pool = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pool: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pool: {e}"));
                 self
             }
         }
@@ -43136,7 +40565,7 @@ pub mod types {
             {
                 self.error_code = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for error_code: {}", e));
+                    .map_err(|e| format!("error converting supplied value for error_code: {e}"));
                 self
             }
             pub fn message<T>(mut self, value: T) -> Self
@@ -43146,7 +40575,7 @@ pub mod types {
             {
                 self.message = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for message: {}", e));
+                    .map_err(|e| format!("error converting supplied value for message: {e}"));
                 self
             }
             pub fn request_id<T>(mut self, value: T) -> Self
@@ -43156,7 +40585,7 @@ pub mod types {
             {
                 self.request_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for request_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for request_id: {e}"));
                 self
             }
         }
@@ -43210,7 +40639,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -43220,7 +40649,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -43273,7 +40702,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn field_type<T>(mut self, value: T) -> Self
@@ -43283,7 +40712,7 @@ pub mod types {
             {
                 self.field_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for field_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for field_type: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -43293,7 +40722,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn source<T>(mut self, value: T) -> Self
@@ -43303,7 +40732,7 @@ pub mod types {
             {
                 self.source = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for source: {}", e));
+                    .map_err(|e| format!("error converting supplied value for source: {e}"));
                 self
             }
         }
@@ -43353,9 +40782,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<super::Name>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.snapshot_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for snapshot_name: {}", e)
-                });
+                self.snapshot_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for snapshot_name: {e}"));
                 self
             }
         }
@@ -43402,10 +40831,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.role_assignments = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for role_assignments: {}",
-                        e
-                    )
+                    format!("error converting supplied value for role_assignments: {e}")
                 });
                 self
             }
@@ -43455,7 +40881,7 @@ pub mod types {
             {
                 self.identity_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for identity_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for identity_id: {e}"));
                 self
             }
             pub fn identity_type<T>(mut self, value: T) -> Self
@@ -43463,9 +40889,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::IdentityType>,
                 T::Error: ::std::fmt::Display,
             {
-                self.identity_type = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for identity_type: {}", e)
-                });
+                self.identity_type = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for identity_type: {e}"));
                 self
             }
             pub fn role_name<T>(mut self, value: T) -> Self
@@ -43475,7 +40901,7 @@ pub mod types {
             {
                 self.role_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for role_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for role_name: {e}"));
                 self
             }
         }
@@ -43547,7 +40973,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -43557,7 +40983,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn instance_id<T>(mut self, value: T) -> Self
@@ -43567,7 +40993,7 @@ pub mod types {
             {
                 self.instance_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for instance_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for instance_id: {e}"));
                 self
             }
             pub fn ip<T>(mut self, value: T) -> Self
@@ -43577,7 +41003,7 @@ pub mod types {
             {
                 self.ip = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip: {e}"));
                 self
             }
             pub fn ip_pool_id<T>(mut self, value: T) -> Self
@@ -43587,7 +41013,7 @@ pub mod types {
             {
                 self.ip_pool_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -43597,7 +41023,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -43607,7 +41033,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -43615,9 +41041,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -43625,9 +41051,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -43690,7 +41116,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn parent<T>(mut self, value: T) -> Self
@@ -43700,7 +41126,7 @@ pub mod types {
             {
                 self.parent = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for parent: {}", e));
+                    .map_err(|e| format!("error converting supplied value for parent: {e}"));
                 self
             }
         }
@@ -43764,7 +41190,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn ip<T>(mut self, value: T) -> Self
@@ -43774,7 +41200,7 @@ pub mod types {
             {
                 self.ip = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip: {e}"));
                 self
             }
             pub fn ip_version<T>(mut self, value: T) -> Self
@@ -43784,7 +41210,7 @@ pub mod types {
             {
                 self.ip_version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_version: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -43794,7 +41220,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn pool<T>(mut self, value: T) -> Self
@@ -43804,7 +41230,7 @@ pub mod types {
             {
                 self.pool = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pool: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pool: {e}"));
                 self
             }
         }
@@ -43862,7 +41288,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -43872,7 +41298,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -43924,7 +41350,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -43934,7 +41360,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -43983,9 +41409,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.display_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for display_name: {}", e)
-                });
+                self.display_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for display_name: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -43995,7 +41421,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn silo_id<T>(mut self, value: T) -> Self
@@ -44005,7 +41431,7 @@ pub mod types {
             {
                 self.silo_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_id: {e}"));
                 self
             }
         }
@@ -44059,7 +41485,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -44069,7 +41495,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -44137,7 +41563,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -44147,7 +41573,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -44157,7 +41583,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -44167,7 +41593,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -44177,7 +41603,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -44187,7 +41613,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -44197,7 +41623,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -44205,9 +41631,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -44217,7 +41643,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -44226,7 +41652,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -44311,7 +41737,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -44321,7 +41747,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -44331,7 +41757,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -44341,7 +41767,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -44351,7 +41777,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -44361,7 +41787,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -44371,7 +41797,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -44379,9 +41805,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -44391,7 +41817,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -44400,7 +41826,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -44485,7 +41911,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -44495,7 +41921,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -44505,7 +41931,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -44515,7 +41941,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -44525,7 +41951,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -44535,7 +41961,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -44545,7 +41971,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -44553,9 +41979,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -44565,7 +41991,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -44574,7 +42000,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -44659,7 +42085,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -44669,7 +42095,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -44679,7 +42105,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -44689,7 +42115,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -44699,7 +42125,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -44709,7 +42135,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -44719,7 +42145,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -44727,9 +42153,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -44739,7 +42165,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -44748,7 +42174,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -44833,7 +42259,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -44843,7 +42269,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -44853,7 +42279,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -44863,7 +42289,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -44873,7 +42299,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -44883,7 +42309,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -44893,7 +42319,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -44901,9 +42327,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -44913,7 +42339,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -44922,7 +42348,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -45007,7 +42433,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -45017,7 +42443,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -45027,7 +42453,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -45037,7 +42463,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -45047,7 +42473,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -45057,7 +42483,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -45067,7 +42493,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -45075,9 +42501,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -45087,7 +42513,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -45096,7 +42522,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -45181,7 +42607,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -45191,7 +42617,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -45201,7 +42627,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -45211,7 +42637,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -45221,7 +42647,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -45231,7 +42657,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -45241,7 +42667,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -45249,9 +42675,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -45261,7 +42687,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -45270,7 +42696,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -45355,7 +42781,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -45365,7 +42791,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -45375,7 +42801,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -45385,7 +42811,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -45395,7 +42821,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -45405,7 +42831,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -45415,7 +42841,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -45423,9 +42849,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -45435,7 +42861,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -45444,7 +42870,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -45529,7 +42955,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -45539,7 +42965,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -45549,7 +42975,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -45559,7 +42985,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -45569,7 +42995,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -45579,7 +43005,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -45589,7 +43015,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -45597,9 +43023,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -45609,7 +43035,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -45618,7 +43044,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -45703,7 +43129,7 @@ pub mod types {
             {
                 self.bins = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bins: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bins: {e}"));
                 self
             }
             pub fn max<T>(mut self, value: T) -> Self
@@ -45713,7 +43139,7 @@ pub mod types {
             {
                 self.max = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for max: {}", e));
+                    .map_err(|e| format!("error converting supplied value for max: {e}"));
                 self
             }
             pub fn min<T>(mut self, value: T) -> Self
@@ -45723,7 +43149,7 @@ pub mod types {
             {
                 self.min = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for min: {}", e));
+                    .map_err(|e| format!("error converting supplied value for min: {e}"));
                 self
             }
             pub fn n_samples<T>(mut self, value: T) -> Self
@@ -45733,7 +43159,7 @@ pub mod types {
             {
                 self.n_samples = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for n_samples: {}", e));
+                    .map_err(|e| format!("error converting supplied value for n_samples: {e}"));
                 self
             }
             pub fn p50<T>(mut self, value: T) -> Self
@@ -45743,7 +43169,7 @@ pub mod types {
             {
                 self.p50 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p50: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p50: {e}"));
                 self
             }
             pub fn p90<T>(mut self, value: T) -> Self
@@ -45753,7 +43179,7 @@ pub mod types {
             {
                 self.p90 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p90: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p90: {e}"));
                 self
             }
             pub fn p99<T>(mut self, value: T) -> Self
@@ -45763,7 +43189,7 @@ pub mod types {
             {
                 self.p99 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p99: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p99: {e}"));
                 self
             }
             pub fn squared_mean<T>(mut self, value: T) -> Self
@@ -45771,9 +43197,9 @@ pub mod types {
                 T: ::std::convert::TryInto<f64>,
                 T::Error: ::std::fmt::Display,
             {
-                self.squared_mean = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for squared_mean: {}", e)
-                });
+                self.squared_mean = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for squared_mean: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -45783,7 +43209,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
             pub fn sum_of_samples<T>(mut self, value: T) -> Self
@@ -45792,7 +43218,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.sum_of_samples = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sum_of_samples: {}", e)
+                    format!("error converting supplied value for sum_of_samples: {e}")
                 });
                 self
             }
@@ -45873,7 +43299,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -45883,7 +43309,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -45893,7 +43319,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn provider_type<T>(mut self, value: T) -> Self
@@ -45901,9 +43327,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::IdentityProviderType>,
                 T::Error: ::std::fmt::Display,
             {
-                self.provider_type = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for provider_type: {}", e)
-                });
+                self.provider_type = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for provider_type: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -45911,9 +43337,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -45921,9 +43347,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -45986,7 +43412,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -45996,7 +43422,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -46071,7 +43497,7 @@ pub mod types {
             {
                 self.block_size = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for block_size: {}", e));
+                    .map_err(|e| format!("error converting supplied value for block_size: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -46081,7 +43507,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn digest<T>(mut self, value: T) -> Self
@@ -46091,7 +43517,7 @@ pub mod types {
             {
                 self.digest = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for digest: {}", e));
+                    .map_err(|e| format!("error converting supplied value for digest: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -46101,7 +43527,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -46111,7 +43537,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn os<T>(mut self, value: T) -> Self
@@ -46121,7 +43547,7 @@ pub mod types {
             {
                 self.os = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for os: {}", e));
+                    .map_err(|e| format!("error converting supplied value for os: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -46131,7 +43557,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn size<T>(mut self, value: T) -> Self
@@ -46141,7 +43567,7 @@ pub mod types {
             {
                 self.size = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for size: {}", e));
+                    .map_err(|e| format!("error converting supplied value for size: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -46149,9 +43575,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -46159,9 +43585,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn version<T>(mut self, value: T) -> Self
@@ -46171,7 +43597,7 @@ pub mod types {
             {
                 self.version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for version: {e}"));
                 self
             }
         }
@@ -46244,7 +43670,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -46254,7 +43680,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn os<T>(mut self, value: T) -> Self
@@ -46264,7 +43690,7 @@ pub mod types {
             {
                 self.os = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for os: {}", e));
+                    .map_err(|e| format!("error converting supplied value for os: {e}"));
                 self
             }
             pub fn source<T>(mut self, value: T) -> Self
@@ -46274,7 +43700,7 @@ pub mod types {
             {
                 self.source = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for source: {}", e));
+                    .map_err(|e| format!("error converting supplied value for source: {e}"));
                 self
             }
             pub fn version<T>(mut self, value: T) -> Self
@@ -46284,7 +43710,7 @@ pub mod types {
             {
                 self.version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for version: {e}"));
                 self
             }
         }
@@ -46342,7 +43768,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -46352,7 +43778,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -46403,10 +43829,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.base64_encoded_data = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for base64_encoded_data: {}",
-                        e
-                    )
+                    format!("error converting supplied value for base64_encoded_data: {e}")
                 });
                 self
             }
@@ -46417,7 +43840,7 @@ pub mod types {
             {
                 self.offset = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for offset: {}", e));
+                    .map_err(|e| format!("error converting supplied value for offset: {e}"));
                 self
             }
         }
@@ -46524,8 +43947,7 @@ pub mod types {
             {
                 self.auto_restart_cooldown_expiration = value.try_into().map_err(|e| {
                     format!(
-                        "error converting supplied value for auto_restart_cooldown_expiration: {}",
-                        e
+                        "error converting supplied value for auto_restart_cooldown_expiration: {e}"
                     )
                 });
                 self
@@ -46536,10 +43958,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.auto_restart_enabled = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for auto_restart_enabled: {}",
-                        e
-                    )
+                    format!("error converting supplied value for auto_restart_enabled: {e}")
                 });
                 self
             }
@@ -46549,10 +43968,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.auto_restart_policy = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for auto_restart_policy: {}",
-                        e
-                    )
+                    format!("error converting supplied value for auto_restart_policy: {e}")
                 });
                 self
             }
@@ -46561,9 +43977,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::uuid::Uuid>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.boot_disk_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for boot_disk_id: {}", e)
-                });
+                self.boot_disk_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for boot_disk_id: {e}"));
                 self
             }
             pub fn cpu_platform<T>(mut self, value: T) -> Self
@@ -46571,9 +43987,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<super::InstanceCpuPlatform>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.cpu_platform = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for cpu_platform: {}", e)
-                });
+                self.cpu_platform = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for cpu_platform: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -46583,7 +43999,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn hostname<T>(mut self, value: T) -> Self
@@ -46593,7 +44009,7 @@ pub mod types {
             {
                 self.hostname = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for hostname: {}", e));
+                    .map_err(|e| format!("error converting supplied value for hostname: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -46603,7 +44019,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -46613,7 +44029,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -46623,7 +44039,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn ncpus<T>(mut self, value: T) -> Self
@@ -46633,7 +44049,7 @@ pub mod types {
             {
                 self.ncpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ncpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ncpus: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -46643,7 +44059,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn run_state<T>(mut self, value: T) -> Self
@@ -46653,7 +44069,7 @@ pub mod types {
             {
                 self.run_state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for run_state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for run_state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -46661,9 +44077,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_last_auto_restarted<T>(mut self, value: T) -> Self
@@ -46674,10 +44090,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.time_last_auto_restarted = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for time_last_auto_restarted: {}",
-                        e
-                    )
+                    format!("error converting supplied value for time_last_auto_restarted: {e}")
                 });
                 self
             }
@@ -46686,9 +44099,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn time_run_state_updated<T>(mut self, value: T) -> Self
@@ -46697,10 +44110,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.time_run_state_updated = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for time_run_state_updated: {}",
-                        e
-                    )
+                    format!("error converting supplied value for time_run_state_updated: {e}")
                 });
                 self
             }
@@ -46830,10 +44240,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.anti_affinity_groups = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for anti_affinity_groups: {}",
-                        e
-                    )
+                    format!("error converting supplied value for anti_affinity_groups: {e}")
                 });
                 self
             }
@@ -46843,10 +44250,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.auto_restart_policy = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for auto_restart_policy: {}",
-                        e
-                    )
+                    format!("error converting supplied value for auto_restart_policy: {e}")
                 });
                 self
             }
@@ -46857,7 +44261,7 @@ pub mod types {
             {
                 self.boot_disk = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for boot_disk: {}", e));
+                    .map_err(|e| format!("error converting supplied value for boot_disk: {e}"));
                 self
             }
             pub fn cpu_platform<T>(mut self, value: T) -> Self
@@ -46865,9 +44269,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<super::InstanceCpuPlatform>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.cpu_platform = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for cpu_platform: {}", e)
-                });
+                self.cpu_platform = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for cpu_platform: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -46877,7 +44281,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn disks<T>(mut self, value: T) -> Self
@@ -46887,7 +44291,7 @@ pub mod types {
             {
                 self.disks = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for disks: {}", e));
+                    .map_err(|e| format!("error converting supplied value for disks: {e}"));
                 self
             }
             pub fn external_ips<T>(mut self, value: T) -> Self
@@ -46895,9 +44299,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::vec::Vec<super::ExternalIpCreate>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.external_ips = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for external_ips: {}", e)
-                });
+                self.external_ips = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for external_ips: {e}"));
                 self
             }
             pub fn hostname<T>(mut self, value: T) -> Self
@@ -46907,7 +44311,7 @@ pub mod types {
             {
                 self.hostname = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for hostname: {}", e));
+                    .map_err(|e| format!("error converting supplied value for hostname: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -46917,7 +44321,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn multicast_groups<T>(mut self, value: T) -> Self
@@ -46926,10 +44330,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.multicast_groups = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for multicast_groups: {}",
-                        e
-                    )
+                    format!("error converting supplied value for multicast_groups: {e}")
                 });
                 self
             }
@@ -46940,7 +44341,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn ncpus<T>(mut self, value: T) -> Self
@@ -46950,7 +44351,7 @@ pub mod types {
             {
                 self.ncpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ncpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ncpus: {e}"));
                 self
             }
             pub fn network_interfaces<T>(mut self, value: T) -> Self
@@ -46959,10 +44360,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.network_interfaces = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for network_interfaces: {}",
-                        e
-                    )
+                    format!("error converting supplied value for network_interfaces: {e}")
                 });
                 self
             }
@@ -46972,7 +44370,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.ssh_public_keys = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for ssh_public_keys: {}", e)
+                    format!("error converting supplied value for ssh_public_keys: {e}")
                 });
                 self
             }
@@ -46983,7 +44381,7 @@ pub mod types {
             {
                 self.start = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start: {e}"));
                 self
             }
             pub fn user_data<T>(mut self, value: T) -> Self
@@ -46993,7 +44391,7 @@ pub mod types {
             {
                 self.user_data = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for user_data: {}", e));
+                    .map_err(|e| format!("error converting supplied value for user_data: {e}"));
                 self
             }
         }
@@ -47097,7 +44495,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -47107,7 +44505,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn instance_id<T>(mut self, value: T) -> Self
@@ -47117,7 +44515,7 @@ pub mod types {
             {
                 self.instance_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for instance_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for instance_id: {e}"));
                 self
             }
             pub fn ip<T>(mut self, value: T) -> Self
@@ -47127,7 +44525,7 @@ pub mod types {
             {
                 self.ip = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip: {e}"));
                 self
             }
             pub fn mac<T>(mut self, value: T) -> Self
@@ -47137,7 +44535,7 @@ pub mod types {
             {
                 self.mac = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mac: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mac: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -47147,7 +44545,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn primary<T>(mut self, value: T) -> Self
@@ -47157,7 +44555,7 @@ pub mod types {
             {
                 self.primary = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for primary: {}", e));
+                    .map_err(|e| format!("error converting supplied value for primary: {e}"));
                 self
             }
             pub fn subnet_id<T>(mut self, value: T) -> Self
@@ -47167,7 +44565,7 @@ pub mod types {
             {
                 self.subnet_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for subnet_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for subnet_id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -47175,9 +44573,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -47185,9 +44583,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn transit_ips<T>(mut self, value: T) -> Self
@@ -47197,7 +44595,7 @@ pub mod types {
             {
                 self.transit_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for transit_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for transit_ips: {e}"));
                 self
             }
             pub fn vpc_id<T>(mut self, value: T) -> Self
@@ -47207,7 +44605,7 @@ pub mod types {
             {
                 self.vpc_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vpc_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vpc_id: {e}"));
                 self
             }
         }
@@ -47288,7 +44686,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn ip<T>(mut self, value: T) -> Self
@@ -47298,7 +44696,7 @@ pub mod types {
             {
                 self.ip = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -47308,7 +44706,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn subnet_name<T>(mut self, value: T) -> Self
@@ -47318,7 +44716,7 @@ pub mod types {
             {
                 self.subnet_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for subnet_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for subnet_name: {e}"));
                 self
             }
             pub fn transit_ips<T>(mut self, value: T) -> Self
@@ -47328,7 +44726,7 @@ pub mod types {
             {
                 self.transit_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for transit_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for transit_ips: {e}"));
                 self
             }
             pub fn vpc_name<T>(mut self, value: T) -> Self
@@ -47338,7 +44736,7 @@ pub mod types {
             {
                 self.vpc_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vpc_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vpc_name: {e}"));
                 self
             }
         }
@@ -47405,7 +44803,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -47415,7 +44813,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -47476,7 +44874,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -47486,7 +44884,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn primary<T>(mut self, value: T) -> Self
@@ -47496,7 +44894,7 @@ pub mod types {
             {
                 self.primary = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for primary: {}", e));
+                    .map_err(|e| format!("error converting supplied value for primary: {e}"));
                 self
             }
             pub fn transit_ips<T>(mut self, value: T) -> Self
@@ -47506,7 +44904,7 @@ pub mod types {
             {
                 self.transit_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for transit_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for transit_ips: {e}"));
                 self
             }
         }
@@ -47566,7 +44964,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -47576,7 +44974,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -47625,7 +45023,7 @@ pub mod types {
             {
                 self.data = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for data: {}", e));
+                    .map_err(|e| format!("error converting supplied value for data: {e}"));
                 self
             }
             pub fn last_byte_offset<T>(mut self, value: T) -> Self
@@ -47634,10 +45032,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.last_byte_offset = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for last_byte_offset: {}",
-                        e
-                    )
+                    format!("error converting supplied value for last_byte_offset: {e}")
                 });
                 self
             }
@@ -47708,10 +45103,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.auto_restart_policy = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for auto_restart_policy: {}",
-                        e
-                    )
+                    format!("error converting supplied value for auto_restart_policy: {e}")
                 });
                 self
             }
@@ -47722,7 +45114,7 @@ pub mod types {
             {
                 self.boot_disk = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for boot_disk: {}", e));
+                    .map_err(|e| format!("error converting supplied value for boot_disk: {e}"));
                 self
             }
             pub fn cpu_platform<T>(mut self, value: T) -> Self
@@ -47730,9 +45122,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<super::InstanceCpuPlatform>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.cpu_platform = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for cpu_platform: {}", e)
-                });
+                self.cpu_platform = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for cpu_platform: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -47742,7 +45134,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn multicast_groups<T>(mut self, value: T) -> Self
@@ -47751,10 +45143,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.multicast_groups = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for multicast_groups: {}",
-                        e
-                    )
+                    format!("error converting supplied value for multicast_groups: {e}")
                 });
                 self
             }
@@ -47765,7 +45154,7 @@ pub mod types {
             {
                 self.ncpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ncpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ncpus: {e}"));
                 self
             }
         }
@@ -47836,7 +45225,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -47846,7 +45235,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -47856,7 +45245,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -47864,9 +45253,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -47874,9 +45263,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vpc_id<T>(mut self, value: T) -> Self
@@ -47886,7 +45275,7 @@ pub mod types {
             {
                 self.vpc_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vpc_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vpc_id: {e}"));
                 self
             }
         }
@@ -47943,7 +45332,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -47953,7 +45342,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -48020,7 +45409,7 @@ pub mod types {
             {
                 self.address = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -48030,7 +45419,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -48040,7 +45429,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn internet_gateway_id<T>(mut self, value: T) -> Self
@@ -48049,10 +45438,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.internet_gateway_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for internet_gateway_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for internet_gateway_id: {e}")
                 });
                 self
             }
@@ -48063,7 +45449,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -48071,9 +45457,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -48081,9 +45467,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -48144,7 +45530,7 @@ pub mod types {
             {
                 self.address = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -48154,7 +45540,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -48164,7 +45550,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -48225,7 +45611,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -48235,7 +45621,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -48306,7 +45692,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -48316,7 +45702,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn internet_gateway_id<T>(mut self, value: T) -> Self
@@ -48325,10 +45711,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.internet_gateway_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for internet_gateway_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for internet_gateway_id: {e}")
                 });
                 self
             }
@@ -48339,7 +45722,7 @@ pub mod types {
             {
                 self.ip_pool_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -48349,7 +45732,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -48357,9 +45740,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -48367,9 +45750,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -48430,7 +45813,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn ip_pool<T>(mut self, value: T) -> Self
@@ -48440,7 +45823,7 @@ pub mod types {
             {
                 self.ip_pool = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_pool: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_pool: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -48450,7 +45833,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -48507,7 +45890,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -48517,7 +45900,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -48576,7 +45959,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -48586,7 +45969,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -48651,7 +46034,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -48661,7 +46044,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn ip_version<T>(mut self, value: T) -> Self
@@ -48671,7 +46054,7 @@ pub mod types {
             {
                 self.ip_version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_version: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -48681,7 +46064,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn pool_type<T>(mut self, value: T) -> Self
@@ -48691,7 +46074,7 @@ pub mod types {
             {
                 self.pool_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pool_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pool_type: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -48699,9 +46082,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -48709,9 +46092,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -48774,7 +46157,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn ip_version<T>(mut self, value: T) -> Self
@@ -48784,7 +46167,7 @@ pub mod types {
             {
                 self.ip_version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_version: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -48794,7 +46177,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn pool_type<T>(mut self, value: T) -> Self
@@ -48804,7 +46187,7 @@ pub mod types {
             {
                 self.pool_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pool_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pool_type: {e}"));
                 self
             }
         }
@@ -48857,7 +46240,7 @@ pub mod types {
             {
                 self.is_default = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for is_default: {}", e));
+                    .map_err(|e| format!("error converting supplied value for is_default: {e}"));
                 self
             }
             pub fn silo<T>(mut self, value: T) -> Self
@@ -48867,7 +46250,7 @@ pub mod types {
             {
                 self.silo = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo: {e}"));
                 self
             }
         }
@@ -48923,7 +46306,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn ip_pool_id<T>(mut self, value: T) -> Self
@@ -48933,7 +46316,7 @@ pub mod types {
             {
                 self.ip_pool_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {e}"));
                 self
             }
             pub fn range<T>(mut self, value: T) -> Self
@@ -48943,7 +46326,7 @@ pub mod types {
             {
                 self.range = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for range: {}", e));
+                    .map_err(|e| format!("error converting supplied value for range: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -48951,9 +46334,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
         }
@@ -49010,7 +46393,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -49020,7 +46403,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -49072,7 +46455,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -49082,7 +46465,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -49133,7 +46516,7 @@ pub mod types {
             {
                 self.ip_pool_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {e}"));
                 self
             }
             pub fn is_default<T>(mut self, value: T) -> Self
@@ -49143,7 +46526,7 @@ pub mod types {
             {
                 self.is_default = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for is_default: {}", e));
+                    .map_err(|e| format!("error converting supplied value for is_default: {e}"));
                 self
             }
             pub fn silo_id<T>(mut self, value: T) -> Self
@@ -49153,7 +46536,7 @@ pub mod types {
             {
                 self.silo_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_id: {e}"));
                 self
             }
         }
@@ -49210,7 +46593,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -49220,7 +46603,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -49267,7 +46650,7 @@ pub mod types {
             {
                 self.is_default = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for is_default: {}", e));
+                    .map_err(|e| format!("error converting supplied value for is_default: {e}"));
                 self
             }
         }
@@ -49317,7 +46700,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -49327,7 +46710,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -49376,7 +46759,7 @@ pub mod types {
             {
                 self.capacity = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for capacity: {}", e));
+                    .map_err(|e| format!("error converting supplied value for capacity: {e}"));
                 self
             }
             pub fn remaining<T>(mut self, value: T) -> Self
@@ -49386,7 +46769,7 @@ pub mod types {
             {
                 self.remaining = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for remaining: {}", e));
+                    .map_err(|e| format!("error converting supplied value for remaining: {e}"));
                 self
             }
         }
@@ -49435,7 +46818,7 @@ pub mod types {
             {
                 self.first = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for first: {}", e));
+                    .map_err(|e| format!("error converting supplied value for first: {e}"));
                 self
             }
             pub fn last<T>(mut self, value: T) -> Self
@@ -49445,7 +46828,7 @@ pub mod types {
             {
                 self.last = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for last: {}", e));
+                    .map_err(|e| format!("error converting supplied value for last: {e}"));
                 self
             }
         }
@@ -49494,7 +46877,7 @@ pub mod types {
             {
                 self.first = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for first: {}", e));
+                    .map_err(|e| format!("error converting supplied value for first: {e}"));
                 self
             }
             pub fn last<T>(mut self, value: T) -> Self
@@ -49504,7 +46887,7 @@ pub mod types {
             {
                 self.last = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for last: {}", e));
+                    .map_err(|e| format!("error converting supplied value for last: {e}"));
                 self
             }
         }
@@ -49567,7 +46950,7 @@ pub mod types {
             {
                 self.autoneg = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for autoneg: {}", e));
+                    .map_err(|e| format!("error converting supplied value for autoneg: {e}"));
                 self
             }
             pub fn fec<T>(mut self, value: T) -> Self
@@ -49577,7 +46960,7 @@ pub mod types {
             {
                 self.fec = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for fec: {}", e));
+                    .map_err(|e| format!("error converting supplied value for fec: {e}"));
                 self
             }
             pub fn link_name<T>(mut self, value: T) -> Self
@@ -49587,7 +46970,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn lldp<T>(mut self, value: T) -> Self
@@ -49597,7 +46980,7 @@ pub mod types {
             {
                 self.lldp = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for lldp: {}", e));
+                    .map_err(|e| format!("error converting supplied value for lldp: {e}"));
                 self
             }
             pub fn mtu<T>(mut self, value: T) -> Self
@@ -49607,7 +46990,7 @@ pub mod types {
             {
                 self.mtu = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mtu: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mtu: {e}"));
                 self
             }
             pub fn speed<T>(mut self, value: T) -> Self
@@ -49617,7 +47000,7 @@ pub mod types {
             {
                 self.speed = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for speed: {}", e));
+                    .map_err(|e| format!("error converting supplied value for speed: {e}"));
                 self
             }
             pub fn tx_eq<T>(mut self, value: T) -> Self
@@ -49627,7 +47010,7 @@ pub mod types {
             {
                 self.tx_eq = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for tx_eq: {}", e));
+                    .map_err(|e| format!("error converting supplied value for tx_eq: {e}"));
                 self
             }
         }
@@ -49716,7 +47099,7 @@ pub mod types {
             {
                 self.chassis_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for chassis_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for chassis_id: {e}"));
                 self
             }
             pub fn enabled<T>(mut self, value: T) -> Self
@@ -49726,7 +47109,7 @@ pub mod types {
             {
                 self.enabled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for enabled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for enabled: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -49736,7 +47119,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn link_description<T>(mut self, value: T) -> Self
@@ -49745,10 +47128,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.link_description = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for link_description: {}",
-                        e
-                    )
+                    format!("error converting supplied value for link_description: {e}")
                 });
                 self
             }
@@ -49759,7 +47139,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn management_ip<T>(mut self, value: T) -> Self
@@ -49767,9 +47147,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::std::net::IpAddr>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.management_ip = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for management_ip: {}", e)
-                });
+                self.management_ip = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for management_ip: {e}"));
                 self
             }
             pub fn system_description<T>(mut self, value: T) -> Self
@@ -49778,10 +47158,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.system_description = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for system_description: {}",
-                        e
-                    )
+                    format!("error converting supplied value for system_description: {e}")
                 });
                 self
             }
@@ -49792,7 +47169,7 @@ pub mod types {
             {
                 self.system_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for system_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for system_name: {e}"));
                 self
             }
         }
@@ -49881,7 +47258,7 @@ pub mod types {
             {
                 self.chassis_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for chassis_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for chassis_id: {e}"));
                 self
             }
             pub fn enabled<T>(mut self, value: T) -> Self
@@ -49891,7 +47268,7 @@ pub mod types {
             {
                 self.enabled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for enabled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for enabled: {e}"));
                 self
             }
             pub fn link_description<T>(mut self, value: T) -> Self
@@ -49900,10 +47277,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.link_description = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for link_description: {}",
-                        e
-                    )
+                    format!("error converting supplied value for link_description: {e}")
                 });
                 self
             }
@@ -49914,7 +47288,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn management_ip<T>(mut self, value: T) -> Self
@@ -49922,9 +47296,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::std::net::IpAddr>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.management_ip = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for management_ip: {}", e)
-                });
+                self.management_ip = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for management_ip: {e}"));
                 self
             }
             pub fn system_description<T>(mut self, value: T) -> Self
@@ -49933,10 +47307,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.system_description = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for system_description: {}",
-                        e
-                    )
+                    format!("error converting supplied value for system_description: {e}")
                 });
                 self
             }
@@ -49947,7 +47318,7 @@ pub mod types {
             {
                 self.system_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for system_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for system_name: {e}"));
                 self
             }
         }
@@ -50038,7 +47409,7 @@ pub mod types {
             {
                 self.chassis_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for chassis_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for chassis_id: {e}"));
                 self
             }
             pub fn first_seen<T>(mut self, value: T) -> Self
@@ -50048,7 +47419,7 @@ pub mod types {
             {
                 self.first_seen = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for first_seen: {}", e));
+                    .map_err(|e| format!("error converting supplied value for first_seen: {e}"));
                 self
             }
             pub fn last_seen<T>(mut self, value: T) -> Self
@@ -50058,7 +47429,7 @@ pub mod types {
             {
                 self.last_seen = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for last_seen: {}", e));
+                    .map_err(|e| format!("error converting supplied value for last_seen: {e}"));
                 self
             }
             pub fn link_description<T>(mut self, value: T) -> Self
@@ -50067,10 +47438,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.link_description = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for link_description: {}",
-                        e
-                    )
+                    format!("error converting supplied value for link_description: {e}")
                 });
                 self
             }
@@ -50081,7 +47449,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn local_port<T>(mut self, value: T) -> Self
@@ -50091,7 +47459,7 @@ pub mod types {
             {
                 self.local_port = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for local_port: {}", e));
+                    .map_err(|e| format!("error converting supplied value for local_port: {e}"));
                 self
             }
             pub fn management_ip<T>(mut self, value: T) -> Self
@@ -50099,9 +47467,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::vec::Vec<super::ManagementAddress>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.management_ip = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for management_ip: {}", e)
-                });
+                self.management_ip = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for management_ip: {e}"));
                 self
             }
             pub fn system_description<T>(mut self, value: T) -> Self
@@ -50110,10 +47478,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.system_description = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for system_description: {}",
-                        e
-                    )
+                    format!("error converting supplied value for system_description: {e}")
                 });
                 self
             }
@@ -50124,7 +47489,7 @@ pub mod types {
             {
                 self.system_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for system_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for system_name: {e}"));
                 self
             }
         }
@@ -50191,7 +47556,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -50201,7 +47566,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -50258,7 +47623,7 @@ pub mod types {
             {
                 self.address = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address: {e}"));
                 self
             }
             pub fn address_lot_block_id<T>(mut self, value: T) -> Self
@@ -50267,10 +47632,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.address_lot_block_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for address_lot_block_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for address_lot_block_id: {e}")
                 });
                 self
             }
@@ -50281,7 +47643,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn rack_id<T>(mut self, value: T) -> Self
@@ -50291,7 +47653,7 @@ pub mod types {
             {
                 self.rack_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rack_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rack_id: {e}"));
                 self
             }
             pub fn switch_location<T>(mut self, value: T) -> Self
@@ -50300,7 +47662,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.switch_location = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for switch_location: {}", e)
+                    format!("error converting supplied value for switch_location: {e}")
                 });
                 self
             }
@@ -50364,7 +47726,7 @@ pub mod types {
             {
                 self.address = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address: {e}"));
                 self
             }
             pub fn address_lot<T>(mut self, value: T) -> Self
@@ -50374,7 +47736,7 @@ pub mod types {
             {
                 self.address_lot = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address_lot: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address_lot: {e}"));
                 self
             }
             pub fn anycast<T>(mut self, value: T) -> Self
@@ -50384,7 +47746,7 @@ pub mod types {
             {
                 self.anycast = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for anycast: {}", e));
+                    .map_err(|e| format!("error converting supplied value for anycast: {e}"));
                 self
             }
             pub fn mask<T>(mut self, value: T) -> Self
@@ -50394,7 +47756,7 @@ pub mod types {
             {
                 self.mask = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mask: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mask: {e}"));
                 self
             }
             pub fn rack_id<T>(mut self, value: T) -> Self
@@ -50404,7 +47766,7 @@ pub mod types {
             {
                 self.rack_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rack_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rack_id: {e}"));
                 self
             }
             pub fn switch_location<T>(mut self, value: T) -> Self
@@ -50413,7 +47775,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.switch_location = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for switch_location: {}", e)
+                    format!("error converting supplied value for switch_location: {e}")
                 });
                 self
             }
@@ -50477,7 +47839,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -50487,7 +47849,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -50541,7 +47903,7 @@ pub mod types {
             {
                 self.addr = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for addr: {}", e));
+                    .map_err(|e| format!("error converting supplied value for addr: {e}"));
                 self
             }
             pub fn interface_num<T>(mut self, value: T) -> Self
@@ -50549,9 +47911,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::InterfaceNum>,
                 T::Error: ::std::fmt::Display,
             {
-                self.interface_num = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for interface_num: {}", e)
-                });
+                self.interface_num = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for interface_num: {e}"));
                 self
             }
             pub fn oid<T>(mut self, value: T) -> Self
@@ -50561,7 +47923,7 @@ pub mod types {
             {
                 self.oid = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for oid: {}", e));
+                    .map_err(|e| format!("error converting supplied value for oid: {e}"));
                 self
             }
         }
@@ -50615,7 +47977,7 @@ pub mod types {
             {
                 self.datum = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for datum: {}", e));
+                    .map_err(|e| format!("error converting supplied value for datum: {e}"));
                 self
             }
             pub fn timestamp<T>(mut self, value: T) -> Self
@@ -50625,7 +47987,7 @@ pub mod types {
             {
                 self.timestamp = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for timestamp: {}", e));
+                    .map_err(|e| format!("error converting supplied value for timestamp: {e}"));
                 self
             }
         }
@@ -50678,7 +48040,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -50688,7 +48050,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -50740,7 +48102,7 @@ pub mod types {
             {
                 self.datum_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for datum_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for datum_type: {e}"));
                 self
             }
             pub fn start_time<T>(mut self, value: T) -> Self
@@ -50752,7 +48114,7 @@ pub mod types {
             {
                 self.start_time = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_time: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
                 self
             }
         }
@@ -50824,7 +48186,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -50834,7 +48196,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn ip_pool_id<T>(mut self, value: T) -> Self
@@ -50844,7 +48206,7 @@ pub mod types {
             {
                 self.ip_pool_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_pool_id: {e}"));
                 self
             }
             pub fn multicast_ip<T>(mut self, value: T) -> Self
@@ -50852,9 +48214,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::net::IpAddr>,
                 T::Error: ::std::fmt::Display,
             {
-                self.multicast_ip = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for multicast_ip: {}", e)
-                });
+                self.multicast_ip = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for multicast_ip: {e}"));
                 self
             }
             pub fn mvlan<T>(mut self, value: T) -> Self
@@ -50864,7 +48226,7 @@ pub mod types {
             {
                 self.mvlan = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mvlan: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mvlan: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -50874,7 +48236,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn source_ips<T>(mut self, value: T) -> Self
@@ -50884,7 +48246,7 @@ pub mod types {
             {
                 self.source_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for source_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for source_ips: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -50894,7 +48256,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -50902,9 +48264,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -50912,9 +48274,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -50996,7 +48358,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn multicast_ip<T>(mut self, value: T) -> Self
@@ -51004,9 +48366,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::std::net::IpAddr>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.multicast_ip = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for multicast_ip: {}", e)
-                });
+                self.multicast_ip = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for multicast_ip: {e}"));
                 self
             }
             pub fn mvlan<T>(mut self, value: T) -> Self
@@ -51016,7 +48378,7 @@ pub mod types {
             {
                 self.mvlan = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mvlan: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mvlan: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -51026,7 +48388,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn pool<T>(mut self, value: T) -> Self
@@ -51036,7 +48398,7 @@ pub mod types {
             {
                 self.pool = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pool: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pool: {e}"));
                 self
             }
             pub fn source_ips<T>(mut self, value: T) -> Self
@@ -51048,7 +48410,7 @@ pub mod types {
             {
                 self.source_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for source_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for source_ips: {e}"));
                 self
             }
         }
@@ -51123,7 +48485,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -51133,7 +48495,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn instance_id<T>(mut self, value: T) -> Self
@@ -51143,7 +48505,7 @@ pub mod types {
             {
                 self.instance_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for instance_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for instance_id: {e}"));
                 self
             }
             pub fn multicast_group_id<T>(mut self, value: T) -> Self
@@ -51152,10 +48514,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.multicast_group_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for multicast_group_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for multicast_group_id: {e}")
                 });
                 self
             }
@@ -51166,7 +48525,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -51176,7 +48535,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -51184,9 +48543,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -51194,9 +48553,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -51255,7 +48614,7 @@ pub mod types {
             {
                 self.instance = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for instance: {}", e));
+                    .map_err(|e| format!("error converting supplied value for instance: {e}"));
                 self
             }
         }
@@ -51308,7 +48667,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -51318,7 +48677,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -51377,7 +48736,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -51387,7 +48746,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -51446,7 +48805,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn mvlan<T>(mut self, value: T) -> Self
@@ -51456,7 +48815,7 @@ pub mod types {
             {
                 self.mvlan = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mvlan: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mvlan: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -51466,7 +48825,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn source_ips<T>(mut self, value: T) -> Self
@@ -51478,7 +48837,7 @@ pub mod types {
             {
                 self.source_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for source_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for source_ips: {e}"));
                 self
             }
         }
@@ -51548,7 +48907,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn ip<T>(mut self, value: T) -> Self
@@ -51558,7 +48917,7 @@ pub mod types {
             {
                 self.ip = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip: {e}"));
                 self
             }
             pub fn kind<T>(mut self, value: T) -> Self
@@ -51568,7 +48927,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn mac<T>(mut self, value: T) -> Self
@@ -51578,7 +48937,7 @@ pub mod types {
             {
                 self.mac = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mac: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mac: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -51588,7 +48947,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn primary<T>(mut self, value: T) -> Self
@@ -51598,7 +48957,7 @@ pub mod types {
             {
                 self.primary = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for primary: {}", e));
+                    .map_err(|e| format!("error converting supplied value for primary: {e}"));
                 self
             }
             pub fn slot<T>(mut self, value: T) -> Self
@@ -51608,7 +48967,7 @@ pub mod types {
             {
                 self.slot = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for slot: {}", e));
+                    .map_err(|e| format!("error converting supplied value for slot: {e}"));
                 self
             }
             pub fn subnet<T>(mut self, value: T) -> Self
@@ -51618,7 +48977,7 @@ pub mod types {
             {
                 self.subnet = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for subnet: {}", e));
+                    .map_err(|e| format!("error converting supplied value for subnet: {e}"));
                 self
             }
             pub fn transit_ips<T>(mut self, value: T) -> Self
@@ -51628,7 +48987,7 @@ pub mod types {
             {
                 self.transit_ips = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for transit_ips: {}", e));
+                    .map_err(|e| format!("error converting supplied value for transit_ips: {e}"));
                 self
             }
             pub fn vni<T>(mut self, value: T) -> Self
@@ -51638,7 +48997,7 @@ pub mod types {
             {
                 self.vni = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vni: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vni: {e}"));
                 self
             }
         }
@@ -51701,7 +49060,7 @@ pub mod types {
             {
                 self.tables = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for tables: {}", e));
+                    .map_err(|e| format!("error converting supplied value for tables: {e}"));
                 self
             }
         }
@@ -51749,7 +49108,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn timeseries<T>(mut self, value: T) -> Self
@@ -51759,7 +49118,7 @@ pub mod types {
             {
                 self.timeseries = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for timeseries: {}", e));
+                    .map_err(|e| format!("error converting supplied value for timeseries: {e}"));
                 self
             }
         }
@@ -51831,7 +49190,7 @@ pub mod types {
             {
                 self.form_factor = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for form_factor: {}", e));
+                    .map_err(|e| format!("error converting supplied value for form_factor: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -51841,7 +49200,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn model<T>(mut self, value: T) -> Self
@@ -51851,7 +49210,7 @@ pub mod types {
             {
                 self.model = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for model: {}", e));
+                    .map_err(|e| format!("error converting supplied value for model: {e}"));
                 self
             }
             pub fn policy<T>(mut self, value: T) -> Self
@@ -51861,7 +49220,7 @@ pub mod types {
             {
                 self.policy = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for policy: {}", e));
+                    .map_err(|e| format!("error converting supplied value for policy: {e}"));
                 self
             }
             pub fn serial<T>(mut self, value: T) -> Self
@@ -51871,7 +49230,7 @@ pub mod types {
             {
                 self.serial = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for serial: {}", e));
+                    .map_err(|e| format!("error converting supplied value for serial: {e}"));
                 self
             }
             pub fn sled_id<T>(mut self, value: T) -> Self
@@ -51881,7 +49240,7 @@ pub mod types {
             {
                 self.sled_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for sled_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for sled_id: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -51891,7 +49250,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -51899,9 +49258,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -51909,9 +49268,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vendor<T>(mut self, value: T) -> Self
@@ -51921,7 +49280,7 @@ pub mod types {
             {
                 self.vendor = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vendor: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vendor: {e}"));
                 self
             }
         }
@@ -51990,7 +49349,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -52000,7 +49359,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -52047,7 +49406,7 @@ pub mod types {
             {
                 self.status = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for status: {}", e));
+                    .map_err(|e| format!("error converting supplied value for status: {e}"));
                 self
             }
         }
@@ -52104,7 +49463,7 @@ pub mod types {
             {
                 self.start_times = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for start_times: {}", e));
+                    .map_err(|e| format!("error converting supplied value for start_times: {e}"));
                 self
             }
             pub fn timestamps<T>(mut self, value: T) -> Self
@@ -52116,7 +49475,7 @@ pub mod types {
             {
                 self.timestamps = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for timestamps: {}", e));
+                    .map_err(|e| format!("error converting supplied value for timestamps: {e}"));
                 self
             }
             pub fn values<T>(mut self, value: T) -> Self
@@ -52126,7 +49485,7 @@ pub mod types {
             {
                 self.values = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for values: {}", e));
+                    .map_err(|e| format!("error converting supplied value for values: {e}"));
                 self
             }
         }
@@ -52191,7 +49550,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -52201,7 +49560,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -52211,7 +49570,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn sled<T>(mut self, value: T) -> Self
@@ -52221,7 +49580,7 @@ pub mod types {
             {
                 self.sled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for sled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for sled: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -52229,9 +49588,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -52239,9 +49598,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -52305,7 +49664,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn ip_pool<T>(mut self, value: T) -> Self
@@ -52315,7 +49674,7 @@ pub mod types {
             {
                 self.ip_pool = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_pool: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_pool: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -52325,7 +49684,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn sled<T>(mut self, value: T) -> Self
@@ -52335,7 +49694,7 @@ pub mod types {
             {
                 self.sled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for sled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for sled: {e}"));
                 self
             }
         }
@@ -52392,7 +49751,7 @@ pub mod types {
             {
                 self.first_port = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for first_port: {}", e));
+                    .map_err(|e| format!("error converting supplied value for first_port: {e}"));
                 self
             }
             pub fn ip<T>(mut self, value: T) -> Self
@@ -52402,7 +49761,7 @@ pub mod types {
             {
                 self.ip = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip: {e}"));
                 self
             }
             pub fn kind<T>(mut self, value: T) -> Self
@@ -52412,7 +49771,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn last_port<T>(mut self, value: T) -> Self
@@ -52422,7 +49781,7 @@ pub mod types {
             {
                 self.last_port = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for last_port: {}", e));
+                    .map_err(|e| format!("error converting supplied value for last_port: {e}"));
                 self
             }
         }
@@ -52482,9 +49841,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::vec::Vec<super::ProbeExternalIp>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.external_ips = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for external_ips: {}", e)
-                });
+                self.external_ips = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for external_ips: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -52494,7 +49853,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn interface<T>(mut self, value: T) -> Self
@@ -52504,7 +49863,7 @@ pub mod types {
             {
                 self.interface = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for interface: {}", e));
+                    .map_err(|e| format!("error converting supplied value for interface: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -52514,7 +49873,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn sled<T>(mut self, value: T) -> Self
@@ -52524,7 +49883,7 @@ pub mod types {
             {
                 self.sled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for sled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for sled: {e}"));
                 self
             }
         }
@@ -52582,7 +49941,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -52592,7 +49951,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -52653,7 +50012,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -52663,7 +50022,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -52673,7 +50032,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -52681,9 +50040,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -52691,9 +50050,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -52748,7 +50107,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -52758,7 +50117,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -52810,7 +50169,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -52820,7 +50179,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -52869,10 +50228,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.role_assignments = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for role_assignments: {}",
-                        e
-                    )
+                    format!("error converting supplied value for role_assignments: {e}")
                 });
                 self
             }
@@ -52922,7 +50278,7 @@ pub mod types {
             {
                 self.identity_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for identity_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for identity_id: {e}"));
                 self
             }
             pub fn identity_type<T>(mut self, value: T) -> Self
@@ -52930,9 +50286,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::IdentityType>,
                 T::Error: ::std::fmt::Display,
             {
-                self.identity_type = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for identity_type: {}", e)
-                });
+                self.identity_type = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for identity_type: {e}"));
                 self
             }
             pub fn role_name<T>(mut self, value: T) -> Self
@@ -52942,7 +50298,7 @@ pub mod types {
             {
                 self.role_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for role_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for role_name: {e}"));
                 self
             }
         }
@@ -52996,7 +50352,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -53006,7 +50362,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -53060,10 +50416,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.desired_marker_positions = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for desired_marker_positions: {}",
-                        e
-                    )
+                    format!("error converting supplied value for desired_marker_positions: {e}")
                 });
                 self
             }
@@ -53073,7 +50426,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.marker_heights = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for marker_heights: {}", e)
+                    format!("error converting supplied value for marker_heights: {e}")
                 });
                 self
             }
@@ -53083,10 +50436,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.marker_positions = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for marker_positions: {}",
-                        e
-                    )
+                    format!("error converting supplied value for marker_positions: {e}")
                 });
                 self
             }
@@ -53097,7 +50447,7 @@ pub mod types {
             {
                 self.p = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for p: {}", e));
+                    .map_err(|e| format!("error converting supplied value for p: {e}"));
                 self
             }
         }
@@ -53158,7 +50508,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -53166,9 +50516,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -53176,9 +50526,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -53230,7 +50580,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -53240,7 +50590,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -53293,7 +50643,7 @@ pub mod types {
             {
                 self.dst = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for dst: {}", e));
+                    .map_err(|e| format!("error converting supplied value for dst: {e}"));
                 self
             }
             pub fn gw<T>(mut self, value: T) -> Self
@@ -53303,7 +50653,7 @@ pub mod types {
             {
                 self.gw = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for gw: {}", e));
+                    .map_err(|e| format!("error converting supplied value for gw: {e}"));
                 self
             }
             pub fn rib_priority<T>(mut self, value: T) -> Self
@@ -53311,9 +50661,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<u8>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.rib_priority = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for rib_priority: {}", e)
-                });
+                self.rib_priority = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for rib_priority: {e}"));
                 self
             }
             pub fn vid<T>(mut self, value: T) -> Self
@@ -53323,7 +50673,7 @@ pub mod types {
             {
                 self.vid = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vid: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vid: {e}"));
                 self
             }
         }
@@ -53376,7 +50726,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn routes<T>(mut self, value: T) -> Self
@@ -53386,7 +50736,7 @@ pub mod types {
             {
                 self.routes = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for routes: {}", e));
+                    .map_err(|e| format!("error converting supplied value for routes: {e}"));
                 self
             }
         }
@@ -53455,7 +50805,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn destination<T>(mut self, value: T) -> Self
@@ -53465,7 +50815,7 @@ pub mod types {
             {
                 self.destination = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for destination: {}", e));
+                    .map_err(|e| format!("error converting supplied value for destination: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -53475,7 +50825,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn kind<T>(mut self, value: T) -> Self
@@ -53485,7 +50835,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -53495,7 +50845,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn target<T>(mut self, value: T) -> Self
@@ -53505,7 +50855,7 @@ pub mod types {
             {
                 self.target = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for target: {}", e));
+                    .map_err(|e| format!("error converting supplied value for target: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -53513,9 +50863,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -53523,9 +50873,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vpc_router_id<T>(mut self, value: T) -> Self
@@ -53533,9 +50883,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::uuid::Uuid>,
                 T::Error: ::std::fmt::Display,
             {
-                self.vpc_router_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for vpc_router_id: {}", e)
-                });
+                self.vpc_router_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for vpc_router_id: {e}"));
                 self
             }
         }
@@ -53602,7 +50952,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn destination<T>(mut self, value: T) -> Self
@@ -53612,7 +50962,7 @@ pub mod types {
             {
                 self.destination = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for destination: {}", e));
+                    .map_err(|e| format!("error converting supplied value for destination: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -53622,7 +50972,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn target<T>(mut self, value: T) -> Self
@@ -53632,7 +50982,7 @@ pub mod types {
             {
                 self.target = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for target: {}", e));
+                    .map_err(|e| format!("error converting supplied value for target: {e}"));
                 self
             }
         }
@@ -53689,7 +51039,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -53699,7 +51049,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -53755,7 +51105,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn destination<T>(mut self, value: T) -> Self
@@ -53765,7 +51115,7 @@ pub mod types {
             {
                 self.destination = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for destination: {}", e));
+                    .map_err(|e| format!("error converting supplied value for destination: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -53775,7 +51125,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn target<T>(mut self, value: T) -> Self
@@ -53785,7 +51135,7 @@ pub mod types {
             {
                 self.target = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for target: {}", e));
+                    .map_err(|e| format!("error converting supplied value for target: {e}"));
                 self
             }
         }
@@ -53873,7 +51223,7 @@ pub mod types {
             {
                 self.acs_url = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for acs_url: {}", e));
+                    .map_err(|e| format!("error converting supplied value for acs_url: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -53883,7 +51233,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn group_attribute_name<T>(mut self, value: T) -> Self
@@ -53892,10 +51242,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.group_attribute_name = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for group_attribute_name: {}",
-                        e
-                    )
+                    format!("error converting supplied value for group_attribute_name: {e}")
                 });
                 self
             }
@@ -53906,7 +51253,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn idp_entity_id<T>(mut self, value: T) -> Self
@@ -53914,9 +51261,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.idp_entity_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for idp_entity_id: {}", e)
-                });
+                self.idp_entity_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for idp_entity_id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -53926,7 +51273,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn public_cert<T>(mut self, value: T) -> Self
@@ -53936,7 +51283,7 @@ pub mod types {
             {
                 self.public_cert = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for public_cert: {}", e));
+                    .map_err(|e| format!("error converting supplied value for public_cert: {e}"));
                 self
             }
             pub fn slo_url<T>(mut self, value: T) -> Self
@@ -53946,7 +51293,7 @@ pub mod types {
             {
                 self.slo_url = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for slo_url: {}", e));
+                    .map_err(|e| format!("error converting supplied value for slo_url: {e}"));
                 self
             }
             pub fn sp_client_id<T>(mut self, value: T) -> Self
@@ -53954,9 +51301,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.sp_client_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sp_client_id: {}", e)
-                });
+                self.sp_client_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sp_client_id: {e}"));
                 self
             }
             pub fn technical_contact_email<T>(mut self, value: T) -> Self
@@ -53965,10 +51312,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.technical_contact_email = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for technical_contact_email: {}",
-                        e
-                    )
+                    format!("error converting supplied value for technical_contact_email: {e}")
                 });
                 self
             }
@@ -53977,9 +51321,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -53987,9 +51331,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -54086,7 +51430,7 @@ pub mod types {
             {
                 self.acs_url = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for acs_url: {}", e));
+                    .map_err(|e| format!("error converting supplied value for acs_url: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -54096,7 +51440,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn group_attribute_name<T>(mut self, value: T) -> Self
@@ -54105,10 +51449,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.group_attribute_name = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for group_attribute_name: {}",
-                        e
-                    )
+                    format!("error converting supplied value for group_attribute_name: {e}")
                 });
                 self
             }
@@ -54117,9 +51458,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.idp_entity_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for idp_entity_id: {}", e)
-                });
+                self.idp_entity_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for idp_entity_id: {e}"));
                 self
             }
             pub fn idp_metadata_source<T>(mut self, value: T) -> Self
@@ -54128,10 +51469,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.idp_metadata_source = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for idp_metadata_source: {}",
-                        e
-                    )
+                    format!("error converting supplied value for idp_metadata_source: {e}")
                 });
                 self
             }
@@ -54142,7 +51480,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn signing_keypair<T>(mut self, value: T) -> Self
@@ -54151,7 +51489,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.signing_keypair = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for signing_keypair: {}", e)
+                    format!("error converting supplied value for signing_keypair: {e}")
                 });
                 self
             }
@@ -54162,7 +51500,7 @@ pub mod types {
             {
                 self.slo_url = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for slo_url: {}", e));
+                    .map_err(|e| format!("error converting supplied value for slo_url: {e}"));
                 self
             }
             pub fn sp_client_id<T>(mut self, value: T) -> Self
@@ -54170,9 +51508,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.sp_client_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for sp_client_id: {}", e)
-                });
+                self.sp_client_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sp_client_id: {e}"));
                 self
             }
             pub fn technical_contact_email<T>(mut self, value: T) -> Self
@@ -54181,10 +51519,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.technical_contact_email = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for technical_contact_email: {}",
-                        e
-                    )
+                    format!("error converting supplied value for technical_contact_email: {e}")
                 });
                 self
             }
@@ -54258,7 +51593,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -54266,9 +51601,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_expires<T>(mut self, value: T) -> Self
@@ -54278,9 +51613,9 @@ pub mod types {
                 >,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_expires = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_expires: {}", e)
-                });
+                self.time_expires = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_expires: {e}"));
                 self
             }
         }
@@ -54339,9 +51674,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.bearer_token = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for bearer_token: {}", e)
-                });
+                self.bearer_token = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for bearer_token: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -54351,7 +51686,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -54359,9 +51694,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_expires<T>(mut self, value: T) -> Self
@@ -54371,9 +51706,9 @@ pub mod types {
                 >,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_expires = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_expires: {}", e)
-                });
+                self.time_expires = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_expires: {e}"));
                 self
             }
         }
@@ -54424,7 +51759,7 @@ pub mod types {
             {
                 self.enabled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for enabled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for enabled: {e}"));
                 self
             }
         }
@@ -54471,7 +51806,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.system_version = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for system_version: {}", e)
+                    format!("error converting supplied value for system_version: {e}")
                 });
                 self
             }
@@ -54544,10 +51879,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.admin_group_name = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for admin_group_name: {}",
-                        e
-                    )
+                    format!("error converting supplied value for admin_group_name: {e}")
                 });
                 self
             }
@@ -54558,7 +51890,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn discoverable<T>(mut self, value: T) -> Self
@@ -54566,9 +51898,9 @@ pub mod types {
                 T: ::std::convert::TryInto<bool>,
                 T::Error: ::std::fmt::Display,
             {
-                self.discoverable = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for discoverable: {}", e)
-                });
+                self.discoverable = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for discoverable: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -54578,7 +51910,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn identity_mode<T>(mut self, value: T) -> Self
@@ -54586,9 +51918,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::SiloIdentityMode>,
                 T::Error: ::std::fmt::Display,
             {
-                self.identity_mode = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for identity_mode: {}", e)
-                });
+                self.identity_mode = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for identity_mode: {e}"));
                 self
             }
             pub fn mapped_fleet_roles<T>(mut self, value: T) -> Self
@@ -54599,10 +51931,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.mapped_fleet_roles = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for mapped_fleet_roles: {}",
-                        e
-                    )
+                    format!("error converting supplied value for mapped_fleet_roles: {e}")
                 });
                 self
             }
@@ -54613,7 +51942,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -54621,9 +51950,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -54631,9 +51960,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -54694,10 +52023,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.device_token_max_ttl_seconds = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for device_token_max_ttl_seconds: {}",
-                        e
-                    )
+                    format!("error converting supplied value for device_token_max_ttl_seconds: {e}")
                 });
                 self
             }
@@ -54708,7 +52034,7 @@ pub mod types {
             {
                 self.silo_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_id: {e}"));
                 self
             }
         }
@@ -54759,10 +52085,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.device_token_max_ttl_seconds = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for device_token_max_ttl_seconds: {}",
-                        e
-                    )
+                    format!("error converting supplied value for device_token_max_ttl_seconds: {e}")
                 });
                 self
             }
@@ -54830,10 +52153,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.admin_group_name = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for admin_group_name: {}",
-                        e
-                    )
+                    format!("error converting supplied value for admin_group_name: {e}")
                 });
                 self
             }
@@ -54844,7 +52164,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn discoverable<T>(mut self, value: T) -> Self
@@ -54852,9 +52172,9 @@ pub mod types {
                 T: ::std::convert::TryInto<bool>,
                 T::Error: ::std::fmt::Display,
             {
-                self.discoverable = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for discoverable: {}", e)
-                });
+                self.discoverable = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for discoverable: {e}"));
                 self
             }
             pub fn identity_mode<T>(mut self, value: T) -> Self
@@ -54862,9 +52182,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::SiloIdentityMode>,
                 T::Error: ::std::fmt::Display,
             {
-                self.identity_mode = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for identity_mode: {}", e)
-                });
+                self.identity_mode = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for identity_mode: {e}"));
                 self
             }
             pub fn mapped_fleet_roles<T>(mut self, value: T) -> Self
@@ -54875,10 +52195,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.mapped_fleet_roles = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for mapped_fleet_roles: {}",
-                        e
-                    )
+                    format!("error converting supplied value for mapped_fleet_roles: {e}")
                 });
                 self
             }
@@ -54889,7 +52206,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn quotas<T>(mut self, value: T) -> Self
@@ -54899,7 +52216,7 @@ pub mod types {
             {
                 self.quotas = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for quotas: {}", e));
+                    .map_err(|e| format!("error converting supplied value for quotas: {e}"));
                 self
             }
             pub fn tls_certificates<T>(mut self, value: T) -> Self
@@ -54908,10 +52225,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.tls_certificates = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for tls_certificates: {}",
-                        e
-                    )
+                    format!("error converting supplied value for tls_certificates: {e}")
                 });
                 self
             }
@@ -54991,7 +52305,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -55001,7 +52315,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn ip_version<T>(mut self, value: T) -> Self
@@ -55011,7 +52325,7 @@ pub mod types {
             {
                 self.ip_version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ip_version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ip_version: {e}"));
                 self
             }
             pub fn is_default<T>(mut self, value: T) -> Self
@@ -55021,7 +52335,7 @@ pub mod types {
             {
                 self.is_default = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for is_default: {}", e));
+                    .map_err(|e| format!("error converting supplied value for is_default: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -55031,7 +52345,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn pool_type<T>(mut self, value: T) -> Self
@@ -55041,7 +52355,7 @@ pub mod types {
             {
                 self.pool_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pool_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pool_type: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -55049,9 +52363,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -55059,9 +52373,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -55125,7 +52439,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -55135,7 +52449,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -55188,7 +52502,7 @@ pub mod types {
             {
                 self.cpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for cpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for cpus: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -55198,7 +52512,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn silo_id<T>(mut self, value: T) -> Self
@@ -55208,7 +52522,7 @@ pub mod types {
             {
                 self.silo_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_id: {e}"));
                 self
             }
             pub fn storage<T>(mut self, value: T) -> Self
@@ -55218,7 +52532,7 @@ pub mod types {
             {
                 self.storage = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for storage: {}", e));
+                    .map_err(|e| format!("error converting supplied value for storage: {e}"));
                 self
             }
         }
@@ -55273,7 +52587,7 @@ pub mod types {
             {
                 self.cpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for cpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for cpus: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -55283,7 +52597,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn storage<T>(mut self, value: T) -> Self
@@ -55293,7 +52607,7 @@ pub mod types {
             {
                 self.storage = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for storage: {}", e));
+                    .map_err(|e| format!("error converting supplied value for storage: {e}"));
                 self
             }
         }
@@ -55347,7 +52661,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -55357,7 +52671,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -55414,7 +52728,7 @@ pub mod types {
             {
                 self.cpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for cpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for cpus: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -55424,7 +52738,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn storage<T>(mut self, value: T) -> Self
@@ -55434,7 +52748,7 @@ pub mod types {
             {
                 self.storage = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for storage: {}", e));
+                    .map_err(|e| format!("error converting supplied value for storage: {e}"));
                 self
             }
         }
@@ -55488,7 +52802,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -55498,7 +52812,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -55547,10 +52861,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.role_assignments = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for role_assignments: {}",
-                        e
-                    )
+                    format!("error converting supplied value for role_assignments: {e}")
                 });
                 self
             }
@@ -55600,7 +52911,7 @@ pub mod types {
             {
                 self.identity_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for identity_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for identity_id: {e}"));
                 self
             }
             pub fn identity_type<T>(mut self, value: T) -> Self
@@ -55608,9 +52919,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::IdentityType>,
                 T::Error: ::std::fmt::Display,
             {
-                self.identity_type = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for identity_type: {}", e)
-                });
+                self.identity_type = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for identity_type: {e}"));
                 self
             }
             pub fn role_name<T>(mut self, value: T) -> Self
@@ -55620,7 +52931,7 @@ pub mod types {
             {
                 self.role_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for role_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for role_name: {e}"));
                 self
             }
         }
@@ -55675,7 +52986,7 @@ pub mod types {
             {
                 self.allocated = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for allocated: {}", e));
+                    .map_err(|e| format!("error converting supplied value for allocated: {e}"));
                 self
             }
             pub fn provisioned<T>(mut self, value: T) -> Self
@@ -55685,7 +52996,7 @@ pub mod types {
             {
                 self.provisioned = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for provisioned: {}", e));
+                    .map_err(|e| format!("error converting supplied value for provisioned: {e}"));
                 self
             }
             pub fn silo_id<T>(mut self, value: T) -> Self
@@ -55695,7 +53006,7 @@ pub mod types {
             {
                 self.silo_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_id: {e}"));
                 self
             }
             pub fn silo_name<T>(mut self, value: T) -> Self
@@ -55705,7 +53016,7 @@ pub mod types {
             {
                 self.silo_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_name: {e}"));
                 self
             }
         }
@@ -55764,7 +53075,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -55774,7 +53085,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -55847,7 +53158,7 @@ pub mod types {
             {
                 self.baseboard = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for baseboard: {}", e));
+                    .map_err(|e| format!("error converting supplied value for baseboard: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -55857,7 +53168,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn policy<T>(mut self, value: T) -> Self
@@ -55867,7 +53178,7 @@ pub mod types {
             {
                 self.policy = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for policy: {}", e));
+                    .map_err(|e| format!("error converting supplied value for policy: {e}"));
                 self
             }
             pub fn rack_id<T>(mut self, value: T) -> Self
@@ -55877,7 +53188,7 @@ pub mod types {
             {
                 self.rack_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rack_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rack_id: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -55887,7 +53198,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -55895,9 +53206,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -55905,9 +53216,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn usable_hardware_threads<T>(mut self, value: T) -> Self
@@ -55916,10 +53227,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.usable_hardware_threads = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for usable_hardware_threads: {}",
-                        e
-                    )
+                    format!("error converting supplied value for usable_hardware_threads: {e}")
                 });
                 self
             }
@@ -55929,10 +53237,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.usable_physical_ram = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for usable_physical_ram: {}",
-                        e
-                    )
+                    format!("error converting supplied value for usable_physical_ram: {e}")
                 });
                 self
             }
@@ -55992,7 +53297,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
         }
@@ -56059,7 +53364,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.active_sled_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for active_sled_id: {}", e)
+                    format!("error converting supplied value for active_sled_id: {e}")
                 });
                 self
             }
@@ -56070,7 +53375,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -56080,7 +53385,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn migration_id<T>(mut self, value: T) -> Self
@@ -56088,9 +53393,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::uuid::Uuid>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.migration_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for migration_id: {}", e)
-                });
+                self.migration_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for migration_id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -56100,7 +53405,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn ncpus<T>(mut self, value: T) -> Self
@@ -56110,7 +53415,7 @@ pub mod types {
             {
                 self.ncpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ncpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ncpus: {e}"));
                 self
             }
             pub fn project_name<T>(mut self, value: T) -> Self
@@ -56118,9 +53423,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::Name>,
                 T::Error: ::std::fmt::Display,
             {
-                self.project_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for project_name: {}", e)
-                });
+                self.project_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for project_name: {e}"));
                 self
             }
             pub fn silo_name<T>(mut self, value: T) -> Self
@@ -56130,7 +53435,7 @@ pub mod types {
             {
                 self.silo_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_name: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -56140,7 +53445,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -56148,9 +53453,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -56158,9 +53463,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -56231,7 +53536,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -56241,7 +53546,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -56288,7 +53593,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
         }
@@ -56335,7 +53640,7 @@ pub mod types {
             {
                 self.new_state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for new_state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for new_state: {e}"));
                 self
             }
             pub fn old_state<T>(mut self, value: T) -> Self
@@ -56345,7 +53650,7 @@ pub mod types {
             {
                 self.old_state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for old_state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for old_state: {e}"));
                 self
             }
         }
@@ -56397,7 +53702,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -56407,7 +53712,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -56476,7 +53781,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn disk_id<T>(mut self, value: T) -> Self
@@ -56486,7 +53791,7 @@ pub mod types {
             {
                 self.disk_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for disk_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for disk_id: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -56496,7 +53801,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -56506,7 +53811,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -56516,7 +53821,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn size<T>(mut self, value: T) -> Self
@@ -56526,7 +53831,7 @@ pub mod types {
             {
                 self.size = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for size: {}", e));
+                    .map_err(|e| format!("error converting supplied value for size: {e}"));
                 self
             }
             pub fn state<T>(mut self, value: T) -> Self
@@ -56536,7 +53841,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -56544,9 +53849,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -56554,9 +53859,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -56621,7 +53926,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn disk<T>(mut self, value: T) -> Self
@@ -56631,7 +53936,7 @@ pub mod types {
             {
                 self.disk = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for disk: {}", e));
+                    .map_err(|e| format!("error converting supplied value for disk: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -56641,7 +53946,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -56695,7 +54000,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -56705,7 +54010,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -56770,7 +54075,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -56780,7 +54085,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -56790,7 +54095,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn public_key<T>(mut self, value: T) -> Self
@@ -56800,7 +54105,7 @@ pub mod types {
             {
                 self.public_key = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for public_key: {}", e));
+                    .map_err(|e| format!("error converting supplied value for public_key: {e}"));
                 self
             }
             pub fn silo_user_id<T>(mut self, value: T) -> Self
@@ -56808,9 +54113,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::uuid::Uuid>,
                 T::Error: ::std::fmt::Display,
             {
-                self.silo_user_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for silo_user_id: {}", e)
-                });
+                self.silo_user_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for silo_user_id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -56818,9 +54123,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -56828,9 +54133,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -56891,7 +54196,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -56901,7 +54206,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn public_key<T>(mut self, value: T) -> Self
@@ -56911,7 +54216,7 @@ pub mod types {
             {
                 self.public_key = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for public_key: {}", e));
+                    .map_err(|e| format!("error converting supplied value for public_key: {e}"));
                 self
             }
         }
@@ -56965,7 +54270,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -56975,7 +54280,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -57023,9 +54328,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.user_comment = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for user_comment: {}", e)
-                });
+                self.user_comment = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for user_comment: {e}"));
                 self
             }
         }
@@ -57092,7 +54397,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn reason_for_creation<T>(mut self, value: T) -> Self
@@ -57101,10 +54406,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.reason_for_creation = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for reason_for_creation: {}",
-                        e
-                    )
+                    format!("error converting supplied value for reason_for_creation: {e}")
                 });
                 self
             }
@@ -57114,10 +54416,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.reason_for_failure = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for reason_for_failure: {}",
-                        e
-                    )
+                    format!("error converting supplied value for reason_for_failure: {e}")
                 });
                 self
             }
@@ -57128,7 +54427,7 @@ pub mod types {
             {
                 self.state = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for state: {}", e));
+                    .map_err(|e| format!("error converting supplied value for state: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -57136,9 +54435,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn user_comment<T>(mut self, value: T) -> Self
@@ -57146,9 +54445,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.user_comment = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for user_comment: {}", e)
-                });
+                self.user_comment = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for user_comment: {e}"));
                 self
             }
         }
@@ -57211,7 +54510,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -57221,7 +54520,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -57269,9 +54568,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.user_comment = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for user_comment: {}", e)
-                });
+                self.user_comment = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for user_comment: {e}"));
                 self
             }
         }
@@ -57330,7 +54629,7 @@ pub mod types {
             {
                 self.baseboard = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for baseboard: {}", e));
+                    .map_err(|e| format!("error converting supplied value for baseboard: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -57340,7 +54639,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn rack_id<T>(mut self, value: T) -> Self
@@ -57350,7 +54649,7 @@ pub mod types {
             {
                 self.rack_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rack_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rack_id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -57358,9 +54657,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -57368,9 +54667,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -57430,7 +54729,7 @@ pub mod types {
             {
                 self.history = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for history: {}", e));
+                    .map_err(|e| format!("error converting supplied value for history: {e}"));
                 self
             }
             pub fn switch<T>(mut self, value: T) -> Self
@@ -57440,7 +54739,7 @@ pub mod types {
             {
                 self.switch = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for switch: {}", e));
+                    .map_err(|e| format!("error converting supplied value for switch: {e}"));
                 self
             }
         }
@@ -57495,7 +54794,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn interface_name<T>(mut self, value: T) -> Self
@@ -57504,7 +54803,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.interface_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for interface_name: {}", e)
+                    format!("error converting supplied value for interface_name: {e}")
                 });
                 self
             }
@@ -57515,7 +54814,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn port_settings_id<T>(mut self, value: T) -> Self
@@ -57524,10 +54823,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_id: {e}")
                 });
                 self
             }
@@ -57538,7 +54834,7 @@ pub mod types {
             {
                 self.v6_enabled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for v6_enabled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for v6_enabled: {e}"));
                 self
             }
         }
@@ -57595,7 +54891,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn link_name<T>(mut self, value: T) -> Self
@@ -57605,7 +54901,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn v6_enabled<T>(mut self, value: T) -> Self
@@ -57615,7 +54911,7 @@ pub mod types {
             {
                 self.v6_enabled = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for v6_enabled: {}", e));
+                    .map_err(|e| format!("error converting supplied value for v6_enabled: {e}"));
                 self
             }
         }
@@ -57673,7 +54969,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn port_name<T>(mut self, value: T) -> Self
@@ -57683,7 +54979,7 @@ pub mod types {
             {
                 self.port_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for port_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for port_name: {e}"));
                 self
             }
             pub fn port_settings_id<T>(mut self, value: T) -> Self
@@ -57692,10 +54988,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_id: {e}")
                 });
                 self
             }
@@ -57706,7 +54999,7 @@ pub mod types {
             {
                 self.rack_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rack_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rack_id: {e}"));
                 self
             }
             pub fn switch_location<T>(mut self, value: T) -> Self
@@ -57715,7 +55008,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.switch_location = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for switch_location: {}", e)
+                    format!("error converting supplied value for switch_location: {e}")
                 });
                 self
             }
@@ -57783,7 +55076,7 @@ pub mod types {
             {
                 self.address = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for address: {}", e));
+                    .map_err(|e| format!("error converting supplied value for address: {e}"));
                 self
             }
             pub fn address_lot_block_id<T>(mut self, value: T) -> Self
@@ -57792,10 +55085,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.address_lot_block_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for address_lot_block_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for address_lot_block_id: {e}")
                 });
                 self
             }
@@ -57805,7 +55095,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.address_lot_id = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for address_lot_id: {}", e)
+                    format!("error converting supplied value for address_lot_id: {e}")
                 });
                 self
             }
@@ -57815,10 +55105,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.address_lot_name = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for address_lot_name: {}",
-                        e
-                    )
+                    format!("error converting supplied value for address_lot_name: {e}")
                 });
                 self
             }
@@ -57828,7 +55115,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.interface_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for interface_name: {}", e)
+                    format!("error converting supplied value for interface_name: {e}")
                 });
                 self
             }
@@ -57838,10 +55125,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_id: {e}")
                 });
                 self
             }
@@ -57852,7 +55136,7 @@ pub mod types {
             {
                 self.vlan_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vlan_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vlan_id: {e}"));
                 self
             }
         }
@@ -57907,9 +55191,9 @@ pub mod types {
                 T: ::std::convert::TryInto<super::NameOrId>,
                 T::Error: ::std::fmt::Display,
             {
-                self.port_settings = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for port_settings: {}", e)
-                });
+                self.port_settings = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for port_settings: {e}"));
                 self
             }
         }
@@ -57956,7 +55240,7 @@ pub mod types {
             {
                 self.geometry = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for geometry: {}", e));
+                    .map_err(|e| format!("error converting supplied value for geometry: {e}"));
                 self
             }
             pub fn port_settings_id<T>(mut self, value: T) -> Self
@@ -57965,10 +55249,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_id: {e}")
                 });
                 self
             }
@@ -58016,7 +55297,7 @@ pub mod types {
             {
                 self.geometry = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for geometry: {}", e));
+                    .map_err(|e| format!("error converting supplied value for geometry: {e}"));
                 self
             }
         }
@@ -58082,7 +55363,7 @@ pub mod types {
             {
                 self.autoneg = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for autoneg: {}", e));
+                    .map_err(|e| format!("error converting supplied value for autoneg: {e}"));
                 self
             }
             pub fn fec<T>(mut self, value: T) -> Self
@@ -58092,7 +55373,7 @@ pub mod types {
             {
                 self.fec = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for fec: {}", e));
+                    .map_err(|e| format!("error converting supplied value for fec: {e}"));
                 self
             }
             pub fn link_name<T>(mut self, value: T) -> Self
@@ -58102,7 +55383,7 @@ pub mod types {
             {
                 self.link_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for link_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for link_name: {e}"));
                 self
             }
             pub fn lldp_link_config<T>(mut self, value: T) -> Self
@@ -58111,10 +55392,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.lldp_link_config = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for lldp_link_config: {}",
-                        e
-                    )
+                    format!("error converting supplied value for lldp_link_config: {e}")
                 });
                 self
             }
@@ -58125,7 +55403,7 @@ pub mod types {
             {
                 self.mtu = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for mtu: {}", e));
+                    .map_err(|e| format!("error converting supplied value for mtu: {e}"));
                 self
             }
             pub fn port_settings_id<T>(mut self, value: T) -> Self
@@ -58134,10 +55412,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_id: {e}")
                 });
                 self
             }
@@ -58148,7 +55423,7 @@ pub mod types {
             {
                 self.speed = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for speed: {}", e));
+                    .map_err(|e| format!("error converting supplied value for speed: {e}"));
                 self
             }
             pub fn tx_eq_config<T>(mut self, value: T) -> Self
@@ -58156,9 +55431,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<super::TxEqConfig2>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.tx_eq_config = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for tx_eq_config: {}", e)
-                });
+                self.tx_eq_config = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for tx_eq_config: {e}"));
                 self
             }
         }
@@ -58222,7 +55497,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -58232,7 +55507,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -58289,7 +55564,7 @@ pub mod types {
             {
                 self.dst = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for dst: {}", e));
+                    .map_err(|e| format!("error converting supplied value for dst: {e}"));
                 self
             }
             pub fn gw<T>(mut self, value: T) -> Self
@@ -58299,7 +55574,7 @@ pub mod types {
             {
                 self.gw = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for gw: {}", e));
+                    .map_err(|e| format!("error converting supplied value for gw: {e}"));
                 self
             }
             pub fn interface_name<T>(mut self, value: T) -> Self
@@ -58308,7 +55583,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.interface_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for interface_name: {}", e)
+                    format!("error converting supplied value for interface_name: {e}")
                 });
                 self
             }
@@ -58318,10 +55593,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_id: {e}")
                 });
                 self
             }
@@ -58330,9 +55602,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<u8>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.rib_priority = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for rib_priority: {}", e)
-                });
+                self.rib_priority = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for rib_priority: {e}"));
                 self
             }
             pub fn vlan_id<T>(mut self, value: T) -> Self
@@ -58342,7 +55614,7 @@ pub mod types {
             {
                 self.vlan_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vlan_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vlan_id: {e}"));
                 self
             }
         }
@@ -58446,7 +55718,7 @@ pub mod types {
             {
                 self.addresses = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for addresses: {}", e));
+                    .map_err(|e| format!("error converting supplied value for addresses: {e}"));
                 self
             }
             pub fn bgp_peers<T>(mut self, value: T) -> Self
@@ -58456,7 +55728,7 @@ pub mod types {
             {
                 self.bgp_peers = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bgp_peers: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bgp_peers: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -58466,7 +55738,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn groups<T>(mut self, value: T) -> Self
@@ -58476,7 +55748,7 @@ pub mod types {
             {
                 self.groups = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for groups: {}", e));
+                    .map_err(|e| format!("error converting supplied value for groups: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -58486,7 +55758,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn interfaces<T>(mut self, value: T) -> Self
@@ -58496,7 +55768,7 @@ pub mod types {
             {
                 self.interfaces = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for interfaces: {}", e));
+                    .map_err(|e| format!("error converting supplied value for interfaces: {e}"));
                 self
             }
             pub fn links<T>(mut self, value: T) -> Self
@@ -58506,7 +55778,7 @@ pub mod types {
             {
                 self.links = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for links: {}", e));
+                    .map_err(|e| format!("error converting supplied value for links: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -58516,7 +55788,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn port<T>(mut self, value: T) -> Self
@@ -58526,7 +55798,7 @@ pub mod types {
             {
                 self.port = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for port: {}", e));
+                    .map_err(|e| format!("error converting supplied value for port: {e}"));
                 self
             }
             pub fn routes<T>(mut self, value: T) -> Self
@@ -58536,7 +55808,7 @@ pub mod types {
             {
                 self.routes = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for routes: {}", e));
+                    .map_err(|e| format!("error converting supplied value for routes: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -58544,9 +55816,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -58554,9 +55826,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vlan_interfaces<T>(mut self, value: T) -> Self
@@ -58565,7 +55837,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.vlan_interfaces = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for vlan_interfaces: {}", e)
+                    format!("error converting supplied value for vlan_interfaces: {e}")
                 });
                 self
             }
@@ -58661,7 +55933,7 @@ pub mod types {
             {
                 self.addresses = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for addresses: {}", e));
+                    .map_err(|e| format!("error converting supplied value for addresses: {e}"));
                 self
             }
             pub fn bgp_peers<T>(mut self, value: T) -> Self
@@ -58671,7 +55943,7 @@ pub mod types {
             {
                 self.bgp_peers = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for bgp_peers: {}", e));
+                    .map_err(|e| format!("error converting supplied value for bgp_peers: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -58681,7 +55953,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn groups<T>(mut self, value: T) -> Self
@@ -58691,7 +55963,7 @@ pub mod types {
             {
                 self.groups = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for groups: {}", e));
+                    .map_err(|e| format!("error converting supplied value for groups: {e}"));
                 self
             }
             pub fn interfaces<T>(mut self, value: T) -> Self
@@ -58701,7 +55973,7 @@ pub mod types {
             {
                 self.interfaces = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for interfaces: {}", e));
+                    .map_err(|e| format!("error converting supplied value for interfaces: {e}"));
                 self
             }
             pub fn links<T>(mut self, value: T) -> Self
@@ -58711,7 +55983,7 @@ pub mod types {
             {
                 self.links = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for links: {}", e));
+                    .map_err(|e| format!("error converting supplied value for links: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -58721,7 +55993,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn port_config<T>(mut self, value: T) -> Self
@@ -58731,7 +56003,7 @@ pub mod types {
             {
                 self.port_config = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for port_config: {}", e));
+                    .map_err(|e| format!("error converting supplied value for port_config: {e}"));
                 self
             }
             pub fn routes<T>(mut self, value: T) -> Self
@@ -58741,7 +56013,7 @@ pub mod types {
             {
                 self.routes = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for routes: {}", e));
+                    .map_err(|e| format!("error converting supplied value for routes: {e}"));
                 self
             }
         }
@@ -58805,10 +56077,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_group_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_group_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_group_id: {e}")
                 });
                 self
             }
@@ -58818,10 +56087,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.port_settings_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for port_settings_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for port_settings_id: {e}")
                 });
                 self
             }
@@ -58883,7 +56149,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -58893,7 +56159,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -58903,7 +56169,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -58911,9 +56177,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -58921,9 +56187,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -58984,7 +56250,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -58994,7 +56260,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -59050,7 +56316,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -59060,7 +56326,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -59110,10 +56376,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.interface_config_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for interface_config_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for interface_config_id: {e}")
                 });
                 self
             }
@@ -59124,7 +56387,7 @@ pub mod types {
             {
                 self.vlan_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vlan_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vlan_id: {e}"));
                 self
             }
         }
@@ -59175,7 +56438,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.time_requested = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_requested: {}", e)
+                    format!("error converting supplied value for time_requested: {e}")
                 });
                 self
             }
@@ -59186,7 +56449,7 @@ pub mod types {
             {
                 self.version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for version: {e}"));
                 self
             }
         }
@@ -59240,7 +56503,7 @@ pub mod types {
             {
                 self.fields = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for fields: {}", e));
+                    .map_err(|e| format!("error converting supplied value for fields: {e}"));
                 self
             }
             pub fn points<T>(mut self, value: T) -> Self
@@ -59250,7 +56513,7 @@ pub mod types {
             {
                 self.points = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for points: {}", e));
+                    .map_err(|e| format!("error converting supplied value for points: {e}"));
                 self
             }
         }
@@ -59299,7 +56562,7 @@ pub mod types {
             {
                 self.metric = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for metric: {}", e));
+                    .map_err(|e| format!("error converting supplied value for metric: {e}"));
                 self
             }
             pub fn target<T>(mut self, value: T) -> Self
@@ -59309,7 +56572,7 @@ pub mod types {
             {
                 self.target = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for target: {}", e));
+                    .map_err(|e| format!("error converting supplied value for target: {e}"));
                 self
             }
         }
@@ -59356,7 +56619,7 @@ pub mod types {
             {
                 self.query = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for query: {}", e));
+                    .map_err(|e| format!("error converting supplied value for query: {e}"));
                 self
             }
         }
@@ -59418,7 +56681,7 @@ pub mod types {
             {
                 self.authz_scope = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for authz_scope: {}", e));
+                    .map_err(|e| format!("error converting supplied value for authz_scope: {e}"));
                 self
             }
             pub fn created<T>(mut self, value: T) -> Self
@@ -59428,7 +56691,7 @@ pub mod types {
             {
                 self.created = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for created: {}", e));
+                    .map_err(|e| format!("error converting supplied value for created: {e}"));
                 self
             }
             pub fn datum_type<T>(mut self, value: T) -> Self
@@ -59438,7 +56701,7 @@ pub mod types {
             {
                 self.datum_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for datum_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for datum_type: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -59448,7 +56711,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn field_schema<T>(mut self, value: T) -> Self
@@ -59456,9 +56719,9 @@ pub mod types {
                 T: ::std::convert::TryInto<Vec<super::FieldSchema>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.field_schema = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for field_schema: {}", e)
-                });
+                self.field_schema = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for field_schema: {e}"));
                 self
             }
             pub fn timeseries_name<T>(mut self, value: T) -> Self
@@ -59467,7 +56730,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.timeseries_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for timeseries_name: {}", e)
+                    format!("error converting supplied value for timeseries_name: {e}")
                 });
                 self
             }
@@ -59478,7 +56741,7 @@ pub mod types {
             {
                 self.units = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for units: {}", e));
+                    .map_err(|e| format!("error converting supplied value for units: {e}"));
                 self
             }
             pub fn version<T>(mut self, value: T) -> Self
@@ -59488,7 +56751,7 @@ pub mod types {
             {
                 self.version = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for version: {}", e));
+                    .map_err(|e| format!("error converting supplied value for version: {e}"));
                 self
             }
         }
@@ -59555,7 +56818,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -59565,7 +56828,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -59622,7 +56885,7 @@ pub mod types {
             {
                 self.file_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for file_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for file_name: {e}"));
                 self
             }
             pub fn hash<T>(mut self, value: T) -> Self
@@ -59632,7 +56895,7 @@ pub mod types {
             {
                 self.hash = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for hash: {}", e));
+                    .map_err(|e| format!("error converting supplied value for hash: {e}"));
                 self
             }
             pub fn system_version<T>(mut self, value: T) -> Self
@@ -59641,7 +56904,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.system_version = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for system_version: {}", e)
+                    format!("error converting supplied value for system_version: {e}")
                 });
                 self
             }
@@ -59650,9 +56913,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
         }
@@ -59708,7 +56971,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -59718,7 +56981,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -59767,7 +57030,7 @@ pub mod types {
             {
                 self.repo = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for repo: {}", e));
+                    .map_err(|e| format!("error converting supplied value for repo: {e}"));
                 self
             }
             pub fn status<T>(mut self, value: T) -> Self
@@ -59777,7 +57040,7 @@ pub mod types {
             {
                 self.status = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for status: {}", e));
+                    .map_err(|e| format!("error converting supplied value for status: {e}"));
                 self
             }
         }
@@ -59832,7 +57095,7 @@ pub mod types {
             {
                 self.main = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for main: {}", e));
+                    .map_err(|e| format!("error converting supplied value for main: {e}"));
                 self
             }
             pub fn post1<T>(mut self, value: T) -> Self
@@ -59842,7 +57105,7 @@ pub mod types {
             {
                 self.post1 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for post1: {}", e));
+                    .map_err(|e| format!("error converting supplied value for post1: {e}"));
                 self
             }
             pub fn post2<T>(mut self, value: T) -> Self
@@ -59852,7 +57115,7 @@ pub mod types {
             {
                 self.post2 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for post2: {}", e));
+                    .map_err(|e| format!("error converting supplied value for post2: {e}"));
                 self
             }
             pub fn pre1<T>(mut self, value: T) -> Self
@@ -59862,7 +57125,7 @@ pub mod types {
             {
                 self.pre1 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pre1: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pre1: {e}"));
                 self
             }
             pub fn pre2<T>(mut self, value: T) -> Self
@@ -59872,7 +57135,7 @@ pub mod types {
             {
                 self.pre2 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pre2: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pre2: {e}"));
                 self
             }
         }
@@ -59933,7 +57196,7 @@ pub mod types {
             {
                 self.main = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for main: {}", e));
+                    .map_err(|e| format!("error converting supplied value for main: {e}"));
                 self
             }
             pub fn post1<T>(mut self, value: T) -> Self
@@ -59943,7 +57206,7 @@ pub mod types {
             {
                 self.post1 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for post1: {}", e));
+                    .map_err(|e| format!("error converting supplied value for post1: {e}"));
                 self
             }
             pub fn post2<T>(mut self, value: T) -> Self
@@ -59953,7 +57216,7 @@ pub mod types {
             {
                 self.post2 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for post2: {}", e));
+                    .map_err(|e| format!("error converting supplied value for post2: {e}"));
                 self
             }
             pub fn pre1<T>(mut self, value: T) -> Self
@@ -59963,7 +57226,7 @@ pub mod types {
             {
                 self.pre1 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pre1: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pre1: {e}"));
                 self
             }
             pub fn pre2<T>(mut self, value: T) -> Self
@@ -59973,7 +57236,7 @@ pub mod types {
             {
                 self.pre2 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for pre2: {}", e));
+                    .map_err(|e| format!("error converting supplied value for pre2: {e}"));
                 self
             }
         }
@@ -60030,7 +57293,7 @@ pub mod types {
             {
                 self.baseboard = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for baseboard: {}", e));
+                    .map_err(|e| format!("error converting supplied value for baseboard: {e}"));
                 self
             }
             pub fn cubby<T>(mut self, value: T) -> Self
@@ -60040,7 +57303,7 @@ pub mod types {
             {
                 self.cubby = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for cubby: {}", e));
+                    .map_err(|e| format!("error converting supplied value for cubby: {e}"));
                 self
             }
             pub fn rack_id<T>(mut self, value: T) -> Self
@@ -60050,7 +57313,7 @@ pub mod types {
             {
                 self.rack_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rack_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rack_id: {e}"));
                 self
             }
         }
@@ -60101,7 +57364,7 @@ pub mod types {
             {
                 self.part = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for part: {}", e));
+                    .map_err(|e| format!("error converting supplied value for part: {e}"));
                 self
             }
             pub fn serial<T>(mut self, value: T) -> Self
@@ -60111,7 +57374,7 @@ pub mod types {
             {
                 self.serial = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for serial: {}", e));
+                    .map_err(|e| format!("error converting supplied value for serial: {e}"));
                 self
             }
         }
@@ -60166,7 +57429,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -60176,7 +57439,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -60242,8 +57505,7 @@ pub mod types {
             {
                 self.components_by_release_version = value.try_into().map_err(|e| {
                     format!(
-                        "error converting supplied value for components_by_release_version: {}",
-                        e
+                        "error converting supplied value for components_by_release_version: {e}"
                     )
                 });
                 self
@@ -60255,7 +57517,7 @@ pub mod types {
             {
                 self.suspended = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for suspended: {}", e));
+                    .map_err(|e| format!("error converting supplied value for suspended: {e}"));
                 self
             }
             pub fn target_release<T>(mut self, value: T) -> Self
@@ -60264,7 +57526,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.target_release = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for target_release: {}", e)
+                    format!("error converting supplied value for target_release: {e}")
                 });
                 self
             }
@@ -60274,10 +57536,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.time_last_step_planned = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for time_last_step_planned: {}",
-                        e
-                    )
+                    format!("error converting supplied value for time_last_step_planned: {e}")
                 });
                 self
             }
@@ -60336,7 +57595,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn root_role<T>(mut self, value: T) -> Self
@@ -60346,7 +57605,7 @@ pub mod types {
             {
                 self.root_role = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for root_role: {}", e));
+                    .map_err(|e| format!("error converting supplied value for root_role: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -60354,9 +57613,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
         }
@@ -60413,7 +57672,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -60423,7 +57682,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -60472,9 +57731,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::string::String>,
                 T::Error: ::std::fmt::Display,
             {
-                self.display_name = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for display_name: {}", e)
-                });
+                self.display_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for display_name: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -60484,7 +57743,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn silo_id<T>(mut self, value: T) -> Self
@@ -60494,7 +57753,7 @@ pub mod types {
             {
                 self.silo_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for silo_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for silo_id: {e}"));
                 self
             }
         }
@@ -60555,7 +57814,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -60565,7 +57824,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -60575,7 +57834,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -60583,9 +57842,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -60593,9 +57852,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -60654,7 +57913,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -60664,7 +57923,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -60713,7 +57972,7 @@ pub mod types {
             {
                 self.external_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for external_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for external_id: {e}"));
                 self
             }
             pub fn password<T>(mut self, value: T) -> Self
@@ -60723,7 +57982,7 @@ pub mod types {
             {
                 self.password = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for password: {}", e));
+                    .map_err(|e| format!("error converting supplied value for password: {e}"));
                 self
             }
         }
@@ -60775,7 +58034,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -60785,7 +58044,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -60834,7 +58093,7 @@ pub mod types {
             {
                 self.password = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for password: {}", e));
+                    .map_err(|e| format!("error converting supplied value for password: {e}"));
                 self
             }
             pub fn username<T>(mut self, value: T) -> Self
@@ -60844,7 +58103,7 @@ pub mod types {
             {
                 self.username = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for username: {}", e));
+                    .map_err(|e| format!("error converting supplied value for username: {e}"));
                 self
             }
         }
@@ -60893,7 +58152,7 @@ pub mod types {
             {
                 self.capacity = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for capacity: {}", e));
+                    .map_err(|e| format!("error converting supplied value for capacity: {e}"));
                 self
             }
             pub fn provisioned<T>(mut self, value: T) -> Self
@@ -60903,7 +58162,7 @@ pub mod types {
             {
                 self.provisioned = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for provisioned: {}", e));
+                    .map_err(|e| format!("error converting supplied value for provisioned: {e}"));
                 self
             }
         }
@@ -60952,7 +58211,7 @@ pub mod types {
             {
                 self.metric_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for metric_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for metric_type: {e}"));
                 self
             }
             pub fn values<T>(mut self, value: T) -> Self
@@ -60962,7 +58221,7 @@ pub mod types {
             {
                 self.values = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for values: {}", e));
+                    .map_err(|e| format!("error converting supplied value for values: {e}"));
                 self
             }
         }
@@ -61013,7 +58272,7 @@ pub mod types {
             {
                 self.cpus = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for cpus: {}", e));
+                    .map_err(|e| format!("error converting supplied value for cpus: {e}"));
                 self
             }
             pub fn memory<T>(mut self, value: T) -> Self
@@ -61023,7 +58282,7 @@ pub mod types {
             {
                 self.memory = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for memory: {}", e));
+                    .map_err(|e| format!("error converting supplied value for memory: {e}"));
                 self
             }
             pub fn storage<T>(mut self, value: T) -> Self
@@ -61033,7 +58292,7 @@ pub mod types {
             {
                 self.storage = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for storage: {}", e));
+                    .map_err(|e| format!("error converting supplied value for storage: {e}"));
                 self
             }
         }
@@ -61104,7 +58363,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn dns_name<T>(mut self, value: T) -> Self
@@ -61114,7 +58373,7 @@ pub mod types {
             {
                 self.dns_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for dns_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for dns_name: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -61124,7 +58383,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn ipv6_prefix<T>(mut self, value: T) -> Self
@@ -61134,7 +58393,7 @@ pub mod types {
             {
                 self.ipv6_prefix = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ipv6_prefix: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ipv6_prefix: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -61144,7 +58403,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn project_id<T>(mut self, value: T) -> Self
@@ -61154,7 +58413,7 @@ pub mod types {
             {
                 self.project_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for project_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for project_id: {e}"));
                 self
             }
             pub fn system_router_id<T>(mut self, value: T) -> Self
@@ -61163,10 +58422,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.system_router_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for system_router_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for system_router_id: {e}")
                 });
                 self
             }
@@ -61175,9 +58431,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -61185,9 +58441,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -61253,7 +58509,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn dns_name<T>(mut self, value: T) -> Self
@@ -61263,7 +58519,7 @@ pub mod types {
             {
                 self.dns_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for dns_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for dns_name: {e}"));
                 self
             }
             pub fn ipv6_prefix<T>(mut self, value: T) -> Self
@@ -61273,7 +58529,7 @@ pub mod types {
             {
                 self.ipv6_prefix = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ipv6_prefix: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ipv6_prefix: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -61283,7 +58539,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -61339,7 +58595,7 @@ pub mod types {
             {
                 self.code = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for code: {}", e));
+                    .map_err(|e| format!("error converting supplied value for code: {e}"));
                 self
             }
             pub fn icmp_type<T>(mut self, value: T) -> Self
@@ -61349,7 +58605,7 @@ pub mod types {
             {
                 self.icmp_type = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for icmp_type: {}", e));
+                    .map_err(|e| format!("error converting supplied value for icmp_type: {e}"));
                 self
             }
         }
@@ -61428,7 +58684,7 @@ pub mod types {
             {
                 self.action = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for action: {}", e));
+                    .map_err(|e| format!("error converting supplied value for action: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -61438,7 +58694,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn direction<T>(mut self, value: T) -> Self
@@ -61448,7 +58704,7 @@ pub mod types {
             {
                 self.direction = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for direction: {}", e));
+                    .map_err(|e| format!("error converting supplied value for direction: {e}"));
                 self
             }
             pub fn filters<T>(mut self, value: T) -> Self
@@ -61458,7 +58714,7 @@ pub mod types {
             {
                 self.filters = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for filters: {}", e));
+                    .map_err(|e| format!("error converting supplied value for filters: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -61468,7 +58724,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -61478,7 +58734,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn priority<T>(mut self, value: T) -> Self
@@ -61488,7 +58744,7 @@ pub mod types {
             {
                 self.priority = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for priority: {}", e));
+                    .map_err(|e| format!("error converting supplied value for priority: {e}"));
                 self
             }
             pub fn status<T>(mut self, value: T) -> Self
@@ -61498,7 +58754,7 @@ pub mod types {
             {
                 self.status = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for status: {}", e));
+                    .map_err(|e| format!("error converting supplied value for status: {e}"));
                 self
             }
             pub fn targets<T>(mut self, value: T) -> Self
@@ -61508,7 +58764,7 @@ pub mod types {
             {
                 self.targets = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for targets: {}", e));
+                    .map_err(|e| format!("error converting supplied value for targets: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -61516,9 +58772,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -61526,9 +58782,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vpc_id<T>(mut self, value: T) -> Self
@@ -61538,7 +58794,7 @@ pub mod types {
             {
                 self.vpc_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vpc_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vpc_id: {e}"));
                 self
             }
         }
@@ -61620,7 +58876,7 @@ pub mod types {
             {
                 self.hosts = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for hosts: {}", e));
+                    .map_err(|e| format!("error converting supplied value for hosts: {e}"));
                 self
             }
             pub fn ports<T>(mut self, value: T) -> Self
@@ -61632,7 +58888,7 @@ pub mod types {
             {
                 self.ports = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ports: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ports: {e}"));
                 self
             }
             pub fn protocols<T>(mut self, value: T) -> Self
@@ -61644,7 +58900,7 @@ pub mod types {
             {
                 self.protocols = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for protocols: {}", e));
+                    .map_err(|e| format!("error converting supplied value for protocols: {e}"));
                 self
             }
         }
@@ -61711,7 +58967,7 @@ pub mod types {
             {
                 self.action = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for action: {}", e));
+                    .map_err(|e| format!("error converting supplied value for action: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -61721,7 +58977,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn direction<T>(mut self, value: T) -> Self
@@ -61731,7 +58987,7 @@ pub mod types {
             {
                 self.direction = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for direction: {}", e));
+                    .map_err(|e| format!("error converting supplied value for direction: {e}"));
                 self
             }
             pub fn filters<T>(mut self, value: T) -> Self
@@ -61741,7 +58997,7 @@ pub mod types {
             {
                 self.filters = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for filters: {}", e));
+                    .map_err(|e| format!("error converting supplied value for filters: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -61751,7 +59007,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn priority<T>(mut self, value: T) -> Self
@@ -61761,7 +59017,7 @@ pub mod types {
             {
                 self.priority = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for priority: {}", e));
+                    .map_err(|e| format!("error converting supplied value for priority: {e}"));
                 self
             }
             pub fn status<T>(mut self, value: T) -> Self
@@ -61771,7 +59027,7 @@ pub mod types {
             {
                 self.status = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for status: {}", e));
+                    .map_err(|e| format!("error converting supplied value for status: {e}"));
                 self
             }
             pub fn targets<T>(mut self, value: T) -> Self
@@ -61781,7 +59037,7 @@ pub mod types {
             {
                 self.targets = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for targets: {}", e));
+                    .map_err(|e| format!("error converting supplied value for targets: {e}"));
                 self
             }
         }
@@ -61843,7 +59099,7 @@ pub mod types {
             {
                 self.rules = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rules: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rules: {e}"));
                 self
             }
         }
@@ -61891,7 +59147,7 @@ pub mod types {
             {
                 self.rules = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for rules: {}", e));
+                    .map_err(|e| format!("error converting supplied value for rules: {e}"));
                 self
             }
         }
@@ -61941,7 +59197,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -61951,7 +59207,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -62016,7 +59272,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -62026,7 +59282,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn kind<T>(mut self, value: T) -> Self
@@ -62036,7 +59292,7 @@ pub mod types {
             {
                 self.kind = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                    .map_err(|e| format!("error converting supplied value for kind: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62046,7 +59302,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -62054,9 +59310,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -62064,9 +59320,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vpc_id<T>(mut self, value: T) -> Self
@@ -62076,7 +59332,7 @@ pub mod types {
             {
                 self.vpc_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vpc_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vpc_id: {e}"));
                 self
             }
         }
@@ -62135,7 +59391,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62145,7 +59401,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -62197,7 +59453,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -62207,7 +59463,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -62259,7 +59515,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62269,7 +59525,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -62338,10 +59594,7 @@ pub mod types {
                 T::Error: ::std::fmt::Display,
             {
                 self.custom_router_id = value.try_into().map_err(|e| {
-                    format!(
-                        "error converting supplied value for custom_router_id: {}",
-                        e
-                    )
+                    format!("error converting supplied value for custom_router_id: {e}")
                 });
                 self
             }
@@ -62352,7 +59605,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -62362,7 +59615,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn ipv4_block<T>(mut self, value: T) -> Self
@@ -62372,7 +59625,7 @@ pub mod types {
             {
                 self.ipv4_block = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ipv4_block: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ipv4_block: {e}"));
                 self
             }
             pub fn ipv6_block<T>(mut self, value: T) -> Self
@@ -62382,7 +59635,7 @@ pub mod types {
             {
                 self.ipv6_block = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ipv6_block: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ipv6_block: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62392,7 +59645,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -62400,9 +59653,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -62410,9 +59663,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
             pub fn vpc_id<T>(mut self, value: T) -> Self
@@ -62422,7 +59675,7 @@ pub mod types {
             {
                 self.vpc_id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for vpc_id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for vpc_id: {e}"));
                 self
             }
         }
@@ -62493,9 +59746,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<super::NameOrId>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.custom_router = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for custom_router: {}", e)
-                });
+                self.custom_router = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for custom_router: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -62505,7 +59758,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn ipv4_block<T>(mut self, value: T) -> Self
@@ -62515,7 +59768,7 @@ pub mod types {
             {
                 self.ipv4_block = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ipv4_block: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ipv4_block: {e}"));
                 self
             }
             pub fn ipv6_block<T>(mut self, value: T) -> Self
@@ -62525,7 +59778,7 @@ pub mod types {
             {
                 self.ipv6_block = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ipv6_block: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ipv6_block: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62535,7 +59788,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -62593,7 +59846,7 @@ pub mod types {
             {
                 self.items = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for items: {}", e));
+                    .map_err(|e| format!("error converting supplied value for items: {e}"));
                 self
             }
             pub fn next_page<T>(mut self, value: T) -> Self
@@ -62603,7 +59856,7 @@ pub mod types {
             {
                 self.next_page = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for next_page: {}", e));
+                    .map_err(|e| format!("error converting supplied value for next_page: {e}"));
                 self
             }
         }
@@ -62658,9 +59911,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::option::Option<super::NameOrId>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.custom_router = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for custom_router: {}", e)
-                });
+                self.custom_router = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for custom_router: {e}"));
                 self
             }
             pub fn description<T>(mut self, value: T) -> Self
@@ -62670,7 +59923,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62680,7 +59933,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -62737,7 +59990,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn dns_name<T>(mut self, value: T) -> Self
@@ -62747,7 +60000,7 @@ pub mod types {
             {
                 self.dns_name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for dns_name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for dns_name: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62757,7 +60010,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -62820,7 +60073,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn endpoint<T>(mut self, value: T) -> Self
@@ -62830,7 +60083,7 @@ pub mod types {
             {
                 self.endpoint = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for endpoint: {}", e));
+                    .map_err(|e| format!("error converting supplied value for endpoint: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -62840,7 +60093,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn secrets<T>(mut self, value: T) -> Self
@@ -62850,7 +60103,7 @@ pub mod types {
             {
                 self.secrets = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for secrets: {}", e));
+                    .map_err(|e| format!("error converting supplied value for secrets: {e}"));
                 self
             }
             pub fn subscriptions<T>(mut self, value: T) -> Self
@@ -62858,9 +60111,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::vec::Vec<super::AlertSubscription>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.subscriptions = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for subscriptions: {}", e)
-                });
+                self.subscriptions = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for subscriptions: {e}"));
                 self
             }
         }
@@ -62926,7 +60179,7 @@ pub mod types {
             {
                 self.attempt = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for attempt: {}", e));
+                    .map_err(|e| format!("error converting supplied value for attempt: {e}"));
                 self
             }
             pub fn response<T>(mut self, value: T) -> Self
@@ -62936,7 +60189,7 @@ pub mod types {
             {
                 self.response = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for response: {}", e));
+                    .map_err(|e| format!("error converting supplied value for response: {e}"));
                 self
             }
             pub fn result<T>(mut self, value: T) -> Self
@@ -62946,7 +60199,7 @@ pub mod types {
             {
                 self.result = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for result: {}", e));
+                    .map_err(|e| format!("error converting supplied value for result: {e}"));
                 self
             }
             pub fn time_sent<T>(mut self, value: T) -> Self
@@ -62956,7 +60209,7 @@ pub mod types {
             {
                 self.time_sent = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for time_sent: {}", e));
+                    .map_err(|e| format!("error converting supplied value for time_sent: {e}"));
                 self
             }
         }
@@ -63009,7 +60262,7 @@ pub mod types {
             {
                 self.duration_ms = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for duration_ms: {}", e));
+                    .map_err(|e| format!("error converting supplied value for duration_ms: {e}"));
                 self
             }
             pub fn status<T>(mut self, value: T) -> Self
@@ -63019,7 +60272,7 @@ pub mod types {
             {
                 self.status = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for status: {}", e));
+                    .map_err(|e| format!("error converting supplied value for status: {e}"));
                 self
             }
         }
@@ -63090,7 +60343,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn endpoint<T>(mut self, value: T) -> Self
@@ -63100,7 +60353,7 @@ pub mod types {
             {
                 self.endpoint = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for endpoint: {}", e));
+                    .map_err(|e| format!("error converting supplied value for endpoint: {e}"));
                 self
             }
             pub fn id<T>(mut self, value: T) -> Self
@@ -63110,7 +60363,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -63120,7 +60373,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
             pub fn secrets<T>(mut self, value: T) -> Self
@@ -63130,7 +60383,7 @@ pub mod types {
             {
                 self.secrets = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for secrets: {}", e));
+                    .map_err(|e| format!("error converting supplied value for secrets: {e}"));
                 self
             }
             pub fn subscriptions<T>(mut self, value: T) -> Self
@@ -63138,9 +60391,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::std::vec::Vec<super::AlertSubscription>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.subscriptions = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for subscriptions: {}", e)
-                });
+                self.subscriptions = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for subscriptions: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -63148,9 +60401,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
             pub fn time_modified<T>(mut self, value: T) -> Self
@@ -63158,9 +60411,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_modified = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_modified: {}", e)
-                });
+                self.time_modified = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_modified: {e}"));
                 self
             }
         }
@@ -63229,7 +60482,7 @@ pub mod types {
             {
                 self.description = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for description: {}", e));
+                    .map_err(|e| format!("error converting supplied value for description: {e}"));
                 self
             }
             pub fn endpoint<T>(mut self, value: T) -> Self
@@ -63239,7 +60492,7 @@ pub mod types {
             {
                 self.endpoint = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for endpoint: {}", e));
+                    .map_err(|e| format!("error converting supplied value for endpoint: {e}"));
                 self
             }
             pub fn name<T>(mut self, value: T) -> Self
@@ -63249,7 +60502,7 @@ pub mod types {
             {
                 self.name = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for name: {}", e));
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
                 self
             }
         }
@@ -63303,7 +60556,7 @@ pub mod types {
             {
                 self.id = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for id: {}", e));
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
                 self
             }
             pub fn time_created<T>(mut self, value: T) -> Self
@@ -63311,9 +60564,9 @@ pub mod types {
                 T: ::std::convert::TryInto<::chrono::DateTime<::chrono::offset::Utc>>,
                 T::Error: ::std::fmt::Display,
             {
-                self.time_created = value.try_into().map_err(|e| {
-                    format!("error converting supplied value for time_created: {}", e)
-                });
+                self.time_created = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for time_created: {e}"));
                 self
             }
         }
@@ -63360,7 +60613,7 @@ pub mod types {
             {
                 self.secret = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for secret: {}", e));
+                    .map_err(|e| format!("error converting supplied value for secret: {e}"));
                 self
             }
         }
@@ -63406,7 +60659,7 @@ pub mod types {
             {
                 self.secrets = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for secrets: {}", e));
+                    .map_err(|e| format!("error converting supplied value for secrets: {e}"));
                 self
             }
         }


### PR DESCRIPTION
see https://github.com/oxidecomputer/progenitor/pull/1273 and https://github.com/oxidecomputer/typify/pull/945