### PR TITLE
Install perl-Time-Piece when building on manylinx

### DIFF
--- a/.github/manylinux.yml
+++ b/.github/manylinux.yml
@@ -1,5 +1,5 @@
 - name: Install perl-IPC-Cmd on manylinux
   if: contains(matrix.container.image, 'manylinux')
   run: |
-    yum install -y perl-IPC-Cmd
+    yum install -y perl-IPC-Cmd perl-Time-Piece
     git config --global --add safe.directory /__w/oxide.rs/oxide.rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       - name: "Install perl-IPC-Cmd on manylinux"
         if: "contains(matrix.container.image, 'manylinux')"
         run: |
-          yum install -y perl-IPC-Cmd
+          yum install -y perl-IPC-Cmd perl-Time-Piece
           git config --global --add safe.directory /__w/oxide.rs/oxide.rs
       - name: Install dist
         run: ${{ matrix.install_dist.run }}


### PR DESCRIPTION
The OpenSSL build process now requires the `perl-Time-Piece` package. Update `manylinux.yml` to pull it in.