### PR TITLE
CLI accepts gzipped responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4659,13 +4659,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,7 +44,7 @@ oxide = { workspace = true, features = ["clap", "extras"] }
 oxnet = { workspace = true }
 predicates = { workspace = true }
 ratatui = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["gzip"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Goes with https://github.com/oxidecomputer/omicron/pull/10341. Let the CLI tell the API it wants gzipped responses. Turns out all we have to do is turn on the `gzip` feature in `reqwest`:

> If the gzip feature is turned on, the default option is enabled.

https://docs.rs/reqwest/0.13.2/reqwest/struct.ClientBuilder.html#method.gzip

The [source](https://github.com/seanmonstar/reqwest/blob/ad83b63824385a4e5758d263db707549bbe59ba7/src/async_impl/client.rs#L124-L128) confirms this reading of that line in the docs.