### PR TITLE
cli: Fix race in test_disk_write_import_fail

### DIFF
--- a/cli/tests/test_disk_import.rs
+++ b/cli/tests/test_disk_import.rs
@@ -565,7 +565,7 @@ fn test_disk_write_import_fail() {
 
     let test_file = Testfile::new_random(CHUNK_SIZE * 2).unwrap();
     let output = concat!(
-        r#"(?m)\AError while uploading the disk image:\n "#,
+        r#"(?m)\AErrors? while uploading the disk image:\n "#,
         r#"\* Error Response: status: 503 Service Unavailable;.*$"#
     );
 


### PR DESCRIPTION
Test `test_disk_write_import_fail` has been flaking in CI with error:

```
Unexpected stderr, failed var.is_match((?m)\AError while uploading the disk image:\n \* Error Response: status: 503 Service Unavailable;.*$)
├── var: Errors while uploading the disk image:
│    * Error Response: status: 503 Service Unavailable; headers: {"content-type": "application/json", "content-length": "86", "date": "Tue, 13 Jan 2026 01:53:18 GMT"}; value: Error { error_code: None, message: "I can't do that Dave", request_id: "24e04e74-bbd8-e4ea-10d6-acc7c9563b97" }
│    * Error Response: status: 503 Service Unavailable; headers: {"content-type": "application/json", "content-length": "86", "date": "Tue, 13 Jan 2026 01:53:19 GMT"}; value: Error { error_code: None, message: "I can't do that Dave", request_id: "24e04e74-bbd8-e4ea-10d6-acc7c9563b97" }
```

This is due to the error deduplication done in the SDK will treat errors with different time stamps as distinct, so when the failures in this test occur at at the boundary between two seconds multiple errors may be reported, which our error regex does not handle.

Update the regex to handle one or more errors being reported.

Closes #1326