### PR TITLE
support enable_jumbo_frames option in instance from-image subcommand

### DIFF
--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -3450,6 +3450,10 @@
               "help": "Description of the instance"
             },
             {
+              "long": "enable-jumbo-frames",
+              "help": "Set network interface MTU to 8500 (requires jumbo-frames to be enabled at fleet-level)"
+            },
+            {
               "long": "hostname",
               "help": "The hostname to be assigned to the instance"
             },

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -3451,7 +3451,7 @@
             },
             {
               "long": "enable-jumbo-frames",
-              "help": "Enable jumbo frames (8500 byte MTU) on the instance's primary OPTE"
+              "help": "Enable jumbo frames (8500 byte MTU) on the instance's primary network interface"
             },
             {
               "long": "hostname",

--- a/cli/docs/cli.json
+++ b/cli/docs/cli.json
@@ -3451,7 +3451,7 @@
             },
             {
               "long": "enable-jumbo-frames",
-              "help": "Set network interface MTU to 8500 (requires jumbo-frames to be enabled at fleet-level)"
+              "help": "Enable jumbo frames (8500 byte MTU) on the instance's primary OPTE"
             },
             {
               "long": "hostname",

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -245,7 +245,7 @@ pub struct CmdInstanceFromImage {
     #[clap(long = "anti-affinity-group")]
     anti_affinity_groups: Vec<NameOrId>,
 
-    /// Set network interface MTU to 8500
+    /// Enable jumbo frames (8500 byte MTU) on the instance's primary OPTE
     #[clap(long)]
     enable_jumbo_frames: bool,
 

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -245,7 +245,7 @@ pub struct CmdInstanceFromImage {
     #[clap(long = "anti-affinity-group")]
     anti_affinity_groups: Vec<NameOrId>,
 
-    /// Enable jumbo frames (8500 byte MTU) on the instance's primary OPTE
+    /// Enable jumbo frames (8500 byte MTU) on the instance's primary NIC
     #[clap(long)]
     enable_jumbo_frames: bool,
 

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -245,7 +245,7 @@ pub struct CmdInstanceFromImage {
     #[clap(long = "anti-affinity-group")]
     anti_affinity_groups: Vec<NameOrId>,
 
-    /// Enable jumbo frames (8500 byte MTU) on the instance's primary NIC
+    /// Enable jumbo frames (8500 byte MTU) on the instance's primary network interface
     #[clap(long)]
     enable_jumbo_frames: bool,
 

--- a/cli/src/cmd_instance.rs
+++ b/cli/src/cmd_instance.rs
@@ -245,6 +245,10 @@ pub struct CmdInstanceFromImage {
     #[clap(long = "anti-affinity-group")]
     anti_affinity_groups: Vec<NameOrId>,
 
+    /// Set network interface MTU to 8500
+    #[clap(long)]
+    enable_jumbo_frames: bool,
+
     /// Source image
     #[clap(long)]
     image: NameOrId,
@@ -296,6 +300,7 @@ impl crate::AuthenticatedCmd for CmdInstanceFromImage {
                     .ncpus(self.ncpus.clone())
                     .cpu_platform(self.cpu_platform)
                     .anti_affinity_groups(self.anti_affinity_groups.clone())
+                    .enable_jumbo_frames(self.enable_jumbo_frames)
                     .start(self.start)
             })
             .send()


### PR DESCRIPTION
Catch up on the support for a new instance attribute known as `enable_jumbo_frames`. The option is uncommon (use of it requires upstream network support and fleet-admin explicitly enabling the option) but having the CLI support will simplify internal test automation.