### PR TITLE
Force HTTP 1.1 to avoid websocket incompatibility

### DIFF
--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -234,7 +234,12 @@ impl ClientConfig {
         const DEFAULT_TIMEOUT: u64 = 15;
 
         let dur = std::time::Duration::from_secs(timeout.unwrap_or(DEFAULT_TIMEOUT));
-        let mut client_builder = ClientBuilder::new().timeout(dur).user_agent(user_agent);
+        let mut client_builder = ClientBuilder::new()
+            .timeout(dur)
+            .user_agent(user_agent)
+            // We don't get any benefit from HTTP/2 and it is incompatible with
+            // websocket upgrades, so force HTTP/1.1 only.
+            .http1_only();
 
         // Use an explicit connect_timeout if provided, otherwise fallback to
         // timeout or default.


### PR DESCRIPTION
See #1352. I don't want to claim that it fixes the issue, because I don't fully understand it yet; but in all likelihood this will suffice.